### PR TITLE
Respect autocapture=false

### DIFF
--- a/posthog-react-native/src/PostHogProvider.tsx
+++ b/posthog-react-native/src/PostHogProvider.tsx
@@ -43,10 +43,13 @@ export const PostHogProvider = ({
   }, [apiKey])
 
   const autocaptureOptions = autocapture && typeof autocapture !== 'boolean' ? autocapture : {}
+  const captureAll = autocapture === true
+  const captureNone = autocapture === false
 
-  const captureTouches = posthog && (autocapture === true || autocaptureOptions?.captureTouches)
-  const captureScreens = posthog && (autocapture === true || (autocaptureOptions?.captureScreens ?? true)) // Default to true if not set
-  const captureLifecycle = posthog && (autocapture === true || (autocaptureOptions?.captureLifecycleEvents ?? true)) // Default to true if not set
+  const captureTouches = !captureNone && posthog && (captureAll || autocaptureOptions?.captureTouches)
+  const captureScreens = !captureNone && posthog && (captureAll || (autocaptureOptions?.captureScreens ?? true)) // Default to true if not set
+  const captureLifecycle =
+    !captureNone && posthog && (captureAll || (autocaptureOptions?.captureLifecycleEvents ?? true)) // Default to true if not set
 
   const onTouch = useCallback(
     (type: 'start' | 'move' | 'end', e: GestureResponderEvent) => {


### PR DESCRIPTION
The `autocapture` prop is typed as `boolean | PostHogAutocaptureOptions`, but passing `false` does nothing at all.

This PR makes the provider behave more intuitively when autocapture is false.

If ignoring the `false` option was intended, the `autocapture` prop should have been typed as `true | PostHogAutocaptureOptions`.