### PR TITLE
fix: Different groupIdentify behaviour for node lib

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -345,16 +345,15 @@ export abstract class PostHogCore {
   }
 
   groupIdentify(groupType: string, groupKey: string | number, groupProperties?: PostHogEventProperties): this {
-    const payload = {
+    const payload = this.buildPayload({
       event: '$groupidentify',
-      distinctId: `$${groupType}_${groupKey}`,
       properties: {
         $group_type: groupType,
         $group_key: groupKey,
         $group_set: groupProperties || {},
         ...this.getCommonEventProperties(),
       },
-    }
+    })
 
     this.enqueue('capture', payload)
     return this

--- a/posthog-core/test/posthog.groups.spec.ts
+++ b/posthog-core/test/posthog.groups.spec.ts
@@ -45,7 +45,7 @@ describe('PostHog Core', () => {
         batch: [
           {
             event: '$groupidentify',
-            distinct_id: '$other_team',
+            distinct_id: posthog.getDistinctId(),
             properties: {
               $group_type: 'other',
               $group_key: 'team',
@@ -62,12 +62,12 @@ describe('PostHog Core', () => {
     it('should identify group', () => {
       posthog.groupIdentify('posthog', 'team-1', { analytics: true })
 
-      expect(parseBody(mocks.fetch.mock.calls[0])).toEqual({
+      expect(parseBody(mocks.fetch.mock.calls[0])).toMatchObject({
         api_key: 'TEST_API_KEY',
         batch: [
           {
             event: '$groupidentify',
-            distinct_id: '$posthog_team-1',
+            distinct_id: posthog.getDistinctId(),
             library: 'posthog-core-tests',
             library_version: '2.0.0-alpha',
             properties: {

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -365,6 +365,7 @@ export class PostHog implements PostHogNodeV1 {
   }
 
   groupIdentify({ groupType, groupKey, properties }: GroupIdentifyMessage): void {
+    this.reInit(`$${groupType}_${groupKey}`)
     this._sharedClient.groupIdentify(groupType, groupKey, properties)
   }
 

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -138,6 +138,27 @@ describe('PostHog Node.js', () => {
     })
   })
 
+  describe('groupIdentify', () => {
+    it('should identify group with unique id', () => {
+      posthog.groupIdentify({ groupType: 'posthog', groupKey: 'team-1', properties: { analytics: true } })
+      jest.runOnlyPendingTimers()
+      const batchEvents = getLastBatchEvents()
+      console.log(batchEvents)
+      expect(batchEvents).toMatchObject([
+        {
+          distinct_id: '$posthog_team-1',
+          event: '$groupidentify',
+          properties: {
+            $group_type: 'posthog',
+            $group_key: 'team-1',
+            $group_set: { analytics: true },
+            $lib: 'posthog-node',
+          },
+        },
+      ])
+    })
+  })
+
   describe('feature flags', () => {
     beforeEach(() => {
       const mockFeatureFlags = {

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.3 - 2023-01-25
+
+- Ensures the distinctId used in `.groupIdentify` is the same as the currently identified user
+
 # 2.2.2 - 2023-01-05
 
 - Fixes an issue with PostHogProvider where autocapture={false} would still capture lifecycle and navigation events.

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 2.0.1 - 2023-01-25
+
+- Ensures the distinctId used in `.groupIdentify` is the same as the currently identified user

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-js-lite",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Problem

For client SDKs we should use the distinctId for the current user and for server SDKS as hash of the key and id. We were always acting like a server SDK

## Changes

* Fixes this and adds tests

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-web
- [ ] posthog-node
- [x] posthog-react-native

### Changelog notes

- Ensures the distinctId used in `.groupIdentify` is the same as the currently identified user

