### PR TITLE
fix: Catch promise error for background refreshes

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -599,10 +599,17 @@ export abstract class PostHogCore {
   }
 
   // Used when we want to trigger the reload but we don't care about the result
-  reloadFeatureFlags(): void {
-    this.decideAsync().catch((e) => {
-      console.log('[PostHog] Error reloading feature flags', e)
-    })
+  reloadFeatureFlags(cb?: (err?: Error, flags?: PostHogDecideResponse['featureFlags']) => void): void {
+    this.decideAsync()
+      .then((res) => {
+        cb?.(undefined, res.featureFlags)
+      })
+      .catch((e) => {
+        cb?.(e, undefined)
+        if (!cb) {
+          console.log('[PostHog] Error reloading feature flags', e)
+        }
+      })
   }
 
   onFeatureFlags(cb: (flags: PostHogDecideResponse['featureFlags']) => void): () => void {

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.5.2 - 2023-02-13
+
+1. Fixes an issue where background network errors would trigger unhandled promise warnings
+
 # 2.5.1 - 2023-02-03
 
 1. Added support for customising the default app properties by passing a function to `options.customAppProperties`

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.1 - 2023-02-13
+
+1. Fixes an issue where background network errors would trigger unhandled promise warnings
+
 # 2.2.0 - 2023-02-02
 
 1. Adds support for overriding timestamp of capture events

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-js-lite",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Problem

We background refresh the feature flags but don't handle if there is a bad response (e.g. due to network issues)

Closes https://github.com/PostHog/posthog-js-lite/issues/70

## Changes

* Adds a new non-async method which takes an optional callback
* Changes background refreshes to use this

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-web
- [ ] posthog-node
- [x] posthog-react-native

### Changelog notes

- Fixes an issue where background network errors would trigger unhandled promise warnings
