### PR TITLE
feat: Add timeout option for all calls

### DIFF
--- a/examples/example-node/example.ts
+++ b/examples/example-node/example.ts
@@ -30,6 +30,8 @@ posthog.capture({
 })
 
 async function testFeatureFlags() {
+  await posthog.shutdownAsync()
+  console.log('flushed')
   console.log(await posthog.isFeatureEnabled('beta-feature', 'distinct_id'))
   console.log(await posthog.isFeatureEnabled('beta-feature', 'new_distinct_id'))
   console.log(await posthog.isFeatureEnabled('beta-feature', 'distinct_id', { groups: { company: 'id:5' } }))

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -672,16 +672,20 @@ export abstract class PostHogCore {
     options: PostHogFetchOptions,
     retryOptions?: RetriableOptions
   ): Promise<PostHogFetchResponse> {
-    (AbortSignal as any).timeout ??= function timeout(ms: number) {
-        const ctrl = new AbortController()
-        setTimeout(() => ctrl.abort(), ms)
-        return ctrl.signal
-      }
+    ;(AbortSignal as any).timeout ??= function timeout(ms: number) {
+      const ctrl = new AbortController()
+      setTimeout(() => ctrl.abort(), ms)
+      return ctrl.signal
+    }
 
-    return retriable(() => this.fetch(url, {
-        signal: (AbortSignal as any).timeout(this.requestTimeout),
-        ...options
-    }), retryOptions || this._retryOptions)
+    return retriable(
+      () =>
+        this.fetch(url, {
+          signal: (AbortSignal as any).timeout(this.requestTimeout),
+          ...options,
+        }),
+      retryOptions || this._retryOptions
+    )
   }
 
   async shutdownAsync(): Promise<void> {

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -28,6 +28,7 @@ export abstract class PostHogCore {
   host: string
   private flushAt: number
   private flushInterval: number
+  private requestTimeout: number
   private captureMode: 'form' | 'json'
   private sendFeatureFlagEvent: boolean
   private flagCallReported: { [key: string]: boolean } = {}
@@ -67,6 +68,7 @@ export abstract class PostHogCore {
       retryCount: options?.fetchRetryCount ?? 3,
       retryDelay: options?.fetchRetryDelay ?? 3000,
     }
+    this.requestTimeout = options?.requestTimeout ?? 10
     this._sessionExpirationTimeSeconds = options?.sessionExpirationTimeSeconds ?? 1800 // 30 minutes
 
     // NOTE: It is important we don't initiate anything in the constructor as some async IO may still be underway on the parent
@@ -670,7 +672,16 @@ export abstract class PostHogCore {
     options: PostHogFetchOptions,
     retryOptions?: RetriableOptions
   ): Promise<PostHogFetchResponse> {
-    return retriable(() => this.fetch(url, options), retryOptions || this._retryOptions)
+    (AbortSignal as any).timeout ??= function timeout(ms: number) {
+        const ctrl = new AbortController()
+        setTimeout(() => ctrl.abort(), ms)
+        return ctrl.signal
+      }
+
+    return retriable(() => this.fetch(url, {
+        signal: (AbortSignal as any).timeout(this.requestTimeout),
+        ...options
+    }), retryOptions || this._retryOptions)
   }
 
   async shutdownAsync(): Promise<void> {

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -21,6 +21,8 @@ export type PosthogCoreOptions = {
   fetchRetryCount?: number
   // The delay between HTTP request retries
   fetchRetryDelay?: number
+  // Timeout in milliseconds for any calls. Defaults to 10 seconds.
+  requestTimeout?: number
   // For Session Analysis how long before we expire a session (defaults to 30 mins)
   sessionExpirationTimeSeconds?: number
   // Whether to post events to PostHog in JSON or compressed format

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -89,7 +89,7 @@ describe('PostHog Core', () => {
           headers: {
             'Content-Type': 'application/json',
           },
-          signal: expect.anything()
+          signal: expect.anything(),
         })
 
         expect(posthog.getFeatureFlags()).toEqual({
@@ -293,7 +293,7 @@ describe('PostHog Core', () => {
           headers: {
             'Content-Type': 'application/json',
           },
-          signal: expect.anything()
+          signal: expect.anything(),
         })
 
         expect(posthog.getFeatureFlags()).toEqual({

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -89,6 +89,7 @@ describe('PostHog Core', () => {
           headers: {
             'Content-Type': 'application/json',
           },
+          signal: expect.anything()
         })
 
         expect(posthog.getFeatureFlags()).toEqual({
@@ -140,6 +141,13 @@ describe('PostHog Core', () => {
           expect(posthog.isFeatureEnabled('feature-variant')).toEqual(undefined)
           expect(posthog.isFeatureEnabled('feature-missing')).toEqual(undefined)
         })
+      })
+      it('should time out', async () => {
+        const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
+
+        expect(posthog.isFeatureEnabled('feature-1')).toEqual(true
+
+        abortSpy.mockRestore();
       })
 
       it('should return the boolean value of a flag', async () => {
@@ -292,6 +300,7 @@ describe('PostHog Core', () => {
           headers: {
             'Content-Type': 'application/json',
           },
+          signal: expect.anything()
         })
 
         expect(posthog.getFeatureFlags()).toEqual({

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -142,13 +142,6 @@ describe('PostHog Core', () => {
           expect(posthog.isFeatureEnabled('feature-missing')).toEqual(undefined)
         })
       })
-      it('should time out', async () => {
-        const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
-
-        expect(posthog.isFeatureEnabled('feature-1')).toEqual(true
-
-        abortSpy.mockRestore();
-      })
 
       it('should return the boolean value of a flag', async () => {
         expect(posthog.isFeatureEnabled('feature-1')).toEqual(true)

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.2.1 - 2022-11-24
+1. Add standard 10 second timeout
+
 # 2.2.0 - 2022-11-18
 
 1. Add support for variant overrides for feature flag local evaluation.

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "PostHog Node.js integration",
   "repository": "PostHog/posthog-node",
   "scripts": {

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -17,7 +17,7 @@ export type PostHogOptions = PosthogCoreOptions & {
   personalApiKey?: string
   // The interval in milliseconds between polls for refreshing feature flag definitions
   featureFlagsPollingInterval?: number
-  // Timeout in milliseconds for feature flag definitions calls. Defaults to 30 seconds.
+  // Timeout in milliseconds for any calls. Defaults to 10 seconds.
   requestTimeout?: number
   // Maximum size of cache that deduplicates $feature_flag_called calls per user.
   maxCacheSize?: number
@@ -84,7 +84,7 @@ export class PostHog implements PostHogNodeV1 {
             : THIRTY_SECONDS,
         personalApiKey: options.personalApiKey,
         projectApiKey: apiKey,
-        timeout: options.requestTimeout,
+        timeout: options.requestTimeout ?? 10,
         host: this._sharedClient.host,
         fetch: options.fetch,
       })


### PR DESCRIPTION
This will auto timeout any calls after 10 seconds (which may be too aggressive?). People were running into issues when we had slow API calls as it'd wait forever.