### PR TITLE
feat(feature-flag): ff bootstrap payload option

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -550,13 +550,16 @@ export abstract class PostHogCore {
     return flags
   }
 
-  getFeatureFlagsAndPayloads(): {flags: PostHogDecideResponse['featureFlags'] | undefined, payloads: PostHogDecideResponse['featureFlagPayloads'] | undefined} {
+  getFeatureFlagsAndPayloads(): {
+    flags: PostHogDecideResponse['featureFlags'] | undefined
+    payloads: PostHogDecideResponse['featureFlagPayloads'] | undefined
+  } {
     const flags = this.getFeatureFlags()
     const payloads = this.getFeatureFlagPayloads()
 
     return {
       flags,
-      payloads
+      payloads,
     }
   }
 

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -550,6 +550,16 @@ export abstract class PostHogCore {
     return flags
   }
 
+  getFeatureFlagsAndPayloads(): {flags: PostHogDecideResponse['featureFlags'] | undefined, payloads: PostHogDecideResponse['featureFlagPayloads'] | undefined} {
+    const flags = this.getFeatureFlags()
+    const payloads = this.getFeatureFlagPayloads()
+
+    return {
+      flags,
+      payloads
+    }
+  }
+
   isFeatureEnabled(key: string): boolean | undefined {
     const response = this.getFeatureFlag(key)
     if (response === undefined) {

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -116,6 +116,7 @@ export abstract class PostHogCore {
           {}
         )
       this.setKnownFeatureFlags(activeFlags)
+      options?.bootstrap.featureFlagPayloads && this.setKnownFeatureFlagPayloads(options?.bootstrap.featureFlagPayloads)
     }
   }
 

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -16,6 +16,7 @@ export type PosthogCoreOptions = {
     distinctId?: string
     isIdentifiedId?: boolean
     featureFlags?: Record<string, boolean | string>
+    featureFlagPayloads?: Record<string, JsonType>
   }
   // How many times we will retry HTTP requests
   fetchRetryCount?: number

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -95,4 +95,9 @@ export type PostHogDecideResponse = {
   sessionRecording: boolean
 }
 
+export type PosthogFlagsAndPayloadsResponse = {
+  featureFlags: PostHogDecideResponse["featureFlags"],
+  featureFlagPayloads: PostHogDecideResponse["featureFlagPayloads"]
+}
+
 export type JsonType = string | number | boolean | null | { [key: string]: JsonType } | Array<JsonType>

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -96,8 +96,8 @@ export type PostHogDecideResponse = {
 }
 
 export type PosthogFlagsAndPayloadsResponse = {
-  featureFlags: PostHogDecideResponse["featureFlags"],
-  featureFlagPayloads: PostHogDecideResponse["featureFlagPayloads"]
+  featureFlags: PostHogDecideResponse['featureFlags']
+  featureFlagPayloads: PostHogDecideResponse['featureFlagPayloads']
 }
 
 export type JsonType = string | number | boolean | null | { [key: string]: JsonType } | Array<JsonType>

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -571,29 +571,29 @@ describe('PostHog Core', () => {
           'feature-variant': 'variant',
         })
       })
-    })
 
-    it('should load new feature flag payloads', async () => {
-      expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
-        body: JSON.stringify({
-          token: 'TEST_API_KEY',
-          distinct_id: posthog.getDistinctId(),
-          $anon_distinct_id: 'tomato',
-          groups: {},
-          person_properties: {},
-          group_properties: {},
-        }),
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        signal: expect.anything(),
+      it('should load new feature flag payloads', async () => {
+        expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+          body: JSON.stringify({
+            token: 'TEST_API_KEY',
+            distinct_id: posthog.getDistinctId(),
+            $anon_distinct_id: 'tomato',
+            groups: {},
+            person_properties: {},
+            group_properties: {},
+          }),
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          signal: expect.anything(),
+        })
+  
+        expect(posthog.getFeatureFlagPayload('feature-1')).toEqual({
+          color: 'blue',
+        })
+        expect(posthog.getFeatureFlagPayload('feature-variant')).toEqual(5)
       })
