### PR TITLE
feat(flags): Enable local evaluation for all cohorts

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.6.0 - 2023-03-14
+
+1. Add support for all cohorts local evaluation in feature flags.
+
 # 2.5.4 - 2023-02-27
 
 1. Fix error log for local evaluation of feature flags (InconclusiveMatchError(s)) to only show during debug mode.

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "2.5.4",
+  "version": "2.6.0",
   "description": "PostHog Node.js integration",
   "repository": "PostHog/posthog-node",
   "scripts": {

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -499,7 +499,6 @@ function matchProperty(
   }
 }
 
-
 function matchCohort(
   property: FeatureFlagCondition['properties'][number],
   propertyValues: Record<string, any>,
@@ -557,7 +556,7 @@ function matchPropertyGroup(
         }
       }
     }
-    
+
     if (errorMatchingLocally) {
       throw new InconclusiveMatchError("Can't match cohort without a given cohort property value")
     }
@@ -610,7 +609,6 @@ function matchPropertyGroup(
     return propertyGroupType === 'AND'
   }
 }
-
 
 function isValidRegex(regex: string): boolean {
   try {

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto'
-import { FeatureFlagCondition, PostHogFeatureFlag } from './types'
+import { FeatureFlagCondition, FlagProperty, PostHogFeatureFlag, PropertyGroup } from './types'
 import { version } from '../package.json'
 import { JsonType, PostHogFetchOptions, PostHogFetchResponse } from 'posthog-core/src'
 import { safeSetTimeout } from 'posthog-core/src/utils'
@@ -46,6 +46,7 @@ class FeatureFlagsPoller {
   featureFlags: Array<PostHogFeatureFlag>
   featureFlagsByKey: Record<string, PostHogFeatureFlag>
   groupTypeMapping: Record<string, string>
+  cohorts: Record<string, PropertyGroup>
   loadedSuccessfullyOnce: boolean
   timeout?: number
   host: FeatureFlagsPollerOptions['host']
@@ -66,6 +67,7 @@ class FeatureFlagsPoller {
     this.featureFlags = []
     this.featureFlagsByKey = {}
     this.groupTypeMapping = {}
+    this.cohorts = {}
     this.loadedSuccessfullyOnce = false
     this.timeout = timeout
     this.projectApiKey = projectApiKey
@@ -291,13 +293,22 @@ class FeatureFlagsPoller {
     const rolloutPercentage = condition.rollout_percentage
 
     if ((condition.properties || []).length > 0) {
-      const matchAll = condition.properties.every((property) => {
-        return matchProperty(property, properties)
-      })
-      if (!matchAll) {
-        return false
-      } else if (rolloutPercentage == undefined) {
-        // == to include `null` as a match, not just `undefined`
+      for (const prop of condition.properties) {
+        const propertyType = prop.type
+        let matches = false
+
+        if (propertyType === 'cohort') {
+          matches = matchCohort(prop, properties, this.cohorts)
+        } else {
+          matches = matchProperty(prop, properties)
+        }
+
+        if (!matches) {
+          return false
+        }
+      }
+
+      if (rolloutPercentage == undefined) {
         return true
       }
     }
@@ -378,6 +389,7 @@ class FeatureFlagsPoller {
         <Record<string, PostHogFeatureFlag>>{}
       )
       this.groupTypeMapping = responseJson.group_type_mapping || {}
+      this.cohorts = responseJson.cohorts || []
       this.loadedSuccessfullyOnce = true
     } catch (err) {
       // if an error that is not an instance of ClientError is thrown
@@ -389,7 +401,7 @@ class FeatureFlagsPoller {
   }
 
   async _requestFeatureFlagDefinitions(): Promise<PostHogFetchResponse> {
-    const url = `${this.host}/api/feature_flag/local_evaluation?token=${this.projectApiKey}`
+    const url = `${this.host}/api/feature_flag/local_evaluation?token=${this.projectApiKey}&send_cohorts`
 
     const options: PostHogFetchOptions = {
       method: 'GET',
@@ -486,6 +498,119 @@ function matchProperty(
       return false
   }
 }
+
+
+function matchCohort(
+  property: FeatureFlagCondition['properties'][number],
+  propertyValues: Record<string, any>,
+  cohortProperties: FeatureFlagsPoller['cohorts']
+): boolean {
+  const cohortId = String(property.value)
+  if (!(cohortId in cohortProperties)) {
+    throw new InconclusiveMatchError("can't match cohort without a given cohort property value")
+  }
+
+  const propertyGroup = cohortProperties[cohortId]
+  return matchPropertyGroup(propertyGroup, propertyValues, cohortProperties)
+}
+
+function matchPropertyGroup(
+  propertyGroup: PropertyGroup,
+  propertyValues: Record<string, any>,
+  cohortProperties: FeatureFlagsPoller['cohorts']
+): boolean {
+  if (!propertyGroup) {
+    return true
+  }
+
+  const propertyGroupType = propertyGroup.type
+  const properties = propertyGroup.values
+
+  if (!properties || properties.length === 0) {
+    // empty groups are no-ops, always match
+    return true
+  }
+
+  let errorMatchingLocally = false
+
+  if ('values' in properties[0]) {
+    // a nested property group
+    for (const prop of properties as PropertyGroup[]) {
+      try {
+        const matches = matchPropertyGroup(prop, propertyValues, cohortProperties)
+        if (propertyGroupType === 'AND') {
+          if (!matches) {
+            return false
+          }
+        } else {
+          // OR group
+          if (matches) {
+            return true
+          }
+        }
+      } catch (err) {
+        if (err instanceof InconclusiveMatchError) {
+          console.debug(`Failed to compute property ${prop} locally: ${err}`)
+          errorMatchingLocally = true
+        } else {
+          throw err
+        }
+      }
+    }
+    
+    if (errorMatchingLocally) {
+      throw new InconclusiveMatchError("Can't match cohort without a given cohort property value")
+    }
+    // if we get here, all matched in AND case, or none matched in OR case
+    return propertyGroupType === 'AND'
+  } else {
+    for (const prop of properties as FlagProperty[]) {
+      try {
+        let matches: boolean
+        if (prop.type === 'cohort') {
+          matches = matchCohort(prop, propertyValues, cohortProperties)
+        } else {
+          matches = matchProperty(prop, propertyValues)
+        }
+
+        const negation = prop.negation || false
+
+        if (propertyGroupType === 'AND') {
+          // if negated property, do the inverse
+          if (!matches && !negation) {
+            return false
+          }
+          if (matches && negation) {
+            return false
+          }
+        } else {
+          // OR group
+          if (matches && !negation) {
+            return true
+          }
+          if (!matches && negation) {
+            return true
+          }
+        }
+      } catch (err) {
+        if (err instanceof InconclusiveMatchError) {
+          console.debug(`Failed to compute property ${prop} locally: ${err}`)
+          errorMatchingLocally = true
+        } else {
+          throw err
+        }
+      }
+    }
+
+    if (errorMatchingLocally) {
+      throw new InconclusiveMatchError("can't match cohort without a given cohort property value")
+    }
+
+    // if we get here, all matched in AND case, or none matched in OR case
+    return propertyGroupType === 'AND'
+  }
+}
+
 
 function isValidRegex(regex: string): boolean {
   try {

--- a/posthog-node/src/types.ts
+++ b/posthog-node/src/types.ts
@@ -19,13 +19,21 @@ export interface GroupIdentifyMessage {
   distinctId?: string // optional distinctId to associate message with a person
 }
 
+export type PropertyGroup = {
+  type: 'AND' | 'OR'
+  values: PropertyGroup[] | FlagProperty[]
+}
+
+export type FlagProperty = {
+  key: string
+  type?: string
+  value: string | number | (string | number)[]
+  operator?: string
+  negation?: boolean
+}
+
 export type FeatureFlagCondition = {
-  properties: {
-    key: string
-    type?: string
-    value: string | number | (string | number)[]
-    operator?: string
-  }[]
+  properties: FlagProperty[]
   rollout_percentage?: number
   variant?: string
 }

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -1192,13 +1192,15 @@ describe('local evaluation', () => {
           filters: {
             groups: [
               {
-                properties: [{
-                  "key": "region",
-                  "operator": "exact",
-                  "value": ["USA"],
-                  "type": "person",
-                }, 
-                {"key": "id", "value": 98, "type": "cohort"},],
+                properties: [
+                  {
+                    key: 'region',
+                    operator: 'exact',
+                    value: ['USA'],
+                    type: 'person',
+                  },
+                  { key: 'id', value: 98, type: 'cohort' },
+                ],
                 rollout_percentage: 100,
               },
             ],
@@ -1206,23 +1208,23 @@ describe('local evaluation', () => {
         },
       ],
       cohorts: {
-        "98": {
-            "type": "OR",
-            "values": [
-                {"key": "id", "value": 1, "type": "cohort"},
-                {
-                    "key": "nation",
-                    "operator": "exact",
-                    "value": ["UK"],
-                    "type": "person",
-                },
-            ],
+        '98': {
+          type: 'OR',
+          values: [
+            { key: 'id', value: 1, type: 'cohort' },
+            {
+              key: 'nation',
+              operator: 'exact',
+              value: ['UK'],
+              type: 'person',
+            },
+          ],
         },
-        "1": {
-            "type": "AND",
-            "values": [{"key": "other", "operator": "exact", "value": ["thing"], "type": "person"}],
+        '1': {
+          type: 'AND',
+          values: [{ key: 'other', operator: 'exact', value: ['thing'], type: 'person' }],
         },
-    }
+      },
     }
     mockedFetch.mockImplementation(
       apiImplementation({
@@ -1236,16 +1238,25 @@ describe('local evaluation', () => {
       personalApiKey: 'TEST_PERSONAL_API_KEY',
     })
 
-    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "UK"}})).toEqual(false)
+    expect(
+      await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', { personProperties: { region: 'UK' } })
+    ).toEqual(false)
     expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
 
     // # even though 'other' property is not present, the cohort should still match since it's an OR condition
-    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "USA", nation: "UK"}})).toEqual(true)
+    expect(
+      await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {
+        personProperties: { region: 'USA', nation: 'UK' },
+      })
+    ).toEqual(true)
     expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
 
-    
     // # even though 'other' property is not present, the cohort should still match since it's an OR condition
-    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "USA", other: "thing"}})).toEqual(true)
+    expect(
+      await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {
+        personProperties: { region: 'USA', other: 'thing' },
+      })
+    ).toEqual(true)
     expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
   })
 
