### PR TITLE
fix: Race conditions when initialising the RN SDK

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -587,10 +587,6 @@ export abstract class PostHogCore extends PostHogCoreStateless {
 
     this.sendFeatureFlagEvent = options?.sendFeatureFlagEvent ?? true
     this._sessionExpirationTimeSeconds = options?.sessionExpirationTimeSeconds ?? 1800 // 30 minutes
-
-    if (options?.preloadFeatureFlags !== false) {
-      this.reloadFeatureFlags()
-    }
   }
 
   protected setupBootstrap(options?: Partial<PosthogCoreOptions>): void {
@@ -740,9 +736,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
       this.setPersistedProperty(PostHogPersistedProperty.AnonymousId, previousDistinctId)
       this.setPersistedProperty(PostHogPersistedProperty.DistinctId, distinctId)
 
-      if (this.getFeatureFlags()) {
-        this.reloadFeatureFlags()
-      }
+      this.reloadFeatureFlags()
     }
 
     super.identifyStateless(distinctId, allProperties, options)
@@ -809,7 +803,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
       },
     })
 
-    if (Object.keys(groups).find((type) => existingGroups[type] !== groups[type]) && this.getFeatureFlags()) {
+    if (Object.keys(groups).find((type) => existingGroups[type] !== groups[type])) {
       this.reloadFeatureFlags()
     }
 

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -556,7 +556,13 @@ export abstract class PostHogCoreStateless {
     clearTimeout(this._flushTimer)
     try {
       await this.flushAsync()
-      await Promise.all(Object.values(this.pendingPromises))
+      await Promise.all(
+        Object.values(this.pendingPromises).map((x) =>
+          x.catch(() => {
+            // ignore errors as we are shutting down and can't deal with them anyways.
+          })
+        )
+      )
     } catch (e) {
       if (!isPostHogFetchError(e)) {
         throw e

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -588,11 +588,8 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     this.sendFeatureFlagEvent = options?.sendFeatureFlagEvent ?? true
     this._sessionExpirationTimeSeconds = options?.sessionExpirationTimeSeconds ?? 1800 // 30 minutes
 
-    // NOTE: It is important we don't initiate anything in the constructor as some async IO may still be underway on the parent
     if (options?.preloadFeatureFlags !== false) {
-      safeSetTimeout(() => {
-        this.reloadFeatureFlags()
-      }, 1)
+      this.reloadFeatureFlags()
     }
   }
 

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -556,7 +556,7 @@ export abstract class PostHogCoreStateless {
     clearTimeout(this._flushTimer)
     try {
       await this.flushAsync()
-      await Promise.allSettled(Object.values(this.pendingPromises))
+      await Promise.all(Object.values(this.pendingPromises))
     } catch (e) {
       if (!isPostHogFetchError(e)) {
         throw e

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -16,6 +16,7 @@ describe('PostHog Core', () => {
     'json-payload': true,
   })
 
+  // NOTE: Aren't these supposed to be strings?
   const createMockFeatureFlagPayloads = (): any => ({
     'feature-1': {
       color: 'blue',
@@ -99,42 +100,8 @@ describe('PostHog Core', () => {
 
     describe('when loaded', () => {
       beforeEach(() => {
-        jest.runOnlyPendingTimers() // trigger init setImmediate
-      })
-
-      it('should load feature flags on init', async () => {
-        expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
-          body: JSON.stringify({
-            token: 'TEST_API_KEY',
-            distinct_id: posthog.getDistinctId(),
-            groups: {},
-            person_properties: {},
-            group_properties: {},
-            $anon_distinct_id: posthog.getAnonymousId(),
-          }),
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          signal: expect.anything(),
-        })
-
-        expect(posthog.getFeatureFlags()).toEqual({
-          'feature-1': true,
-          'feature-2': true,
-          'json-payload': true,
-          'feature-variant': 'variant',
-        })
-
-        expect(posthog.getFeatureFlagPayloads()).toEqual({
-          'feature-1': {
-            color: 'blue',
-          },
-          'json-payload': {
-            a: 'payload',
-          },
-          'feature-variant': 5,
-        })
+        // The core doesn't reload flags by default (this is handled differently by web and RN)
+        posthog.reloadFeatureFlags()
       })
 
       it('should return the value of a flag', async () => {
@@ -171,7 +138,7 @@ describe('PostHog Core', () => {
             })
           })
 
-          jest.runOnlyPendingTimers() // trigger init setImmediate
+          posthog.reloadFeatureFlags()
         })
 
         it('should return undefined', async () => {
@@ -241,7 +208,7 @@ describe('PostHog Core', () => {
               })
           })
 
-          jest.runOnlyPendingTimers() // trigger init setImmediate
+          posthog.reloadFeatureFlags()
         })
 
         it('should return combined results', async () => {
@@ -344,7 +311,7 @@ describe('PostHog Core', () => {
               })
           })
 
-          jest.runOnlyPendingTimers() // trigger init setImmediate
+          posthog.reloadFeatureFlags()
         })
 
         it('should return only latest results', async () => {
@@ -557,7 +524,7 @@ describe('PostHog Core', () => {
 
     describe('when loaded', () => {
       beforeEach(() => {
-        jest.runOnlyPendingTimers() // trigger init setImmediate
+        posthog.reloadFeatureFlags()
       })
 
       it('should load new feature flags', async () => {

--- a/posthog-core/test/posthog.groups.spec.ts
+++ b/posthog-core/test/posthog.groups.spec.ts
@@ -41,7 +41,8 @@ describe('PostHog Core', () => {
     it('should call groupIdentify if including props', () => {
       posthog.group('other', 'team', { foo: 'bar' })
 
-      expect(parseBody(mocks.fetch.mock.calls[0])).toMatchObject({
+      expect(mocks.fetch).toHaveBeenCalledTimes(2) // 1 for decide, 1 for groupIdentify
+      expect(parseBody(mocks.fetch.mock.calls[1])).toMatchObject({
         batch: [
           {
             event: '$groupidentify',

--- a/posthog-core/test/posthog.identify.spec.ts
+++ b/posthog-core/test/posthog.identify.spec.ts
@@ -14,11 +14,12 @@ describe('PostHog Core', () => {
   })
 
   describe('identify', () => {
+    // Identify also triggers a decide call so we should expect 2 calls
     it('should send an $identify event', () => {
       posthog.identify('id-1', { foo: 'bar' })
 
-      expect(mocks.fetch).toHaveBeenCalledTimes(1)
-      expect(parseBody(mocks.fetch.mock.calls[0])).toEqual({
+      expect(mocks.fetch).toHaveBeenCalledTimes(2)
+      expect(parseBody(mocks.fetch.mock.calls[1])).toEqual({
         api_key: 'TEST_API_KEY',
         batch: [
           {
@@ -47,8 +48,8 @@ describe('PostHog Core', () => {
     it('should include anonymous ID if set', () => {
       posthog.identify('id-1', { foo: 'bar' })
 
-      expect(mocks.fetch).toHaveBeenCalledTimes(1)
-      expect(parseBody(mocks.fetch.mock.calls[0])).toMatchObject({
+      expect(mocks.fetch).toHaveBeenCalledTimes(2)
+      expect(parseBody(mocks.fetch.mock.calls[1])).toMatchObject({
         batch: [
           {
             distinct_id: posthog.getDistinctId(),
@@ -74,8 +75,8 @@ describe('PostHog Core', () => {
       posthog.identify('id-1', { foo: 'bar' })
       // One call exists for the queueing, one for persisting distinct id
       expect(mocks.storage.setItem).toHaveBeenCalledWith('distinct_id', 'id-1')
-      expect(mocks.fetch).toHaveBeenCalledTimes(1)
-      expect(parseBody(mocks.fetch.mock.calls[0])).toMatchObject({
+      expect(mocks.fetch).toHaveBeenCalledTimes(2) // Once for reload flags, once for identify
+      expect(parseBody(mocks.fetch.mock.calls[1])).toMatchObject({
         batch: [
           {
             distinct_id: 'id-1',

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -210,7 +210,6 @@ describe('PostHog Node.js', () => {
         host: 'http://example.com',
         disableGeoip: false,
       })
-      client.debug()
       client.capture({ distinctId: '123', event: 'test-event', properties: { foo: 'bar' }, groups: { org: 123 } })
 
       jest.runOnlyPendingTimers()
@@ -296,7 +295,7 @@ describe('PostHog Node.js', () => {
         flushAt: 1,
       })
 
-      const logSpy = jest.spyOn(global.console, 'log')
+      const logSpy = jest.spyOn(global.console, 'log').mockImplementation(() => {})
       jest.useRealTimers()
       // using debug mode to check console.log output
       // which tells us when the flush is complete

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.7.0 - 2023-04-20
+
+1. Fixes a race condition that could occur when initialising PostHog
+2. Fixes an issue where feature flags would not be reloaded after a reset
+3. PostHog should always be initialized via .initAsync and will now warn if this is not the case
+
 # 2.6.0 - 2023-04-19
 
 1. Some small fixes to incorrect types

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/test/init.spec.ts
+++ b/posthog-react-native/test/init.spec.ts
@@ -8,6 +8,20 @@ describe('PostHog React Native', () => {
   jest.useRealTimers()
 
   beforeEach(() => {
+    ;(global as any).window.fetch = jest.fn(async (url) => {
+      let res: any = { status: 'ok' }
+      if (url.includes('decide')) {
+        res = {
+          featureFlags: {},
+        }
+      }
+
+      return {
+        status: 200,
+        json: () => Promise.resolve(res),
+      }
+    })
+
     cache = {}
     mockStorage = {
       getItem: async (key) => {

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.4.0 - 2023-04-20
+
+1. Fixes a race condition that could occur when initialising PostHog
+2. Fixes an issue where feature flags would not be reloaded after a reset
+
 # 2.3.0 - 2023-04-19
 
 1. Some small fixes to incorrect types

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-js-lite",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",

--- a/posthog-web/src/posthog-web.ts
+++ b/posthog-web/src/posthog-web.ts
@@ -21,6 +21,10 @@ export class PostHog extends PostHogCore {
     this._storageKey = options?.persistence_name ? `ph_${options.persistence_name}` : `ph_${apiKey}_posthog`
     this._storage = getStorage(options?.persistence || 'localStorage', window)
     this.setupBootstrap(options)
+
+    if (options?.preloadFeatureFlags !== false) {
+      this.reloadFeatureFlags()
+    }
   }
 
   getPersistedProperty<T>(key: PostHogPersistedProperty): T | undefined {

--- a/posthog-web/test/posthog-web.spec.ts
+++ b/posthog-web/test/posthog-web.spec.ts
@@ -6,27 +6,89 @@ import { PostHog } from '..'
 
 describe('PosthogWeb', () => {
   let fetch: jest.Mock
-  jest.useFakeTimers()
+  jest.useRealTimers()
 
   beforeEach(() => {
-    ;(global as any).window.fetch = fetch = jest.fn(() =>
-      Promise.resolve({
+    ;(global as any).window.fetch = fetch = jest.fn(async (url) => {
+      let res: any = { status: 'ok' }
+      if (url.includes('decide')) {
+        res = {
+          featureFlags: {
+            'feature-1': true,
+            'feature-2': true,
+            'json-payload': true,
+            'feature-variant': 'variant',
+          },
+          // NOTE: Aren't these supposed to be strings?
+
+          featureFlagPayloads: {
+            'feature-1': {
+              color: 'blue',
+            },
+            'json-payload': {
+              a: 'payload',
+            },
+            'feature-variant': 5,
+          },
+        }
+      }
+
+      return {
         status: 200,
-        json: () => Promise.resolve({ status: 'ok' }),
-      })
-    ) as any
+        json: () => Promise.resolve(res),
+      }
+    })
   })
 
   describe('init', () => {
     it('should initialise', () => {
-      const postHog = new PostHog('TEST_API_KEY', {
+      const posthog = new PostHog('TEST_API_KEY', {
         flushAt: 1,
       })
-      expect(postHog.optedOut).toEqual(false)
+      expect(posthog.optedOut).toEqual(false)
 
-      postHog.capture('test')
+      posthog.capture('test')
 
-      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should load feature flags on init', async () => {
+      const posthog = new PostHog('TEST_API_KEY', {
+        flushAt: 1,
+      })
+
+      expect(fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+        body: JSON.stringify({
+          token: 'TEST_API_KEY',
+          distinct_id: posthog.getDistinctId(),
+          groups: {},
+          person_properties: {},
+          group_properties: {},
+          $anon_distinct_id: posthog.getAnonymousId(),
+        }),
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        signal: expect.anything(),
+      })
+
+      expect(posthog.getFeatureFlags()).toEqual({
+        'feature-1': true,
+        'feature-2': true,
+        'json-payload': true,
+        'feature-variant': 'variant',
+      })
+
+      expect(posthog.getFeatureFlagPayloads()).toEqual({
+        'feature-1': {
+          color: 'blue',
+        },
+        'json-payload': {
+          a: 'payload',
+        },
+        'feature-variant': 5,
+      })
     })
   })
 })


### PR DESCRIPTION
## Problem

Customer noticed that there seemed to be some ID issues despite using `PostHog.initAsync`. Investigated and found that the issue is happening as we don't wait for the async storage to be loaded _before_ we init PostHog and in turn call the reload.

## Changes

* Changes `.initAsync` to warn if the SDK has already been initialised
* Moves the preload await to _before_ instantiating PostHog which ensures the correct IDs are loaded
* Handles the preloading of FF in the RN constructor to ensure we definitely don't accidentally load too early

- [x] TODO: Fix the reset logic so that we reload flags on subsequent identify

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-web
- [ ] posthog-node
- [x] posthog-react-native

### Changelog notes

- Fixes a race condition that could occur when initialising PostHog
- Fixes an issue where feature flags would not be reloaded after a reset
- (RN): PostHog should always be initialized via `.initAsync` and will now warn if this is not the case.
