### PR TITLE
Update node version for release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,11 @@ jobs:
         with:
           path: ${{ matrix.package.name }}
 
-      - name: Set up Node 14
+      - name: Set up Node 15
         uses: actions/setup-node@v2
         if: steps.check-package-version.outputs.is-new-version == 'true'
         with:
-          node-version: 14
+          node-version: 15
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies


### PR DESCRIPTION
## Problem

Restricting Node to 15+ seems to have broken CI 😅 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