@@ -1262,13 +1273,15 @@ describe('local evaluation', () => {
           filters: {
             groups: [
               {
-                properties: [{
-                  "key": "region",
-                  "operator": "exact",
-                  "value": ["USA"],
-                  "type": "person",
-                }, 
-                {"key": "id", "value": 98, "type": "cohort"},],
+                properties: [
+                  {
+                    key: 'region',
+                    operator: 'exact',
+                    value: ['USA'],
+                    type: 'person',
+                  },
+                  { key: 'id', value: 98, type: 'cohort' },
+                ],
                 rollout_percentage: 100,
               },
             ],
@@ -1276,23 +1289,23 @@ describe('local evaluation', () => {
         },
       ],
       cohorts: {
-        "98": {
-            "type": "OR",
-            "values": [
-                {"key": "id", "value": 1, "type": "cohort"},
-                {
-                    "key": "nation",
-                    "operator": "exact",
-                    "value": ["UK"],
-                    "type": "person",
-                },
-            ],
+        '98': {
+          type: 'OR',
+          values: [
+            { key: 'id', value: 1, type: 'cohort' },
+            {
+              key: 'nation',
+              operator: 'exact',
+              value: ['UK'],
+              type: 'person',
+            },
+          ],
         },
-        "1": {
-            "type": "AND",
-            "values": [{"key": "other", "operator": "exact", "value": ["thing"], "type": "person", "negation": true}],
+        '1': {
+          type: 'AND',
+          values: [{ key: 'other', operator: 'exact', value: ['thing'], type: 'person', negation: true }],
         },
-    }
+      },
     }
     mockedFetch.mockImplementation(
       apiImplementation({
@@ -1306,23 +1319,35 @@ describe('local evaluation', () => {
       personalApiKey: 'TEST_PERSONAL_API_KEY',
     })
 
-    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "UK"}})).toEqual(false)
+    expect(
+      await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', { personProperties: { region: 'UK' } })
+    ).toEqual(false)
     expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
 
     // # even though 'other' property is not present, the cohort should still match since it's an OR condition
-    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "USA", nation: "UK"}})).toEqual(true)
+    expect(
+      await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {
+        personProperties: { region: 'USA', nation: 'UK' },
+      })
+    ).toEqual(true)
     expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
