### PR TITLE
Add stricter type checking to the library

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,11 @@
     "description": "Reimplementation of posthog-js to be as light and modular as possible.",
     "main": "dist/src/index.js",
     "scripts": {
-        "start": "npm run build",
         "build": "tsc -p .",
         "test": "jest",
-        "prepublish": "npm run test && npm run build"
+        "prepublish": "yarn test && yarn build"
     },
-    "author": "",
+    "author": "PostHog",
     "license": "MIT",
     "devDependencies": {
         "@babel/core": "^7.10.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { version } from '../package.json'
-import { PostHogOptions, PostHogSession } from './types'
+import { PostHogApiRequest, PostHogOptions, PostHogSession } from './types'
 import { currentISOTime, currentTimestamp, generateUUID } from './utils/utils'
 import { getContext } from './utils/context'
 
@@ -12,7 +12,7 @@ const defaultOptions: PostHogOptions = {
 }
 
 export function createInternalPostHogInstance(apiKey: string, options: PostHogOptions, globalThis: any) {
-    const session = {} as PostHogSession // getDataFromCookiesAndLocalStorage
+    const session = {} as Partial<PostHogSession> // getDataFromCookiesAndLocalStorage
     const anonymousId = generateUUID()
 
     let postHogInstance = {
@@ -78,8 +78,8 @@ export function createInternalPostHogInstance(apiKey: string, options: PostHogOp
             }
         },
 
-        queue: [],
-        enqueue(apiRequest) {
+        queue: [] as PostHogApiRequest[],
+        enqueue(apiRequest: PostHogApiRequest) {
             postHogInstance.queue.push(apiRequest)
 
             if (postHogInstance.optedIn() && postHogInstance.queue.length >= postHogInstance.options.maxQueueLength) {
@@ -93,7 +93,7 @@ export function createInternalPostHogInstance(apiKey: string, options: PostHogOp
             postHogInstance.makeRequest(queue)
         },
 
-        makeRequest: async function (events) {
+        makeRequest: async function (events: PostHogApiRequest[]) {
             const requestData = {
                 api_key: postHogInstance.options.apiKey,
                 batch: events,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { version } from '../package.json'
-import { PostHogApiRequest, PostHogOptions, PostHogSession } from './types'
+import { PostHogAPIRequest, PostHogOptions, PostHogSession } from './types'
 import { currentISOTime, currentTimestamp, generateUUID } from './utils/utils'
 import { getContext } from './utils/context'
 
@@ -78,8 +78,8 @@ export function createInternalPostHogInstance(apiKey: string, options: PostHogOp
             }
         },
 
-        queue: [] as PostHogApiRequest[],
-        enqueue(apiRequest: PostHogApiRequest) {
+        queue: [] as PostHogAPIRequest[],
+        enqueue(apiRequest: PostHogAPIRequest) {
             postHogInstance.queue.push(apiRequest)
 
             if (postHogInstance.optedIn() && postHogInstance.queue.length >= postHogInstance.options.maxQueueLength) {
@@ -93,7 +93,7 @@ export function createInternalPostHogInstance(apiKey: string, options: PostHogOp
             postHogInstance.makeRequest(queue)
         },
 
-        makeRequest: async function (events: PostHogApiRequest[]) {
+        makeRequest: async function (events: PostHogAPIRequest[]) {
             const requestData = {
                 api_key: postHogInstance.options.apiKey,
                 batch: events,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,3 +12,11 @@ export type PostHogSession = {
     distinctId: string
     anonymousId: string
 }
+
+export type PostHogApiRequest = {
+    event: string
+    distinct_id: string
+    timestamp: string
+    properties?: Record<string, unknown>
+    $set?: Record<string, unknown>
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export type PostHogSession = {
     anonymousId: string
 }
 
-export type PostHogApiRequest = {
+export type PostHogAPIRequest = {
     event: string
     distinct_id: string
     timestamp: string

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,18 +1,18 @@
 import { version } from '../../package.json'
 import { currentTimestamp } from './utils'
 
-export function getContext(window) {
+export function getContext(window: Window) {
     const userAgent = window.navigator.userAgent
     const context = {
         $os: os(window),
-        $browser: browser(userAgent, navigator.vendor, window.opera),
+        $browser: browser(userAgent, navigator.vendor, !!(window as any).opera),
         $referrer: window.document.referrer,
         $referring_domain: referringDomain(window.document.referrer),
         $device: device(userAgent),
         $current_url: window.location.href,
         $host: window.location.host,
         $pathname: window.location.pathname,
-        $browser_version: browserVersion(userAgent, window.navigator.vendor, window.opera),
+        $browser_version: browserVersion(userAgent, window.navigator.vendor, !!(window as any).opera),
         $screen_height: window.screen.height,
         $screen_width: window.screen.width,
         $screen_dpr: window.devicePixelRatio,
@@ -24,11 +24,11 @@ export function getContext(window) {
     return context // TODO: strip empty props?
 }
 
-function includes(haystack, needle) {
+function includes(haystack: string, needle: string) {
     return haystack.indexOf(needle) >= 0
 }
 
-function browser(userAgent, vendor, opera) {
+function browser(userAgent: string, vendor: string, opera: boolean): string {
     vendor = vendor || '' // vendor is undefined for at least IE9
     if (opera || includes(userAgent, ' OPR/')) {
         if (includes(userAgent, 'Mini')) {
@@ -74,8 +74,8 @@ function browser(userAgent, vendor, opera) {
     }
 }
 
-function browserVersion(userAgent, vendor, opera) {
-    const regex = {
+function browserVersion(userAgent: string, vendor: string, opera: boolean) {
+    const regexList = {
         'Internet Explorer Mobile': /rv:(\d+(\.\d+)?)/,
         'Microsoft Edge': /Edge?\/(\d+(\.\d+)?)/,
         Chrome: /Chrome\/(\d+(\.\d+)?)/,
@@ -92,7 +92,10 @@ function browserVersion(userAgent, vendor, opera) {
         'Samsung Internet': /SamsungBrowser\/(\d+(\.\d+)?)/,
         'Internet Explorer': /(rv:|MSIE )(\d+(\.\d+)?)/,
         Mozilla: /rv:(\d+(\.\d+)?)/,
-    }[browser(userAgent, vendor, opera)]
+    }
+
+    const browserString = browser(userAgent, vendor, opera) as keyof typeof regexList
+    const regex: RegExp = regexList[browserString] || undefined
 
     if (regex === undefined) {
         return null
@@ -104,7 +107,7 @@ function browserVersion(userAgent, vendor, opera) {
     return parseFloat(matches[matches.length - 2])
 }
 
-function os(window) {
+function os(window: Window) {
     var a = window.navigator.userAgent
     if (/Windows/i.test(a)) {
         if (/Phone/.test(a) || /WPDesktop/.test(a)) {
@@ -128,7 +131,7 @@ function os(window) {
     }
 }
 
-function device(userAgent) {
+function device(userAgent: string) {
     if (/Windows Phone/i.test(userAgent) || /WPDesktop/.test(userAgent)) {
         return 'Windows Phone'
     } else if (/iPad/.test(userAgent)) {
@@ -146,7 +149,7 @@ function device(userAgent) {
     }
 }
 
-function referringDomain(referrer) {
+function referringDomain(referrer: string) {
     var split = referrer.split('/')
     if (split.length >= 3) {
         return split[2]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
         "outDir": "./dist",
         "baseUrl": "./src",
         "incremental": true,
-        "types": ["jest", "node"]
+        "types": ["jest", "node"],
+        "strict": true
     },
     "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Previously the call to `posthog.identify(distinctId, properties)` required a string `distinctId` argument, even though `null` is perfectly acceptable if you just want to set properties.

Typescript was not in `strict` mode, thus the `| null` part in `string | null` was omitted from the generated definitions.