### PR TITLE
feat(feature-flags): Allow upserting decide v3 responses

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -407,7 +407,7 @@ export abstract class PostHogCore {
   }
 
   private async _decideAsync(sendAnonDistinctId: boolean = true): Promise<PostHogDecideResponse> {
-    const url = `${this.host}/decide/?v=2`
+    const url = `${this.host}/decide/?v=3`
 
     const distinctId = this.getDistinctId()
     const groups = this.props.$groups || {}
@@ -433,9 +433,15 @@ export abstract class PostHogCore {
       .then((r) => r.json() as Promise<PostHogDecideResponse>)
       .then((res) => {
         if (res.featureFlags) {
-          this.setKnownFeatureFlags(res.featureFlags)
-        }
+          let newFeatureFlags = res.featureFlags
+          if (res.errorsWhileComputingFlags) {
+            // if not all flags were computed, we upsert flags instead of replacing them
+            const currentFlags = this.getPersistedProperty<PostHogDecideResponse['featureFlags']>(PostHogPersistedProperty.FeatureFlags)
+            newFeatureFlags = { ...currentFlags, ...res.featureFlags }
 
+          }
+          this.setKnownFeatureFlags(newFeatureFlags)
+        }
         return res
       })
       .finally(() => {
@@ -461,8 +467,10 @@ export abstract class PostHogCore {
     }
 
     let response = featureFlags[key]
+    // `/decide` v3 returns all flags
+
     if (response === undefined) {
-      // `/decide` returns nothing for flags which are false.
+      // For cases where the flag is unknown, return false
       response = false
     }
 

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -436,9 +436,10 @@ export abstract class PostHogCore {
           let newFeatureFlags = res.featureFlags
           if (res.errorsWhileComputingFlags) {
             // if not all flags were computed, we upsert flags instead of replacing them
-            const currentFlags = this.getPersistedProperty<PostHogDecideResponse['featureFlags']>(PostHogPersistedProperty.FeatureFlags)
+            const currentFlags = this.getPersistedProperty<PostHogDecideResponse['featureFlags']>(
+              PostHogPersistedProperty.FeatureFlags
+            )
             newFeatureFlags = { ...currentFlags, ...res.featureFlags }
-
           }
           this.setKnownFeatureFlags(newFeatureFlags)
         }

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -86,5 +86,6 @@ export type PostHogDecideResponse = {
   featureFlags: {
     [key: string]: string | boolean
   }
+  errorsWhileComputingFlags: boolean
   sessionRecording: boolean
 }

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -15,10 +15,19 @@ describe('PostHog Core', () => {
     'feature-variant': 'variant',
   })
 
+  const errorAPIResponse = Promise.resolve({
+    status: 400,
+    text: () => Promise.resolve('error'),
+    json: () =>
+      Promise.resolve({
+        status: 'error',
+      }),
+  })
+
   beforeEach(() => {
     ;[posthog, mocks] = createTestClient('TEST_API_KEY', { flushAt: 1 }, (_mocks) => {
       _mocks.fetch.mockImplementation((url) => {
-        if (url.includes('/decide/')) {
+        if (url.includes('/decide/?v=3')) {
           return Promise.resolve({
             status: 200,
             text: () => Promise.resolve('ok'),
@@ -76,7 +85,7 @@ describe('PostHog Core', () => {
       })
 
       it('should load feature flags on init', async () => {
-        expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=2', {
+        expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
           body: JSON.stringify({
             token: 'TEST_API_KEY',
             distinct_id: posthog.getDistinctId(),
@@ -120,19 +129,31 @@ describe('PostHog Core', () => {
                 })
               }
 
-              return Promise.resolve({
-                status: 400,
-                text: () => Promise.resolve('ok'),
-                json: () =>
-                  Promise.resolve({
-                    status: 'ok',
-                  }),
-              })
+              return errorAPIResponse
             })
           })
+
+          jest.runOnlyPendingTimers() // trigger init setImmediate
+
         })
 
         it('should return undefined', async () => {
+          expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+            body: JSON.stringify({
+              token: 'TEST_API_KEY',
+              distinct_id: posthog.getDistinctId(),
+              $anon_distinct_id: posthog.getAnonymousId(),
+              groups: {},
+              person_properties: {},
+              group_properties: {},
+            }),
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            signal: expect.anything(),
+          })
+
           expect(posthog.getFeatureFlag('feature-1')).toEqual(undefined)
           expect(posthog.getFeatureFlag('feature-variant')).toEqual(undefined)
           expect(posthog.getFeatureFlag('feature-missing')).toEqual(undefined)
@@ -140,6 +161,206 @@ describe('PostHog Core', () => {
           expect(posthog.isFeatureEnabled('feature-1')).toEqual(undefined)
           expect(posthog.isFeatureEnabled('feature-variant')).toEqual(undefined)
           expect(posthog.isFeatureEnabled('feature-missing')).toEqual(undefined)
+        })
+      })
+
+      describe('when subsequent decide calls return partial results', () => {
+        beforeEach(() => {
+          ;[posthog, mocks] = createTestClient('TEST_API_KEY', { flushAt: 1 }, (_mocks) => {
+            _mocks.fetch.mockImplementationOnce((url) => {
+              if (url.includes('/decide/?v=3')) {
+                return Promise.resolve({
+                  status: 200,
+                  text: () => Promise.resolve('ok'),
+                  json: () =>
+                    Promise.resolve({
+                      featureFlags: createMockFeatureFlags(),
+                    }),
+                })
+              }
+              return errorAPIResponse
+            })
+            .mockImplementationOnce((url) => {
+              if (url.includes('/decide/?v=3')) {
+                return Promise.resolve({
+                  status: 200,
+                  text: () => Promise.resolve('ok'),
+                  json: () =>
+                    Promise.resolve({
+                      featureFlags: {'x-flag': 'x-value', 'feature-1': false},
+                      errorsWhileComputingFlags: true,
+                    }),
+                })
+              }
+
+              return errorAPIResponse
+            })
+            .mockImplementation((url) => {
+              return errorAPIResponse
+          })
+        })
+
+        jest.runOnlyPendingTimers() // trigger init setImmediate
+
+      })
+
+        it('should return combined results', async () => {
+          expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+            body: JSON.stringify({
+              token: 'TEST_API_KEY',
+              distinct_id: posthog.getDistinctId(),
+              $anon_distinct_id: posthog.getAnonymousId(),
+              groups: {},
+              person_properties: {},
+              group_properties: {},
+            }),
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            signal: expect.anything(),
+          })
+
+          expect(posthog.getFeatureFlags()).toEqual({
+            'feature-1': true,
+            'feature-2': true,
+            'feature-variant': 'variant',
+          })
+
+          // now second call to feature flags
+          await posthog.reloadFeatureFlagsAsync(false)
+
+          expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+            body: JSON.stringify({
+              token: 'TEST_API_KEY',
+              distinct_id: posthog.getDistinctId(),
+              $anon_distinct_id: posthog.getAnonymousId(),
+              groups: {},
+              person_properties: {},
+              group_properties: {},
+            }),
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            signal: expect.anything(),
+          })
+
+          expect(posthog.getFeatureFlags()).toEqual({
+            'feature-1': false,
+            'feature-2': true,
+            'feature-variant': 'variant',
+            'x-flag': 'x-value',
+          })
+
+          expect(posthog.getFeatureFlag('feature-1')).toEqual(false)
+          expect(posthog.getFeatureFlag('feature-variant')).toEqual('variant')
+          expect(posthog.getFeatureFlag('feature-missing')).toEqual(false)
+          expect(posthog.getFeatureFlag('x-flag')).toEqual('x-value')
+
+          expect(posthog.isFeatureEnabled('feature-1')).toEqual(false)
+          expect(posthog.isFeatureEnabled('feature-variant')).toEqual(true)
+          expect(posthog.isFeatureEnabled('feature-missing')).toEqual(false)
+          expect(posthog.isFeatureEnabled('x-flag')).toEqual(true)
+        })
+      })
+      
+      describe('when subsequent decide calls return results without errors', () => {
+        beforeEach(() => {
+          ;[posthog, mocks] = createTestClient('TEST_API_KEY', { flushAt: 1 }, (_mocks) => {
+            _mocks.fetch.mockImplementationOnce((url) => {
+              if (url.includes('/decide/?v=3')) {
+                return Promise.resolve({
+                  status: 200,
+                  text: () => Promise.resolve('ok'),
+                  json: () =>
+                    Promise.resolve({
+                      featureFlags: createMockFeatureFlags(),
+                    }),
+                })
+              }
+              return errorAPIResponse
+            })
+            .mockImplementationOnce((url) => {
+              if (url.includes('/decide/?v=3')) {
+                return Promise.resolve({
+                  status: 200,
+                  text: () => Promise.resolve('ok'),
+                  json: () =>
+                    Promise.resolve({
+                      featureFlags: {'x-flag': 'x-value', 'feature-1': false},
+                      errorsWhileComputingFlags: false,
+                    }),
+                })
+              }
+
+              return errorAPIResponse
+            })
+            .mockImplementation((url) => {
+              return errorAPIResponse
+          })
+        })
+
+        jest.runOnlyPendingTimers() // trigger init setImmediate
+
+      })
+
+        it('should return only latest results', async () => {
+          expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+            body: JSON.stringify({
+              token: 'TEST_API_KEY',
+              distinct_id: posthog.getDistinctId(),
+              $anon_distinct_id: posthog.getAnonymousId(),
+              groups: {},
+              person_properties: {},
+              group_properties: {},
+            }),
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            signal: expect.anything(),
+          })
+
+          expect(posthog.getFeatureFlags()).toEqual({
+            'feature-1': true,
+            'feature-2': true,
+            'feature-variant': 'variant',
+          })
+
+          // now second call to feature flags
+          await posthog.reloadFeatureFlagsAsync(false)
+
+          expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+            body: JSON.stringify({
+              token: 'TEST_API_KEY',
+              distinct_id: posthog.getDistinctId(),
+              $anon_distinct_id: posthog.getAnonymousId(),
+              groups: {},
+              person_properties: {},
+              group_properties: {},
+            }),
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            signal: expect.anything(),
+          })
+
+          expect(posthog.getFeatureFlags()).toEqual({
+            'feature-1': false,
+            'x-flag': 'x-value',
+          })
+
+          expect(posthog.getFeatureFlag('feature-1')).toEqual(false)
+          expect(posthog.getFeatureFlag('feature-variant')).toEqual(false)
+          expect(posthog.getFeatureFlag('feature-missing')).toEqual(false)
+          expect(posthog.getFeatureFlag('x-flag')).toEqual('x-value')
+
+          expect(posthog.isFeatureEnabled('feature-1')).toEqual(false)
+          expect(posthog.isFeatureEnabled('feature-variant')).toEqual(false)
+          expect(posthog.isFeatureEnabled('feature-missing')).toEqual(false)
+          expect(posthog.isFeatureEnabled('x-flag')).toEqual(true)
         })
       })
 
