### PR TITLE
fix(flags): hooks

### DIFF
--- a/posthog-react-native/src/hooks/useFeatureFlag.ts
+++ b/posthog-react-native/src/hooks/useFeatureFlag.ts
@@ -6,11 +6,10 @@ export function useFeatureFlag(flag: string): string | boolean | undefined {
 
   const [featureFlag, setFeatureFlag] = useState<boolean | string | undefined>(posthog?.getFeatureFlag(flag))
 
-  if (!posthog) {
-    return featureFlag
-  }
-
   useEffect(() => {
+    if (!posthog) {
+      return
+    }
     setFeatureFlag(posthog.getFeatureFlag(flag))
     return posthog.onFeatureFlags(() => {
       setFeatureFlag(posthog.getFeatureFlag(flag))

--- a/posthog-react-native/src/hooks/useFeatureFlags.ts
+++ b/posthog-react-native/src/hooks/useFeatureFlags.ts
@@ -11,11 +11,10 @@ export function useFeatureFlags(client?: PostHog): PostHogDecideResponse['featur
     posthog?.getFeatureFlags()
   )
 
-  if (!posthog) {
-    return featureFlags
-  }
-
   useEffect(() => {
+    if (!posthog) {
+      return
+    }
     setFeatureFlags(posthog.getFeatureFlags())
     return posthog.onFeatureFlags((flags) => {
       setFeatureFlags(flags)


### PR DESCRIPTION
`useFeatureFlag` and `useFeatureFlags` were violating the [rules of hooks](https://reactjs.org/docs/hooks-rules.html#explanation) by calling hooks conditionally. This PR fixes that.

See also https://github.com/PostHog/posthog-js-lite/issues/34#issuecomment-1321891181