### PR TITLE
add prepublishOnly

### DIFF
--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -4,7 +4,7 @@
   "description": "PostHog Node.js integration",
   "repository": "PostHog/posthog-node",
   "scripts": {
-    "prepublish": "cd .. && yarn build"
+    "prepublishOnly": "cd .. && yarn build"
   },
   "engines": {
     "node": ">=14.17.0"

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -10,7 +10,7 @@
   "dependencies": {},
   "scripts": {
     "test": "jest -c jest.config.js",
-    "prepublish": "cd .. && yarn build"
+    "prepublishOnly": "cd .. && yarn build"
   },
   "devDependencies": {
     "@react-navigation/native": "^5.0.10",

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -6,6 +6,6 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "test": "jest -c jest.config.js",
-    "prepublish": "cd .. && yarn build"
+    "prepublishOnly": "cd .. && yarn build"
   }
 }


### PR DESCRIPTION
I released a new version of posthog-react-native, but `npm publishg` did not build the new library, and thus I published the old one again under a new number.

This changes the scripts in package.json to always run yarn build before publishing