### PR TITLE
fix(core): feature flag typing

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -486,15 +486,9 @@ export abstract class PostHogCore {
       return flags
     }
 
-    flags = flags || {}
+    flags = flags || []
 
-    for (const key in overriddenFlags) {
-      if (!overriddenFlags[key]) {
-        delete flags[key]
-      } else {
-        flags[key] = overriddenFlags[key]
-      }
-    }
+    flags.filter(flag => overriddenFlags.includes(flag))
 
     return flags
   }

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -79,10 +79,8 @@ export type PostHogAutocaptureElement = {
 export type PostHogDecideResponse = {
   config: { enable_collect_everything: boolean }
   editorParams: { toolbarVersion: string; jsURL: string }
-  isAuthenticated: true
+  isAuthenticated: boolean
   supportedCompression: string[]
-  featureFlags: {
-    [key: string]: string | boolean
-  }
+  featureFlags: string[]
   sessionRecording: boolean
 }


### PR DESCRIPTION
The results I got from `posthog.getFeatureFlags()` were not matching the typing. The typing indicated that the return type should be `{ [key: string]: string | boolean }`, but I only ever got `string[]`.

So I checked what the API is actually returning:
<img width="502" alt="Screenshot 2022-11-21 at 12 55 33" src="https://user-images.githubusercontent.com/64152453/203054345-6200435b-82ea-4092-8d00-cd82b54ce015.png">


And indeed the API was returning an array of strings. So I changed the type with this PR.

Also see [this](https://github.com/PostHog/posthog-js-lite/issues/34#issue-1449972311).