### PR TITLE
Restrict to node 15.0.0 and above

### DIFF
--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -7,7 +7,7 @@
     "prepublishOnly": "cd .. && yarn build"
   },
   "engines": {
-    "node": ">=14.17.0"
+    "node": ">=15.0.0"
   },
   "license": "MIT",
   "author": {


### PR DESCRIPTION
AbortController and AbortSignal are only supported in 15 and above: https://github.com/PostHog/posthog-js-lite/issues/51