### PR TITLE
feat: allow API host as config option

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -24,6 +24,20 @@ export * as utils from './utils'
 import { LZString } from './lz-string'
 import { SimpleEventEmitter } from './eventemitter'
 
+function hostFromOptions(options: PosthogCoreOptions | undefined): string | undefined {
+  if (!options) {
+    return undefined
+  }
+
+  if ('host' in options) {
+    return options.host
+  } else if ('api_host' in options) {
+    return options.api_host
+  } else {
+    return undefined
+  }
+}
+
 export abstract class PostHogCoreStateless {
   // options
   private apiKey: string
@@ -57,7 +71,7 @@ export abstract class PostHogCoreStateless {
     assert(apiKey, "You must pass your PostHog project's api key.")
 
     this.apiKey = apiKey
-    this.host = removeTrailingSlash(options?.host || 'https://app.posthog.com')
+    this.host = removeTrailingSlash(hostFromOptions(options) || 'https://app.posthog.com')
     this.flushAt = options?.flushAt ? Math.max(options?.flushAt, 1) : 20
     this.flushInterval = options?.flushInterval ?? 10000
     this.captureMode = options?.captureMode || 'form'

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -1,6 +1,4 @@
-export type PosthogCoreOptions = {
-  // PostHog API host (https://app.posthog.com by default)
-  host?: string
+type PosthogCommonOptions = {
   // The number of events to queue before sending to Posthog (flushing)
   flushAt?: number
   // The interval in milliseconds between periodic flushes
@@ -29,6 +27,25 @@ export type PosthogCoreOptions = {
   // Whether to post events to PostHog in JSON or compressed format
   captureMode?: 'json' | 'form'
 }
+
+export type PosthogOptionsWithHost = PosthogCommonOptions & {
+  // PostHog API host (https://app.posthog.com by default)
+  host: string
+  api_host?: never
+}
+
+export type PosthogOptionsWithAPIHost = PosthogCommonOptions & {
+  // Alternative name for PostHog API host to mirror posthog-js options
+  api_host: string
+  host?: never
+}
+
+export type PosthogOptionsWithDefaultHost = PosthogCommonOptions & {
+  host?: never
+  api_host?: never
+}
+
+export type PosthogCoreOptions = PosthogOptionsWithHost | PosthogOptionsWithAPIHost | PosthogOptionsWithDefaultHost
 
 export enum PostHogPersistedProperty {
   AnonymousId = 'anonymous_id',

--- a/posthog-core/test/posthog.init.spec.ts
+++ b/posthog-core/test/posthog.init.spec.ts
@@ -44,6 +44,21 @@ describe('PostHog Core', () => {
       })
     })
 
+    it('can use api_host instead of host in options', () => {
+      ;[posthog, mocks] = createTestClient('key', {
+        api_host: 'https://a.com',
+        flushAt: 1,
+        flushInterval: 2,
+      })
+
+      expect(posthog).toMatchObject({
+        apiKey: 'key',
+        host: 'https://a.com',
+        flushAt: 1,
+        flushInterval: 2,
+      })
+    })
+
     it('should keep the flushAt option above zero', () => {
       ;[posthog, mocks] = createTestClient('key', { flushAt: -2 }) as any
       expect((posthog as any).flushAt).toEqual(1)


### PR DESCRIPTION
## Problem

In this community slack thread, the user points out we have confusingly similar init options https://posthogusers.slack.com/archives/CTLTM70RM/p1679968951879879

```
//(Basic) Initialization of posthog-js:
const posthog = new PostHog(env.POSTHOG_KEY, {
    api_host: env.POSTHOG_HOST
});
//(Basic) Initialization of posthog-node:
const posthog = new PostHog(env.POSTHOG_KEY, {
    host: env.POSTHOG_HOST
});
```

Note one is `host` and the other `api_host`

## Changes

Allows you to init posthog-node (and other libraries that use posthog-core) with **either** `host` or `api_host`

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for initialising using either `host` or `api_host` as the key to config the posthog URL for the library