@@ -280,7 +501,7 @@ describe('PostHog Core', () => {
       })
 
       it('should load new feature flags', async () => {
-        expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=2', {
+        expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
           body: JSON.stringify({
             token: 'TEST_API_KEY',
             distinct_id: posthog.getDistinctId(),

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -134,7 +134,6 @@ describe('PostHog Core', () => {
           })
 
           jest.runOnlyPendingTimers() // trigger init setImmediate
-
         })
 
         it('should return undefined', async () => {
@@ -167,42 +166,42 @@ describe('PostHog Core', () => {
       describe('when subsequent decide calls return partial results', () => {
         beforeEach(() => {
           ;[posthog, mocks] = createTestClient('TEST_API_KEY', { flushAt: 1 }, (_mocks) => {
-            _mocks.fetch.mockImplementationOnce((url) => {
-              if (url.includes('/decide/?v=3')) {
-                return Promise.resolve({
-                  status: 200,
-                  text: () => Promise.resolve('ok'),
-                  json: () =>
-                    Promise.resolve({
-                      featureFlags: createMockFeatureFlags(),
-                    }),
-                })
-              }
-              return errorAPIResponse
-            })
-            .mockImplementationOnce((url) => {
-              if (url.includes('/decide/?v=3')) {
-                return Promise.resolve({
-                  status: 200,
-                  text: () => Promise.resolve('ok'),
-                  json: () =>
-                    Promise.resolve({
-                      featureFlags: {'x-flag': 'x-value', 'feature-1': false},
-                      errorsWhileComputingFlags: true,
-                    }),
-                })
-              }
+            _mocks.fetch
+              .mockImplementationOnce((url) => {
+                if (url.includes('/decide/?v=3')) {
+                  return Promise.resolve({
+                    status: 200,
+                    text: () => Promise.resolve('ok'),
+                    json: () =>
+                      Promise.resolve({
+                        featureFlags: createMockFeatureFlags(),
+                      }),
+                  })
+                }
+                return errorAPIResponse
+              })
+              .mockImplementationOnce((url) => {
+                if (url.includes('/decide/?v=3')) {
+                  return Promise.resolve({
+                    status: 200,
+                    text: () => Promise.resolve('ok'),
+                    json: () =>
+                      Promise.resolve({
+                        featureFlags: { 'x-flag': 'x-value', 'feature-1': false },
+                        errorsWhileComputingFlags: true,
+                      }),
+                  })
+                }
 
-              return errorAPIResponse
-            })
-            .mockImplementation((url) => {
-              return errorAPIResponse
+                return errorAPIResponse
+              })
+              .mockImplementation(() => {
+                return errorAPIResponse
+              })
           })
+
+          jest.runOnlyPendingTimers() // trigger init setImmediate
         })
-
-        jest.runOnlyPendingTimers() // trigger init setImmediate
-
-      })
 
         it('should return combined results', async () => {
           expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
@@ -264,46 +263,46 @@ describe('PostHog Core', () => {
           expect(posthog.isFeatureEnabled('x-flag')).toEqual(true)
         })
       })
-      
+
       describe('when subsequent decide calls return results without errors', () => {
         beforeEach(() => {
           ;[posthog, mocks] = createTestClient('TEST_API_KEY', { flushAt: 1 }, (_mocks) => {
-            _mocks.fetch.mockImplementationOnce((url) => {
-              if (url.includes('/decide/?v=3')) {
-                return Promise.resolve({
-                  status: 200,
-                  text: () => Promise.resolve('ok'),
-                  json: () =>
-                    Promise.resolve({
-                      featureFlags: createMockFeatureFlags(),
-                    }),
-                })
-              }
-              return errorAPIResponse
-            })
-            .mockImplementationOnce((url) => {
-              if (url.includes('/decide/?v=3')) {
-                return Promise.resolve({
-                  status: 200,
-                  text: () => Promise.resolve('ok'),
-                  json: () =>
-                    Promise.resolve({
-                      featureFlags: {'x-flag': 'x-value', 'feature-1': false},
-                      errorsWhileComputingFlags: false,
-                    }),
-                })
-              }
+            _mocks.fetch
+              .mockImplementationOnce((url) => {
+                if (url.includes('/decide/?v=3')) {
+                  return Promise.resolve({
+                    status: 200,
+                    text: () => Promise.resolve('ok'),
+                    json: () =>
+                      Promise.resolve({
+                        featureFlags: createMockFeatureFlags(),
+                      }),
+                  })
+                }
+                return errorAPIResponse
+              })
+              .mockImplementationOnce((url) => {
+                if (url.includes('/decide/?v=3')) {
+                  return Promise.resolve({
+                    status: 200,
+                    text: () => Promise.resolve('ok'),
+                    json: () =>
+                      Promise.resolve({
+                        featureFlags: { 'x-flag': 'x-value', 'feature-1': false },
+                        errorsWhileComputingFlags: false,
+                      }),
+                  })
+                }
 
-              return errorAPIResponse
-            })
-            .mockImplementation((url) => {
-              return errorAPIResponse
+                return errorAPIResponse
+              })
+              .mockImplementation(() => {
+                return errorAPIResponse
+              })
           })
+
+          jest.runOnlyPendingTimers() // trigger init setImmediate
         })
-
-        jest.runOnlyPendingTimers() // trigger init setImmediate
-
-      })
 
         it('should return only latest results', async () => {
           expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -315,6 +315,13 @@ class FeatureFlagsPoller {
           `Your personalApiKey is invalid. Are you sure you're not using your Project API key? More information: https://posthog.com/docs/api/overview`
         )
       }
+
+      if (res && res.status !== 200) {
+        // something else went wrong, or the server is down.
+        // In this case, don't override existing flags
+        return
+      }
+
       const responseJson = await res.json()
       if (!('flags' in responseJson)) {
         console.error(`Invalid response when getting feature flags: ${JSON.stringify(responseJson)}`)

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -58,7 +58,7 @@ export const anyLocalEvalCall = [
   'http://example.com/api/feature_flag/local_evaluation?token=TEST_API_KEY',
   expect.any(Object),
 ]
-export const anyDecideCall = ['http://example.com/decide/?v=2', expect.any(Object)]
+export const anyDecideCall = ['http://example.com/decide/?v=3', expect.any(Object)]
 
 describe('local evaluation', () => {
   let posthog: PostHog
@@ -325,7 +325,7 @@ describe('local evaluation', () => {
       })
     ).toEqual('decide-fallback-value')
     expect(mockedFetch).toHaveBeenCalledWith(
-      'http://example.com/decide/?v=2',
+      'http://example.com/decide/?v=3',
       expect.objectContaining({
         body: JSON.stringify({
           token: 'TEST_API_KEY',
@@ -343,7 +343,7 @@ describe('local evaluation', () => {
       await posthog.getFeatureFlag('complex-flag', 'some-distinct-id', { personProperties: { doesnt_matter: '1' } })
     ).toEqual('decide-fallback-value')
     expect(mockedFetch).toHaveBeenCalledWith(
-      'http://example.com/decide/?v=2',
+      'http://example.com/decide/?v=3',
       expect.objectContaining({
         body: JSON.stringify({
           token: 'TEST_API_KEY',

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -186,7 +186,7 @@ describe('PostHog Node.js', () => {
       })
 
       expect(mockedFetch).toHaveBeenCalledWith(
-        'http://example.com/decide/?v=2',
+        'http://example.com/decide/?v=3',
         expect.objectContaining({ method: 'POST' })
       )
 


### PR DESCRIPTION
~~Shouldn't go in until accompanying posthog PR is done.~~ It's done!

When decide partially computes flag, this PR ensures that we upsert flag information, rather than replace. Replace only happens when there were no errors on decide.