### PR TITLE
fix: add debug logs only in debug mode

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -35,10 +35,9 @@ export abstract class PostHogCoreStateless {
   private removeDebugCallback?: () => void
   private debugMode: boolean = false
   private pendingPromises: Record<string, Promise<any>> = {}
-  
+
   private _optoutOverride: boolean | undefined
-  
-  
+
   // internal
   protected _events = new SimpleEventEmitter()
   protected _flushTimer?: any

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -33,10 +33,12 @@ export abstract class PostHogCoreStateless {
   private requestTimeout: number
   private captureMode: 'form' | 'json'
   private removeDebugCallback?: () => void
+  private debugMode: boolean = false
   private pendingPromises: Record<string, Promise<any>> = {}
-
+  
   private _optoutOverride: boolean | undefined
-
+  
+  
   // internal
   protected _events = new SimpleEventEmitter()
   protected _flushTimer?: any
@@ -96,6 +98,8 @@ export abstract class PostHogCoreStateless {
 
   debug(enabled: boolean = true): void {
     this.removeDebugCallback?.()
+
+    this.debugMode = enabled
 
     if (enabled) {
       this.removeDebugCallback = this.on('*', (event, payload) => console.log('PostHog Debug', event, payload))

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.5.4 - 2023-02-27
+
+1. Fix error log for local evaluation of feature flags (InconclusiveMatchError(s)) to only show during debug mode.
 # 2.5.3 - 2023-02-21
 
 1. Allow passing in a distinctId to `groupIdentify()`.

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "PostHog Node.js integration",
   "repository": "PostHog/posthog-node",
   "scripts": {

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -51,6 +51,7 @@ class FeatureFlagsPoller {
   host: FeatureFlagsPollerOptions['host']
   poller?: NodeJS.Timeout
   fetch: (url: string, options: PostHogFetchOptions) => Promise<PostHogFetchResponse>
+  debugMode: boolean = false
 
   constructor({
     pollingInterval,
@@ -74,6 +75,10 @@ class FeatureFlagsPoller {
     this.fetch = options.fetch || fetch
 
     void this.loadFeatureFlags()
+  }
+
+  debug(enabled: boolean = true): void {
+    this.debugMode = enabled
   }
 
   async getFeatureFlag(
@@ -102,9 +107,14 @@ class FeatureFlagsPoller {
     if (featureFlag !== undefined) {
       try {
         response = this.computeFlagLocally(featureFlag, distinctId, groups, personProperties, groupProperties)
+        if (this.debugMode) {
+          console.debug(`Successfully computed flag locally: ${key} -> ${response}`)
+        }
       } catch (e) {
         if (e instanceof InconclusiveMatchError) {
-          console.error(`InconclusiveMatchError when computing flag locally: ${key}: ${e}`)
+          if (this.debugMode) {
+            console.debug(`InconclusiveMatchError when computing flag locally: ${key}: ${e}`)
+          }
         } else if (e instanceof Error) {
           console.error(`Error computing flag locally: ${key}: ${e}`)
         }

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -92,6 +92,11 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
     return super.optOut()
   }
 
+  debug(enabled: boolean = true): void {
+    super.debug(enabled)
+    this.featureFlagsPoller?.debug(enabled)
+  }
+
   capture({ distinctId, event, properties, groups, sendFeatureFlags, timestamp }: EventMessageV1): void {
     const _capture = (props: EventMessageV1['properties']): void => {
       super.captureStateless(distinctId, event, props, { timestamp })


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog-node/issues/83

A proper fix for https://github.com/PostHog/posthog-js-lite/pull/44

Tested locally, in debug mode, debug logs show up. In non-debug mode, they don't show up.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
