### PR TITLE
Local eval date operators support

### DIFF
--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -420,14 +420,14 @@ function isValidRegex(regex: string): boolean {
 function convertToDateTime(value: string | number | (string | number)[] | Date): Date {
   if (value instanceof Date) {
     return value
-  } else if (typeof value === 'string') {
-    const timestamp = Date.parse(value)
-    if (isNaN(timestamp) == false) {
-      return new Date(timestamp)
+  } else if (typeof value === 'string' || typeof value === 'number') {
+    const date = new Date(value)
+    if (!isNaN(date.valueOf())) {
+      return date
     }
     throw new InconclusiveMatchError(`${value} is in an invalid date format`)
   } else {
-    throw new InconclusiveMatchError(`The date provided ${value} must be a string or date object`)
+    throw new InconclusiveMatchError(`The date provided ${value} must be a string, number, or date object`)
   }
 }
 

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -394,13 +394,14 @@ function matchProperty(
       return typeof overrideValue == typeof value && overrideValue < value
     case 'lte':
       return typeof overrideValue == typeof value && overrideValue <= value
-    case 'is_date_after': case 'is_date_before':
+    case 'is_date_after':
+    case 'is_date_before':
       const parsedDate = convertToDateTime(value)
       const overrideDate = convertToDateTime(overrideValue)
-      if (operator === 'is_date_after') {
+      if (operator === 'is_date_before') {
         return overrideDate < parsedDate
       }
-      return parsedDate < overrideDate
+      return overrideDate > parsedDate
     default:
       console.error(`Unknown operator: ${operator}`)
       return false
@@ -420,12 +421,11 @@ function convertToDateTime(value: string | number | (string | number)[] | Date):
   if (value instanceof Date) {
     return value
   } else if (typeof value === 'string') {
-    try {
-      const parsedDate = new Date(value)
-      return parsedDate
-    } catch (e) {
-      throw new InconclusiveMatchError(`${e} is in an invalid date format`)
+    const timestamp = Date.parse(value)
+    if (isNaN(timestamp) == false) {
+      return new Date(timestamp)
     }
+    throw new InconclusiveMatchError(`${value} is in an invalid date format`)
   } else {
     throw new InconclusiveMatchError(`The date provided ${value} must be a string or date object`)
   }

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -394,6 +394,13 @@ function matchProperty(
       return typeof overrideValue == typeof value && overrideValue < value
     case 'lte':
       return typeof overrideValue == typeof value && overrideValue <= value
+    case 'is_date_after': case 'is_date_before':
+      const parsedDate = convertToDateTime(value)
+      const overrideDate = convertToDateTime(overrideValue)
+      if (operator === 'is_date_after') {
+        return overrideDate < parsedDate
+      }
+      return parsedDate < overrideDate
     default:
       console.error(`Unknown operator: ${operator}`)
       return false
@@ -406,6 +413,21 @@ function isValidRegex(regex: string): boolean {
     return true
   } catch (err) {
     return false
+  }
+}
+
+function convertToDateTime(value: string | number | (string | number)[] | Date): Date {
+  if (value instanceof Date) {
+    return value
+  } else if (typeof value === 'string') {
+    try {
+      const parsedDate = new Date(value)
+      return parsedDate
+    } catch (e) {
+      throw new InconclusiveMatchError(`${e} is in an invalid date format`)
+    }
+  } else {
+    throw new InconclusiveMatchError(`The date provided ${value} must be a string or date object`)
   }
 }
 

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -1118,11 +1118,11 @@ describe('match properties', () => {
     expect(matchProperty(property_b, { key: new Date('2022-05-30') })).toBe(true)
     expect(matchProperty(property_b, { key: '2022-04-30' })).toBe(false)
 
-    // can't be a number or invalid string
-    expect(() => matchProperty(property_a, { key: 1 })).toThrow(InconclusiveMatchError)
+    // can't be an invalid number or invalid string
+    expect(() => matchProperty(property_a, { key: 62802180000012345 })).toThrow(InconclusiveMatchError)
     expect(() => matchProperty(property_a, { key: 'abcdef' })).toThrow(InconclusiveMatchError)
     // invalid flag property
-    const property_c = { key: 'key', value: 1234, operator: 'is_date_before' }
+    const property_c = { key: 'key', value: 'abcd123', operator: 'is_date_before' }
     expect(() => matchProperty(property_c, { key: '2022-05-30' })).toThrow(InconclusiveMatchError)
 
     // Timezone

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -1119,7 +1119,7 @@ describe('match properties', () => {
     expect(matchProperty(property_b, { key: '2022-04-30' })).toBe(false)
 
     // can't be an invalid number or invalid string
-    expect(() => matchProperty(property_a, { key: 62802180000012345 })).toThrow(InconclusiveMatchError)
+    expect(() => matchProperty(property_a, { key: 62802180000012345n })).toThrow(InconclusiveMatchError)
     expect(() => matchProperty(property_a, { key: 'abcdef' })).toThrow(InconclusiveMatchError)
     // invalid flag property
     const property_c = { key: 'key', value: 'abcd123', operator: 'is_date_before' }

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -1098,6 +1098,42 @@ describe('match properties', () => {
     expect(matchProperty(property_d, { key: '44' })).toBe(false)
     expect(matchProperty(property_d, { key: 44 })).toBe(false)
   })
+
+  it('with date operators', () => {
+    // is date before
+    const property_a = { key: 'key', value: '2022-05-01', operator: 'is_date_before' }
+    expect(matchProperty(property_a, { key: '2022-03-01' })).toBe(true)
+    expect(matchProperty(property_a, { key: '2022-04-30', })).toBe(true)
+    expect(matchProperty(property_a, { key: new Date(2022, 4, 30) })).toBe(true)
+    expect(matchProperty(property_a, { key: new Date(2022, 4, 30, 1, 2, 3) })).toBe(true)
+    expect(matchProperty(property_a, { key: new Date("2022-04-30T00:00:00+02:00") })).toBe(true) // europe/madrid
+    expect(matchProperty(property_a, { key: new Date('2022-04-30') })).toBe(true)
+    expect(matchProperty(property_a, { key: '2022-05-30' })).toBe(false)
+
+    // is date after
+    const property_b = { key: 'key', value: '2022-05-01', operator: 'is_date_after' }
+    expect(matchProperty(property_b, { key: '2022-05-02' })).toBe(true)
+    expect(matchProperty(property_b, { key: '2022-05-30' })).toBe(true)
+    expect(matchProperty(property_b, { key: new Date(2022, 5, 30) })).toBe(true)
+    expect(matchProperty(property_b, { key: new Date('2022-05-30') })).toBe(true)
+    expect(matchProperty(property_b, { key: '2022-04-30' })).toBe(false)
+
+    // can't be a number or invalid string
+    expect(() => matchProperty(property_a, { key: 1 })).toThrow(InconclusiveMatchError)
+    expect(() => matchProperty(property_a, { key: 'abcdef' })).toThrow(InconclusiveMatchError)
+    // invalid flag property
+    const property_c = { key: 'key', value: 1234, operator: 'is_date_before' }
+    expect(() => matchProperty(property_c, { key: '2022-05-30' })).toThrow(InconclusiveMatchError)
+
+    // Timezone
+    const property_d = { key: 'key', value: '2022-04-05 12:34:12 +01:00', operator: 'is_date_before' }
+    expect(matchProperty(property_d, { key: '2022-05-30' })).toBe(false)
+
+    expect(matchProperty(property_d, { key: '2022-03-30' })).toBe(true)
+    expect(matchProperty(property_d, { key: '2022-04-05 12:34:11+01:00' })).toBe(true)
+    expect(matchProperty(property_d, { key: '2022-04-05 11:34:11 +00:00' })).toBe(true)
+    expect(matchProperty(property_d, { key: '2022-04-05 11:34:13 +00:00' })).toBe(false)
+  })
 })
 
 describe('consistency tests', () => {

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -1119,7 +1119,7 @@ describe('match properties', () => {
     expect(matchProperty(property_b, { key: '2022-04-30' })).toBe(false)
 
     // can't be an invalid number or invalid string
-    expect(() => matchProperty(property_a, { key: 62802180000012345n })).toThrow(InconclusiveMatchError)
+    expect(() => matchProperty(property_a, { key: parseInt('62802180000012345') })).toThrow(InconclusiveMatchError)
     expect(() => matchProperty(property_a, { key: 'abcdef' })).toThrow(InconclusiveMatchError)
     // invalid flag property
     const property_c = { key: 'key', value: 'abcd123', operator: 'is_date_before' }

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -1103,10 +1103,10 @@ describe('match properties', () => {
     // is date before
     const property_a = { key: 'key', value: '2022-05-01', operator: 'is_date_before' }
     expect(matchProperty(property_a, { key: '2022-03-01' })).toBe(true)
-    expect(matchProperty(property_a, { key: '2022-04-30', })).toBe(true)
-    expect(matchProperty(property_a, { key: new Date(2022, 4, 30) })).toBe(true)
-    expect(matchProperty(property_a, { key: new Date(2022, 4, 30, 1, 2, 3) })).toBe(true)
-    expect(matchProperty(property_a, { key: new Date("2022-04-30T00:00:00+02:00") })).toBe(true) // europe/madrid
+    expect(matchProperty(property_a, { key: '2022-04-30' })).toBe(true)
+    expect(matchProperty(property_a, { key: new Date(2022, 3, 30) })).toBe(true)
+    expect(matchProperty(property_a, { key: new Date(2022, 3, 30, 1, 2, 3) })).toBe(true)
+    expect(matchProperty(property_a, { key: new Date('2022-04-30T00:00:00+02:00') })).toBe(true) // europe/madrid
     expect(matchProperty(property_a, { key: new Date('2022-04-30') })).toBe(true)
     expect(matchProperty(property_a, { key: '2022-05-30' })).toBe(false)
 
@@ -1114,7 +1114,7 @@ describe('match properties', () => {
     const property_b = { key: 'key', value: '2022-05-01', operator: 'is_date_after' }
     expect(matchProperty(property_b, { key: '2022-05-02' })).toBe(true)
     expect(matchProperty(property_b, { key: '2022-05-30' })).toBe(true)
-    expect(matchProperty(property_b, { key: new Date(2022, 5, 30) })).toBe(true)
+    expect(matchProperty(property_b, { key: new Date(2022, 4, 30) })).toBe(true)
     expect(matchProperty(property_b, { key: new Date('2022-05-30') })).toBe(true)
     expect(matchProperty(property_b, { key: '2022-04-30' })).toBe(false)
 


### PR DESCRIPTION
Add support for date operators in feature flags local evaluation, modeled after https://github.com/PostHog/posthog-python/pull/75