### PR TITLE
fix: Identify $set for Node

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,10 +1,16 @@
+# 2.5.2 - 2023-02-17
+
+1. Fix issue where properties passed to `.identify` were not set correctly
+
 # 2.5.1 - 2023-02-16
 
 1. Make sure shutdown waits for pending promises to resolve. Fixes a problem with using PostHog Node in serverless environments.
+
 # 2.5.0 - 2023-02-15
 
 1. Removes shared client from `posthog-node`, getting rid of some race condition bugs when capturing events.
 2. Sets minimum version of node.js to 15
+
 # 2.4.0 - 2023-02-02
 
 1. Adds support for overriding timestamp of capture events

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "PostHog Node.js integration",
   "repository": "PostHog/posthog-node",
   "scripts": {

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -117,7 +117,12 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
   }
 
   identify({ distinctId, properties }: IdentifyMessageV1): void {
-    super.identifyStateless(distinctId, properties)
+    // Catch properties passed as $set and move them to the top level
+    const personProperties = properties?.$set || properties
+
+    super.identifyStateless(distinctId, {
+      $set: personProperties,
+    })
   }
 
   alias(data: { distinctId: string; alias: string }): void {

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -114,7 +114,27 @@ describe('PostHog Node.js', () => {
           distinct_id: '123',
           event: '$identify',
           properties: {
-            foo: 'bar',
+            $set: {
+              foo: 'bar',
+            },
+          },
+        },
+      ])
+    })
+
+    it('should handle identify mistakenly using $set', async () => {
+      expect(mockedFetch).toHaveBeenCalledTimes(0)
+      posthog.identify({ distinctId: '123', properties: { foo: 'bar', $set: { foo: 'other' } } })
+      jest.runOnlyPendingTimers()
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents).toMatchObject([
+        {
+          distinct_id: '123',
+          event: '$identify',
+          properties: {
+            $set: {
+              foo: 'other',
+            },
           },
         },
       ])


### PR DESCRIPTION
## Problem

Stateless refactor introduced a bug with identify on node

## Changes

* Fix this to use $set and also handle if someone treats it like a `capture` call.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-react-native