### PR TITLE
chore: feature flag payload try to parse json

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -517,18 +517,25 @@ export abstract class PostHogCore {
       return null
     }
 
-    try {
-      return JSON.parse(response as any)
-    } catch {
-      return response
-    }
+    return this._parsePayload(response)
   }
 
   getFeatureFlagPayloads(): PostHogDecideResponse['featureFlagPayloads'] | undefined {
     let payloads = this.getPersistedProperty<PostHogDecideResponse['featureFlagPayloads']>(
       PostHogPersistedProperty.FeatureFlagPayloads
     )
+    if(payloads) {
+      return Object.fromEntries(Object.entries(payloads).map(([k, v]) => [k, this._parsePayload(v)]))
+    }
     return payloads
+  }
+
+  _parsePayload(response: any) {
+    try {
+      return JSON.parse(response)
+    } catch {
+      return response
+    }
   }
 
   getFeatureFlags(): PostHogDecideResponse['featureFlags'] | undefined {

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -510,7 +510,7 @@ export abstract class PostHogCore {
       return undefined
     }
 
-    let response = payloads[key]
+    const response = payloads[key]
 
     // Undefined means a loading or missing data issue. Null means evaluation happened and there was no match
     if (response === undefined) {
@@ -521,7 +521,7 @@ export abstract class PostHogCore {
   }
 
   getFeatureFlagPayloads(): PostHogDecideResponse['featureFlagPayloads'] | undefined {
-    let payloads = this.getPersistedProperty<PostHogDecideResponse['featureFlagPayloads']>(
+    const payloads = this.getPersistedProperty<PostHogDecideResponse['featureFlagPayloads']>(
       PostHogPersistedProperty.FeatureFlagPayloads
     )
     if(payloads) {
@@ -530,7 +530,7 @@ export abstract class PostHogCore {
     return payloads
   }
 
-  _parsePayload(response: any) {
+  _parsePayload(response: any): any {
     try {
       return JSON.parse(response)
     } catch {

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -524,7 +524,7 @@ export abstract class PostHogCore {
     const payloads = this.getPersistedProperty<PostHogDecideResponse['featureFlagPayloads']>(
       PostHogPersistedProperty.FeatureFlagPayloads
     )
-    if(payloads) {
+    if (payloads) {
       return Object.fromEntries(Object.entries(payloads).map(([k, v]) => [k, this._parsePayload(v)]))
     }
     return payloads

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -517,7 +517,11 @@ export abstract class PostHogCore {
       return null
     }
 
-    return response
+    try {
+      return JSON.parse(response as any)
+    } catch {
+      return response
+    }
   }
 
   getFeatureFlagPayloads(): PostHogDecideResponse['featureFlagPayloads'] | undefined {

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -13,6 +13,7 @@ describe('PostHog Core', () => {
     'feature-1': true,
     'feature-2': true,
     'feature-variant': 'variant',
+    'json-payload': true
   })
 
   const createMockFeatureFlagPayloads = (): any => ({
@@ -20,6 +21,7 @@ describe('PostHog Core', () => {
       color: 'blue',
     },
     'feature-variant': 5,
+    'json-payload': '{"a":"payload"}'
   })
 
   const errorAPIResponse = Promise.resolve({
@@ -120,12 +122,16 @@ describe('PostHog Core', () => {
         expect(posthog.getFeatureFlags()).toEqual({
           'feature-1': true,
           'feature-2': true,
+          'json-payload': true,
           'feature-variant': 'variant',
         })
 
         expect(posthog.getFeatureFlagPayloads()).toEqual({
           'feature-1': {
             color: 'blue',
+          },
+          'json-payload': {
+            a: 'payload'
           },
           'feature-variant': 5,
         })
@@ -258,6 +264,7 @@ describe('PostHog Core', () => {
           expect(posthog.getFeatureFlags()).toEqual({
             'feature-1': true,
             'feature-2': true,
+            'json-payload': true,
             'feature-variant': 'variant',
           })
 
@@ -283,6 +290,7 @@ describe('PostHog Core', () => {
           expect(posthog.getFeatureFlags()).toEqual({
             'feature-1': false,
             'feature-2': true,
+            'json-payload': true,
             'feature-variant': 'variant',
             'x-flag': 'x-value',
           })
@@ -359,6 +367,7 @@ describe('PostHog Core', () => {
           expect(posthog.getFeatureFlags()).toEqual({
             'feature-1': true,
             'feature-2': true,
+            'json-payload': true,
             'feature-variant': 'variant',
           })
 
@@ -448,9 +457,10 @@ describe('PostHog Core', () => {
               event: 'test-event',
               distinct_id: posthog.getDistinctId(),
               properties: {
-                $active_feature_flags: ['feature-1', 'feature-2', 'feature-variant'],
+                $active_feature_flags: ['feature-1', 'feature-2', 'feature-variant', 'json-payload'],
                 '$feature/feature-1': true,
                 '$feature/feature-2': true,
+                '$feature/json-payload': true,
                 '$feature/feature-variant': 'variant',
               },
               type: 'capture',
@@ -465,6 +475,7 @@ describe('PostHog Core', () => {
           'feature-variant': 'control',
         })
         expect(posthog.getFeatureFlags()).toEqual({
+          'json-payload': true,
           'feature-1': true,
           'feature-variant': 'control',
         })
@@ -569,6 +580,7 @@ describe('PostHog Core', () => {
         expect(posthog.getFeatureFlags()).toEqual({
           'feature-1': true,
           'feature-2': true,
+          'json-payload': true,
           'feature-variant': 'variant',
         })
       })

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -13,7 +13,7 @@ describe('PostHog Core', () => {
     'feature-1': true,
     'feature-2': true,
     'feature-variant': 'variant',
-    'json-payload': true
+    'json-payload': true,
   })
 
   const createMockFeatureFlagPayloads = (): any => ({
@@ -21,7 +21,7 @@ describe('PostHog Core', () => {
       color: 'blue',
     },
     'feature-variant': 5,
-    'json-payload': '{"a":"payload"}'
+    'json-payload': '{"a":"payload"}',
   })
 
   const errorAPIResponse = Promise.resolve({
@@ -131,7 +131,7 @@ describe('PostHog Core', () => {
             color: 'blue',
           },
           'json-payload': {
-            a: 'payload'
+            a: 'payload',
           },
           'feature-variant': 5,
         })

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -265,7 +265,11 @@ export class PostHog implements PostHogNodeV1 {
       response = this._sharedClient.getFeatureFlagPayload(key)
     }
 
-    return response
+    try {
+      return JSON.parse(response as any)
+    } catch {
+      return response
+    }
   }
 
   async isFeatureEnabled(


### PR DESCRIPTION
## Problem

- the returned payload may be a stringified json payload
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- try-catch parse json
<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
