### PR TITLE
fix: Make type import relative so typescript builds correctly

### DIFF
--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "PostHog Node.js integration",
   "repository": "PostHog/posthog-node",
   "scripts": {

--- a/posthog-node/src/types.ts
+++ b/posthog-node/src/types.ts
@@ -1,4 +1,4 @@
-import { JsonType } from 'posthog-core/src'
+import { JsonType } from '../../posthog-core/src'
 
 export interface IdentifyMessageV1 {
   distinctId: string


### PR DESCRIPTION
## Problem

- https://github.com/PostHog/posthog-js-lite/issues/65
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- makes the import relative
<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
