### PR TITLE
Jest-matcher requires node 16 for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,11 @@ jobs:
         with:
           path: ${{ matrix.package.name }}
 
-      - name: Set up Node 15
+      - name: Set up Node 16
         uses: actions/setup-node@v2
         if: steps.check-package-version.outputs.is-new-version == 'true'
         with:
-          node-version: 15
+          node-version: 16
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies


### PR DESCRIPTION
## Problem

See run fail:  https://github.com/PostHog/posthog-js-lite/actions/runs/4183402196/jobs/7247712879
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
