### PR TITLE
Updated changelogs and versions

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.1.0 - 2023-04-19
+
+1. Some small fixes to incorrect types
+2. Improved error handling logic to ensure that API errors are handled the same regardless of underlying fetch mechanism.
+
 # 3.0.0 - 2023-04-14
 
 Breaking change:
@@ -12,7 +17,7 @@ To restore previous behaviour, you can set the default to False like so:
 ```javascript
 const posthog = new PostHog(PH_API_KEY, {
   host: PH_HOST,
-  disableGeoip: false
+  disableGeoip: false,
 })
 ```
 
@@ -23,10 +28,12 @@ const posthog = new PostHog(PH_API_KEY, {
 # 2.5.4 - 2023-02-27
 
 1. Fix error log for local evaluation of feature flags (InconclusiveMatchError(s)) to only show during debug mode.
+
 # 2.5.3 - 2023-02-21
 
 1. Allow passing in a distinctId to `groupIdentify()`.
 2. Fix a bug with active feature flags on capture events, where non-active flags would be added to the list as well.
+
 # 2.5.2 - 2023-02-17
 
 1. Fix issue where properties passed to `.identify` were not set correctly

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,7 +1,10 @@
 # 3.1.0 - 2023-04-19
 
 1. Some small fixes to incorrect types
-2. Improved error handling logic to ensure that API errors are handled the same regardless of underlying fetch mechanism.
+2. Fixed fetch compatibility by aligning error handling
+3. Added two errors: PostHogFetchHttpError (non-2xx status) and PostHogFetchNetworkError (fetch network error)
+4. Added .on('error', (err) => void)
+5. shutdownAsync now ignores fetch errors. They should be handled with .on('error', ...) from now on.
 
 # 3.0.0 - 2023-04-14
 

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "PostHog Node.js integration",
   "repository": "PostHog/posthog-node",
   "scripts": {

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.6.0 - 2023-04-19
+
+1. Some small fixes to incorrect types
+2. Improved error handling logic to ensure that API errors are handled the same regardless of underlying fetch mechanism.
+
 # 2.5.2 - 2023-02-13
 
 1. Fixes an issue where background network errors would trigger unhandled promise warnings

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,7 +1,10 @@
 # 2.6.0 - 2023-04-19
 
 1. Some small fixes to incorrect types
-2. Improved error handling logic to ensure that API errors are handled the same regardless of underlying fetch mechanism.
+2. Fixed fetch compatibility by aligning error handling
+3. Added two errors: PostHogFetchHttpError (non-2xx status) and PostHogFetchNetworkError (fetch network error)
+4. Added .on('error', (err) => void)
+5. shutdownAsync now ignores fetch errors. They should be handled with .on('error', ...) from now on.
 
 # 2.5.2 - 2023-02-13
 

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.3.0 - 2023-04-19
+
+1. Some small fixes to incorrect types
+2. Improved error handling logic to ensure that API errors are handled the same regardless of underlying fetch mechanism.
+
 # 2.2.1 - 2023-02-13
 
 1. Fixes an issue where background network errors would trigger unhandled promise warnings

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,7 +1,10 @@
 # 2.3.0 - 2023-04-19
 
 1. Some small fixes to incorrect types
-2. Improved error handling logic to ensure that API errors are handled the same regardless of underlying fetch mechanism.
+2. Fixed fetch compatibility by aligning error handling
+3. Added two errors: PostHogFetchHttpError (non-2xx status) and PostHogFetchNetworkError (fetch network error)
+4. Added .on('error', (err) => void)
+5. shutdownAsync now ignores fetch errors. They should be handled with .on('error', ...) from now on.
 
 # 2.2.1 - 2023-02-13
 

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-js-lite",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION

## Changes

Updates versions after [this PR](https://github.com/PostHog/posthog-js-lite/pull/88)

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native