-
-      expect(posthog.getFeatureFlagPayload('feature-1')).toEqual({
-        color: 'blue',
-      })
-      expect(posthog.getFeatureFlagPayload('feature-variant')).toEqual(5)
     })
   })
 })

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -572,5 +572,28 @@ describe('PostHog Core', () => {
         })
       })
     })
+
+    it('should load new feature flag payloads', async () => {
+      expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+        body: JSON.stringify({
+          token: 'TEST_API_KEY',
+          distinct_id: posthog.getDistinctId(),
+          $anon_distinct_id: 'tomato',
+          groups: {},
+          person_properties: {},
+          group_properties: {},
+        }),
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        signal: expect.anything(),
+      })
+
+      expect(posthog.getFeatureFlagPayload('feature-1')).toEqual({
+        color: 'blue',
+      })
+      expect(posthog.getFeatureFlagPayload('feature-variant')).toEqual(5)
+    })
   })
 })

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -483,10 +483,10 @@ describe('PostHog Core', () => {
             featureFlags: { 'bootstrap-1': 'variant-1', enabled: true, disabled: false },
             featureFlagPayloads: {
               'bootstrap-1': {
-                "some": "key"
+                some: 'key',
               },
-              'enabled': 200
-            }
+              enabled: 200,
+            },
           },
         },
         (_mocks) => {
@@ -538,7 +538,7 @@ describe('PostHog Core', () => {
     it('getFeatureFlagPayload should return bootstrapped payloads', () => {
       expect(posthog.getFeatureFlagPayload('my-flag')).toEqual(null)
       expect(posthog.getFeatureFlagPayload('bootstrap-1')).toEqual({
-        'some': 'key'
+        some: 'key',
       })
       expect(posthog.getFeatureFlagPayload('enabled')).toEqual(200)
     })

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -481,6 +481,12 @@ describe('PostHog Core', () => {
           bootstrap: {
             distinctId: 'tomato',
             featureFlags: { 'bootstrap-1': 'variant-1', enabled: true, disabled: false },
+            featureFlagPayloads: {
+              'bootstrap-1': {
+                "some": "key"
+              },
+              'enabled': 200
+            }
           },
         },
         (_mocks) => {
@@ -527,6 +533,14 @@ describe('PostHog Core', () => {
       expect(posthog.isFeatureEnabled('bootstrap-1')).toEqual(true)
       expect(posthog.isFeatureEnabled('enabled')).toEqual(true)
       expect(posthog.isFeatureEnabled('disabled')).toEqual(false)
+    })
+
+    it('getFeatureFlagPayload should return bootstrapped payloads', () => {
+      expect(posthog.getFeatureFlagPayload('my-flag')).toEqual(null)
+      expect(posthog.getFeatureFlagPayload('bootstrap-1')).toEqual({
+        'some': 'key'
+      })
+      expect(posthog.getFeatureFlagPayload('enabled')).toEqual(200)
     })
 
     describe('when loaded', () => {

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -498,7 +498,7 @@ describe('PostHog Core', () => {
                 json: () =>
                   Promise.resolve({
                     featureFlags: createMockFeatureFlags(),
-                    featureFlagPayloads: createMockFeatureFlagPayloads()
+                    featureFlagPayloads: createMockFeatureFlagPayloads(),
                   }),
               })
             }

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -498,6 +498,7 @@ describe('PostHog Core', () => {
                 json: () =>
                   Promise.resolve({
                     featureFlags: createMockFeatureFlags(),
+                    featureFlagPayloads: createMockFeatureFlagPayloads()
                   }),
               })
             }
@@ -588,7 +589,6 @@ describe('PostHog Core', () => {
           },
           signal: expect.anything(),
         })
-  
         expect(posthog.getFeatureFlagPayload('feature-1')).toEqual({
           color: 'blue',
         })

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -114,7 +114,7 @@ class FeatureFlagsPoller {
     return response
   }
 
-  async getFeatureFlagPayload(key: string, matchValue: string | boolean): Promise<JsonType | undefined> {
+  async computeFeatureFlagPayloadLocally(key: string, matchValue: string | boolean): Promise<JsonType | undefined> {
     await this.loadFeatureFlags()
 
     let response = undefined
@@ -157,7 +157,7 @@ class FeatureFlagsPoller {
       try {
         const matchValue = this.computeFlagLocally(flag, distinctId, groups, personProperties, groupProperties)
         response[flag.key] = matchValue
-        const matchPayload = await this.getFeatureFlagPayload(flag.key, matchValue)
+        const matchPayload = await this.computeFeatureFlagPayloadLocally(flag.key, matchValue)
         if (matchPayload) {
           payloads[flag.key] = matchPayload
         }

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -142,7 +142,11 @@ class FeatureFlagsPoller {
     groups: Record<string, string> = {},
     personProperties: Record<string, string> = {},
     groupProperties: Record<string, Record<string, string>> = {}
-  ): Promise<{ response: Record<string, string | boolean>, payloads: Record<string, JsonType>, fallbackToDecide: boolean }> {
+  ): Promise<{
+    response: Record<string, string | boolean>
+    payloads: Record<string, JsonType>
+    fallbackToDecide: boolean
+  }> {
     await this.loadFeatureFlags()
 
     const response: Record<string, string | boolean> = {}
@@ -157,7 +161,6 @@ class FeatureFlagsPoller {
         if (matchPayload) {
           payloads[flag.key] = matchPayload
         }
-
       } catch (e) {
         if (e instanceof InconclusiveMatchError) {
           // do nothing

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -6,6 +6,7 @@ import {
   PosthogCoreOptions,
   PostHogFetchOptions,
   PostHogFetchResponse,
+  PosthogFlagsAndPayloadsResponse,
   PostHogPersistedProperty,
 } from '../../posthog-core/src'
 import { PostHogMemoryStorage } from '../../posthog-core/src/storage-memory'
@@ -294,51 +295,11 @@ export class PostHog implements PostHogNodeV1 {
       onlyEvaluateLocally?: boolean
     }
   ): Promise<Record<string, string | boolean>> {
-    const { groups, personProperties, groupProperties } = options || {}
-    let { onlyEvaluateLocally } = options || {}
-
-    // set defaults
-    if (onlyEvaluateLocally == undefined) {
-      onlyEvaluateLocally = false
-    }
-
-    const localEvaluationResult = await this.featureFlagsPoller?.getAllFlagsAndPayloads(
-      distinctId,
-      groups,
-      personProperties,
-      groupProperties
-    )
-
-    let response = {}
-    let fallbackToDecide = true
-    if (localEvaluationResult) {
-      response = localEvaluationResult.response
-      fallbackToDecide = localEvaluationResult.fallbackToDecide
-    }
-
-    if (fallbackToDecide && !onlyEvaluateLocally) {
-      this.reInit(distinctId)
-      if (groups) {
-        this._sharedClient.groups(groups)
-      }
-
-      if (personProperties) {
-        this._sharedClient.personProperties(personProperties)
-      }
-
-      if (groupProperties) {
-        this._sharedClient.groupProperties(groupProperties)
-      }
-      await this._sharedClient.reloadFeatureFlagsAsync(false)
-      const remoteEvaluationResult = this._sharedClient.getFeatureFlags()
-
-      return { ...response, ...remoteEvaluationResult }
-    }
-
-    return response
+    const response = await this.getAllFlagsAndPayloads(distinctId, options)
+    return response.featureFlags
   }
 
-  async getAllPayloads(
+  async getAllFlagsAndPayloads(
     distinctId: string,
     options?: {
       groups?: Record<string, string>
@@ -346,7 +307,7 @@ export class PostHog implements PostHogNodeV1 {
       groupProperties?: Record<string, Record<string, string>>
       onlyEvaluateLocally?: boolean
     }
-  ): Promise<Record<string, JsonType>> {
+  ): Promise<PosthogFlagsAndPayloadsResponse> {
     const { groups, personProperties, groupProperties } = options || {}
     let { onlyEvaluateLocally } = options || {}
 
@@ -362,10 +323,12 @@ export class PostHog implements PostHogNodeV1 {
       groupProperties
     )
 
-    let response = {}
+    let featureFlags = {}
+    let featureFlagPayloads = {}
     let fallbackToDecide = true
     if (localEvaluationResult) {
-      response = localEvaluationResult.payloads
+      featureFlags = localEvaluationResult.response
+      featureFlagPayloads = localEvaluationResult.payloads
       fallbackToDecide = localEvaluationResult.fallbackToDecide
     }
 
@@ -383,12 +346,18 @@ export class PostHog implements PostHogNodeV1 {
         this._sharedClient.groupProperties(groupProperties)
       }
       await this._sharedClient.reloadFeatureFlagsAsync(false)
-      const remoteEvaluationResult = this._sharedClient.getFeatureFlagPayloads()
-
-      return { ...response, ...remoteEvaluationResult }
+      const remoteEvaluationResult = this._sharedClient.getFeatureFlagsAndPayloads()
+      featureFlags = {
+        ...featureFlags,
+        ...(remoteEvaluationResult.flags || {})
+      }
+      featureFlagPayloads = {
+        ...featureFlagPayloads,
+        ...(remoteEvaluationResult.payloads || {})
+      }
     }
 
-    return response
+    return { featureFlags, featureFlagPayloads }
   }
 
   groupIdentify({ groupType, groupKey, properties }: GroupIdentifyMessage): void {

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -230,7 +230,7 @@ export class PostHog implements PostHogNodeV1 {
     }
 
     if (matchValue) {
-      response = await this.featureFlagsPoller?.getFeatureFlagPayload(key, matchValue)
+      response = await this.featureFlagsPoller?.computeFeatureFlagPayloadLocally(key, matchValue)
     }
 
     // set defaults

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -349,11 +349,11 @@ export class PostHog implements PostHogNodeV1 {
       const remoteEvaluationResult = this._sharedClient.getFeatureFlagsAndPayloads()
       featureFlags = {
         ...featureFlags,
-        ...(remoteEvaluationResult.flags || {})
+        ...(remoteEvaluationResult.flags || {}),
       }
       featureFlagPayloads = {
         ...featureFlagPayloads,
-        ...(remoteEvaluationResult.payloads || {})
+        ...(remoteEvaluationResult.payloads || {}),
       }
     }
 

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -708,8 +708,8 @@ describe('local evaluation', () => {
               },
             ],
             payloads: {
-              "true": "some-payload"
-            }
+              true: 'some-payload',
+            },
           },
         },
         {
@@ -726,8 +726,8 @@ describe('local evaluation', () => {
               },
             ],
             payloads: {
-              "true": "another-payload"
-            }
+              true: 'another-payload',
+            },
           },
         },
         {
@@ -744,8 +744,8 @@ describe('local evaluation', () => {
               },
             ],
             payloads: {
-              "true": "payload-3"
-            }
+              true: 'payload-3',
+            },
           },
         },
       ],
@@ -754,7 +754,7 @@ describe('local evaluation', () => {
       apiImplementation({
         localFlags: flags,
         decideFlags: { 'beta-feature': 'variant-1', 'beta-feature2': 'variant-2' },
-        decideFlagPayloads: { 'beta-feature': 100, 'beta-feature2': 300 }
+        decideFlagPayloads: { 'beta-feature': 100, 'beta-feature2': 300 },
       })
     )
 
@@ -766,7 +766,7 @@ describe('local evaluation', () => {
     // # beta-feature value overridden by /decide
     expect(await posthog.getAllPayloads('distinct-id')).toEqual({
       'beta-feature': 100,
-      'beta-feature2': 300
+      'beta-feature2': 300,
     })
     expect(mockedFetch).toHaveBeenCalledWith(...anyDecideCall)
     mockedFetch.mockClear()
@@ -861,8 +861,8 @@ describe('local evaluation', () => {
               },
             ],
             payloads: {
-              "true": "some-payload"
-            }
+              true: 'some-payload',
+            },
           },
         },
         {
@@ -879,8 +879,8 @@ describe('local evaluation', () => {
               },
             ],
             payloads: {
-              "true": "another-payload"
-            }
+              true: 'another-payload',
+            },
           },
         },
         {
@@ -897,8 +897,8 @@ describe('local evaluation', () => {
               },
             ],
             payloads: {
-              "true": "payload-3"
-            }
+              true: 'payload-3',
+            },
           },
         },
       ],