-    
+
     // # since 'other' is negated, we return False. Since 'nation' is not present, we can't tell whether the flag should be true or false, so go to decide
-    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "USA", other: "thing"}})).toEqual(false)
+    expect(
+      await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {
+        personProperties: { region: 'USA', other: 'thing' },
+      })
+    ).toEqual(false)
     expect(mockedFetch).toHaveBeenCalledWith(...anyDecideCall)
-    
+
     mockedFetch.mockClear()
 
-    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "USA", other: "thing2"}})).toEqual(true)
+    expect(
+      await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {
+        personProperties: { region: 'USA', other: 'thing2' },
+      })
+    ).toEqual(true)
     expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
-
-
   })
 
   it('gets feature flag with variant overrides', async () => {

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -38,7 +38,7 @@ export const apiImplementation = ({
       }) as any
     }
 
-    if ((url as any).includes('api/feature_flag/local_evaluation?token=TEST_API_KEY')) {
+    if ((url as any).includes('api/feature_flag/local_evaluation?token=TEST_API_KEY&send_cohorts')) {
       return Promise.resolve({
         status: 200,
         text: () => Promise.resolve('ok'),
@@ -58,7 +58,7 @@ export const apiImplementation = ({
 }
 
 export const anyLocalEvalCall = [
-  'http://example.com/api/feature_flag/local_evaluation?token=TEST_API_KEY',
+  'http://example.com/api/feature_flag/local_evaluation?token=TEST_API_KEY&send_cohorts',
   expect.any(Object),
 ]
 export const anyDecideCall = ['http://example.com/decide/?v=3', expect.any(Object)]
@@ -1177,6 +1177,152 @@ describe('local evaluation', () => {
 
     expect(await posthog.getAllFlags('distinct-id')).toEqual({ 'beta-feature': false, 'disabled-feature': true })
     expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
+  })
+
+  it('computes complex cohorts locally', async () => {
+    const flags = {
+      flags: [
+        {
+          id: 1,
+          name: 'Beta Feature',
+          key: 'beta-feature',
+          is_simple_flag: false,
+          active: true,
+          rollout_percentage: 100,
+          filters: {
+            groups: [
+              {
+                properties: [{
+                  "key": "region",
+                  "operator": "exact",
+                  "value": ["USA"],
+                  "type": "person",
+                }, 
+                {"key": "id", "value": 98, "type": "cohort"},],
+                rollout_percentage: 100,
+              },
+            ],
+          },
+        },
+      ],
+      cohorts: {
+        "98": {
+            "type": "OR",
+            "values": [
+                {"key": "id", "value": 1, "type": "cohort"},
+                {
+                    "key": "nation",
+                    "operator": "exact",
+                    "value": ["UK"],
+                    "type": "person",
+                },
+            ],
+        },
+        "1": {
+            "type": "AND",
+            "values": [{"key": "other", "operator": "exact", "value": ["thing"], "type": "person"}],
+        },
+    }
+    }
+    mockedFetch.mockImplementation(
+      apiImplementation({
+        localFlags: flags,
+        decideFlags: {},
+      })
+    )
+
+    posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      personalApiKey: 'TEST_PERSONAL_API_KEY',
+    })
+
+    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "UK"}})).toEqual(false)
+    expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
+
+    // # even though 'other' property is not present, the cohort should still match since it's an OR condition
+    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "USA", nation: "UK"}})).toEqual(true)
+    expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
+
+    
+    // # even though 'other' property is not present, the cohort should still match since it's an OR condition
+    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "USA", other: "thing"}})).toEqual(true)
+    expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
+  })
+
+  it('computes complex cohorts with negation locally', async () => {
+    const flags = {
+      flags: [
+        {
+          id: 1,
+          name: 'Beta Feature',
+          key: 'beta-feature',
+          is_simple_flag: false,
+          active: true,
+          rollout_percentage: 100,
+          filters: {
+            groups: [
+              {
+                properties: [{
+                  "key": "region",
+                  "operator": "exact",
+                  "value": ["USA"],
+                  "type": "person",
+                }, 
+                {"key": "id", "value": 98, "type": "cohort"},],
+                rollout_percentage: 100,
+              },
+            ],
+          },
+        },
+      ],
+      cohorts: {
+        "98": {
+            "type": "OR",
+            "values": [
+                {"key": "id", "value": 1, "type": "cohort"},
+                {
+                    "key": "nation",
+                    "operator": "exact",
+                    "value": ["UK"],
+                    "type": "person",
+                },
+            ],
+        },
+        "1": {
+            "type": "AND",
+            "values": [{"key": "other", "operator": "exact", "value": ["thing"], "type": "person", "negation": true}],
+        },
+    }
+    }
+    mockedFetch.mockImplementation(
+      apiImplementation({
+        localFlags: flags,
+        decideFlags: {},
+      })
+    )
+
+    posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      personalApiKey: 'TEST_PERSONAL_API_KEY',
+    })
+
+    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "UK"}})).toEqual(false)
+    expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
+
+    // # even though 'other' property is not present, the cohort should still match since it's an OR condition
+    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "USA", nation: "UK"}})).toEqual(true)
+    expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
+    
+    // # since 'other' is negated, we return False. Since 'nation' is not present, we can't tell whether the flag should be true or false, so go to decide
+    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "USA", other: "thing"}})).toEqual(false)
+    expect(mockedFetch).toHaveBeenCalledWith(...anyDecideCall)
+    
+    mockedFetch.mockClear()
+
+    expect(await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {personProperties: {region: "USA", other: "thing2"}})).toEqual(true)
+    expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
+
+
   })
 
   it('gets feature flag with variant overrides', async () => {


### PR DESCRIPTION
## Problem

Part of https://github.com/PostHog/meta/pull/90

Enables locally evaluating all cohorts.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
