### PR TITLE
Improve error handling and make fetch error handling behave like fetch

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
   globals: {
     'ts-jest': {
       tsconfig: {
-        lib: ['ES2015', 'DOM'], // We need to include DOM for tests
+        lib: ['ES2015', 'ES2022.Error', 'DOM'], // We need to include DOM for tests
       },
     },
   },

--- a/posthog-core/src/utils.ts
+++ b/posthog-core/src/utils.ts
@@ -11,7 +11,7 @@ export function removeTrailingSlash(url: string): string {
 export interface RetriableOptions {
   retryCount?: number
   retryDelay?: number
-  retryCheck?: (err: any) => true
+  retryCheck?: (err: any) => boolean
 }
 
 export async function retriable<T>(fn: () => Promise<T>, props: RetriableOptions = {}): Promise<T> {
@@ -19,6 +19,11 @@ export async function retriable<T>(fn: () => Promise<T>, props: RetriableOptions
   let lastError = null
 
   for (let i = 0; i < retryCount + 1; i++) {
+    if (i > 0) {
+      // don't wait when it's the last try
+      await new Promise((r) => setTimeout(r, retryDelay))
+    }
+    
     try {
       const res = await fn()
       return res
@@ -28,8 +33,6 @@ export async function retriable<T>(fn: () => Promise<T>, props: RetriableOptions
         throw e
       }
     }
-
-    await new Promise((r) => setTimeout(r, retryDelay))
   }
 
   throw lastError

--- a/posthog-core/src/utils.ts
+++ b/posthog-core/src/utils.ts
@@ -23,7 +23,7 @@ export async function retriable<T>(fn: () => Promise<T>, props: RetriableOptions
       // don't wait when it's the last try
       await new Promise((r) => setTimeout(r, retryDelay))
     }
-    
+
     try {
       const res = await fn()
       return res

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -425,7 +425,7 @@ class FeatureFlagsPoller {
     try {
       return await this.fetch(url, options)
     } catch (err) {
-      throw new Error(`Request failed with error: ${err}`)
+      throw err
     } finally {
       clearTimeout(abortTimeout)
     }

--- a/posthog-node/src/fetch.ts
+++ b/posthog-node/src/fetch.ts
@@ -10,11 +10,13 @@ export const fetch = async (url: string, options: PostHogFetchOptions): Promise<
     method: options.method.toLowerCase(),
     data: options.body,
     signal: options.signal,
+    // fetch only throws on network errors, not on HTTP errors
+    validateStatus: () => true,
   })
 
   return {
     status: res.status,
-    text: () => res.data,
-    json: () => res.data,
+    text: async () => res.data,
+    json: async () => res.data,
   }
 }

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -1,6 +1,6 @@
-// import { PostHog } from '../'
+// import { PostHog, PostHogOptions } from '../'
 // Uncomment below line while developing to not compile code everytime
-import { PostHog as PostHog } from '../src/posthog-node'
+import { PostHog as PostHog, PostHogOptions } from '../src/posthog-node'
 import { matchProperty, InconclusiveMatchError } from '../src/feature-flags'
 jest.mock('../src/fetch')
 import { fetch } from '../src/fetch'
@@ -8,6 +8,10 @@ import { fetch } from '../src/fetch'
 jest.spyOn(global.console, 'debug').mockImplementation()
 
 const mockedFetch = jest.mocked(fetch, true)
+
+const posthogImmediateResolveOptions: PostHogOptions = {
+  fetchRetryCount: 0,
+}
 
 export const apiImplementation = ({
   localFlags,
@@ -105,6 +109,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(
@@ -151,6 +156,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     // # groups not passed in, hence false
@@ -231,6 +237,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
     // # group_type_mappings not present, so fallback to `/decide`
     expect(
@@ -304,6 +311,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(
@@ -426,6 +434,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     // # beta-feature fallbacks to decide because property type is unknown
@@ -488,6 +497,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     // # beta-feature should fallback to decide because property type is unknown
@@ -536,6 +546,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     // # beta-feature resolves to False
@@ -576,12 +587,20 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
+    })
+
+    let err: any = null
+    posthog.on('error', (e) => {
+      err = e
     })
 
     // # beta-feature2 falls back to decide, which on error returns undefined
     expect(await posthog.getFeatureFlag('beta-feature2', 'some-distinct-id')).toEqual(undefined)
     expect(await posthog.isFeatureEnabled('beta-feature2', 'some-distinct-id')).toEqual(undefined)
     expect(mockedFetch).toHaveBeenCalledWith(...anyDecideCall)
+    await posthog.shutdownAsync()
+    expect(err).toHaveProperty('name', 'PostHogFetchHttpError')
   })
 
   it('experience continuity flags are not evaluated locally', async () => {
@@ -612,6 +631,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     // # beta-feature2 falls back to decide, which on error returns default
@@ -680,6 +700,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     // # beta-feature value overridden by /decide
@@ -763,6 +784,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     // # beta-feature value overridden by /decide
@@ -835,6 +857,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     // # beta-feature2 has no value
@@ -916,6 +939,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(
@@ -940,6 +964,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(await posthog.getAllFlags('distinct-id')).toEqual({
@@ -965,6 +990,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect((await posthog.getAllFlagsAndPayloads('distinct-id')).featureFlagPayloads).toEqual({
@@ -1021,6 +1047,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(await posthog.getAllFlags('distinct-id')).toEqual({ 'beta-feature': true, 'disabled-feature': false })
@@ -1079,6 +1106,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect((await posthog.getAllFlagsAndPayloads('distinct-id')).featureFlagPayloads).toEqual({ 'beta-feature': 'new' })
@@ -1131,6 +1159,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(await posthog.getAllFlags('distinct-id')).toEqual({ 'beta-feature': true, 'disabled-feature': false })
@@ -1238,6 +1267,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(
@@ -1319,6 +1349,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(
@@ -1408,6 +1439,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(
@@ -1489,6 +1521,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(
@@ -1560,6 +1593,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(
@@ -1632,6 +1666,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(
@@ -1682,6 +1717,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(
@@ -1762,6 +1798,7 @@ describe('local evaluation', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     expect(
@@ -1990,10 +2027,6 @@ describe('consistency tests', () => {
   let posthog: PostHog
   jest.useFakeTimers()
 
-  afterEach(async () => {
-    await posthog.shutdownAsync()
-  })
-
   it('is consistent for simple flags', () => {
     const flags = {
       flags: [
@@ -2015,6 +2048,7 @@ describe('consistency tests', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     const results = [
@@ -3057,6 +3091,7 @@ describe('consistency tests', () => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       personalApiKey: 'TEST_PERSONAL_API_KEY',
+      ...posthogImmediateResolveOptions,
     })
 
     const results = [

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -28,6 +28,7 @@ describe('PostHog Node.js', () => {
   beforeEach(() => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
+      fetchRetryCount: 0,
     })
 
     mockedFetch.mockResolvedValue({
@@ -266,8 +267,7 @@ describe('PostHog Node.js', () => {
       // a serverless posthog configuration
       posthog = new PostHog('TEST_API_KEY', {
         host: 'http://example.com',
-        flushAt: 1,
-        flushInterval: 0,
+        fetchRetryCount: 0,
       })
 
       mockedFetch.mockImplementation(async () => {
@@ -290,6 +290,12 @@ describe('PostHog Node.js', () => {
     })
 
     it('should shutdown cleanly', async () => {
+      posthog = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        fetchRetryCount: 0,
+        flushAt: 1,
+      })
+
       const logSpy = jest.spyOn(global.console, 'log')
       jest.useRealTimers()
       // using debug mode to check console.log output
@@ -319,9 +325,10 @@ describe('PostHog Node.js', () => {
   })
 
   describe('groupIdentify', () => {
-    it('should identify group with unique id', () => {
+    it('should identify group with unique id', async () => {
       posthog.groupIdentify({ groupType: 'posthog', groupKey: 'team-1', properties: { analytics: true } })
       jest.runOnlyPendingTimers()
+      await posthog.flushAsync()
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toMatchObject([
         {
@@ -338,7 +345,7 @@ describe('PostHog Node.js', () => {
       ])
     })
 
-    it('should allow passing optional distinctID to identify group', () => {
+    it('should allow passing optional distinctID to identify group', async () => {
       posthog.groupIdentify({
         groupType: 'posthog',
         groupKey: 'team-1',
@@ -346,6 +353,7 @@ describe('PostHog Node.js', () => {
         distinctId: '123',
       })
       jest.runOnlyPendingTimers()
+      await posthog.flushAsync()
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toMatchObject([
         {
@@ -383,6 +391,7 @@ describe('PostHog Node.js', () => {
 
       posthog = new PostHog('TEST_API_KEY', {
         host: 'http://example.com',
+        fetchRetryCount: 0,
       })
     })
 
@@ -413,6 +422,7 @@ describe('PostHog Node.js', () => {
       posthog = new PostHog('TEST_API_KEY', {
         host: 'http://example.com',
         flushAt: 1,
+        fetchRetryCount: 0,
       })
 
       posthog.capture({
@@ -463,6 +473,7 @@ describe('PostHog Node.js', () => {
       posthog = new PostHog('TEST_API_KEY', {
         host: 'http://example.com',
         flushAt: 1,
+        fetchRetryCount: 0,
       })
 
       posthog.capture({
@@ -523,6 +534,7 @@ describe('PostHog Node.js', () => {
         host: 'http://example.com',
         personalApiKey: 'TEST_PERSONAL_API_KEY',
         maxCacheSize: 10,
+        fetchRetryCount: 0,
       })
 
       expect(Object.keys(posthog.distinctIdHasSentFlagCalls).length).toEqual(0)
@@ -581,6 +593,7 @@ describe('PostHog Node.js', () => {
         host: 'http://example.com',
         personalApiKey: 'TEST_PERSONAL_API_KEY',
         maxCacheSize: 10,
+        fetchRetryCount: 0,
       })
 
       expect(

--- a/posthog-web/tsconfig.json
+++ b/posthog-web/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "lib": ["DOM"]
+    "lib": ["DOM", "ES2015", "ES2022.Error"]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "strict": true,
     "baseUrl": "./", // this must be specified if "paths" is specified.
     "rootDir": "./",
-    "lib": ["ES2015"],
+    "lib": ["ES2015", "ES2022.Error"],
     "types": ["node", "jest"],
     "jsx": "react"
   },


### PR DESCRIPTION
## Problem

- Axios throws on HTTP errors (non-2xx), fetch does not
- There's no way to listen for PostHog errors
- `shutdownAsync` throws when the associated flush throws, but the flush interval ignores errors
- `retriable` delays even if everything succeeded

## Changes

- I added `validateStatus: () => true` to Axios. This makes sure Axios doesn't throw any HTTP errors.
- I added two errors: PostHogFetchHttpError (non-2xx status) and PostHogFetchNetworkError (fetch network error)
- I added `.on('error', (err) => void)` to the API
- I made shutdownAsync ignore fetch errors. They should be handled with `.on('error', ...)` from now on.
- I fixed `retriable` by only delaying when multiple tries are needed

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Fixed fetch compatibility by aligning error handling
- Added two errors: PostHogFetchHttpError (non-2xx status) and PostHogFetchNetworkError (fetch network error)
- Added `.on('error', (err) => void)`
- `shutdownAsync` now ignores fetch errors. They should be handled with `.on('error', ...)` from now on.