@@ -907,7 +907,7 @@ describe('local evaluation', () => {
       apiImplementation({
         localFlags: flags,
         decideFlags: { 'beta-feature': 'variant-1', 'beta-feature2': 'variant-2' },
-        decideFlagPayloads: { 'beta-feature': 100, 'beta-feature2': 300 }
+        decideFlagPayloads: { 'beta-feature': 100, 'beta-feature2': 300 },
       })
     )
 
@@ -917,7 +917,7 @@ describe('local evaluation', () => {
     })
 
     expect(await posthog.getAllPayloads('distinct-id', { onlyEvaluateLocally: true })).toEqual({
-      'beta-feature': "some-payload"
+      'beta-feature': 'some-payload',
     })
     expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
   })
@@ -954,7 +954,7 @@ describe('local evaluation', () => {
       apiImplementation({
         localFlags: flags,
         decideFlags: { 'beta-feature': 'variant-1', 'beta-feature2': 'variant-2' },
-        decideFlagPayloads: { 'beta-feature': 100, 'beta-feature2': 300 }
+        decideFlagPayloads: { 'beta-feature': 100, 'beta-feature2': 300 },
       })
     )
 
@@ -1041,8 +1041,8 @@ describe('local evaluation', () => {
               },
             ],
             payloads: {
-              'true': "new"
-            }
+              true: 'new',
+            },
           },
         },
         {
@@ -1059,8 +1059,8 @@ describe('local evaluation', () => {
               },
             ],
             payloads: {
-              'true': 'some-payload'
-            }
+              true: 'some-payload',
+            },
           },
         },
       ],

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -916,7 +916,9 @@ describe('local evaluation', () => {
       personalApiKey: 'TEST_PERSONAL_API_KEY',
     })
 
-    expect((await posthog.getAllFlagsAndPayloads('distinct-id', { onlyEvaluateLocally: true })).featureFlagPayloads).toEqual({
+    expect(
+      (await posthog.getAllFlagsAndPayloads('distinct-id', { onlyEvaluateLocally: true })).featureFlagPayloads
+    ).toEqual({
       'beta-feature': 'some-payload',
     })
     expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -764,7 +764,7 @@ describe('local evaluation', () => {
     })
 
     // # beta-feature value overridden by /decide
-    expect(await posthog.getAllPayloads('distinct-id')).toEqual({
+    expect((await posthog.getAllFlagsAndPayloads('distinct-id')).featureFlagPayloads).toEqual({
       'beta-feature': 100,
       'beta-feature2': 300,
     })
@@ -916,7 +916,7 @@ describe('local evaluation', () => {
       personalApiKey: 'TEST_PERSONAL_API_KEY',
     })
 
-    expect(await posthog.getAllPayloads('distinct-id', { onlyEvaluateLocally: true })).toEqual({
+    expect((await posthog.getAllFlagsAndPayloads('distinct-id', { onlyEvaluateLocally: true })).featureFlagPayloads).toEqual({
       'beta-feature': 'some-payload',
     })
     expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
@@ -963,7 +963,7 @@ describe('local evaluation', () => {
       personalApiKey: 'TEST_PERSONAL_API_KEY',
     })
 
-    expect(await posthog.getAllPayloads('distinct-id')).toEqual({
+    expect((await posthog.getAllFlagsAndPayloads('distinct-id')).featureFlagPayloads).toEqual({
       'beta-feature': 100,
       'beta-feature2': 300,
     })
@@ -1077,7 +1077,7 @@ describe('local evaluation', () => {
       personalApiKey: 'TEST_PERSONAL_API_KEY',
     })
 
-    expect(await posthog.getAllPayloads('distinct-id')).toEqual({ 'beta-feature': 'new' })
+    expect((await posthog.getAllFlagsAndPayloads('distinct-id')).featureFlagPayloads).toEqual({ 'beta-feature': 'new' })
     expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
   })
 


### PR DESCRIPTION
- Add ability to bootstrap payloads
- init can now accept `featureFlagPayloads: Record<string, JsonType>`