### PR TITLE
Add pure JS sha1 library

### DIFF
--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -19,7 +19,8 @@
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",
   "dependencies": {
-    "axios": "^0.27.0"
+    "axios": "^0.27.0",
+    "rusha": "^0.8.14"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto'
+import { createHash } from 'rusha'
 import { FeatureFlagCondition, FlagProperty, PostHogFeatureFlag, PropertyGroup } from './types'
 import { version } from '../package.json'
 import { JsonType, PostHogFetchOptions, PostHogFetchResponse } from 'posthog-core/src'
@@ -441,7 +441,8 @@ class FeatureFlagsPoller {
 // # uniformly distributed between 0 and 1, so if we want to show this feature to 20% of traffic
 // # we can do _hash(key, distinct_id) < 0.2
 function _hash(key: string, distinctId: string, salt: string = ''): number {
-  const sha1Hash = createHash('sha1')
+  // rusha is a fast sha1 implementation in pure javascript
+  const sha1Hash = createHash()
   sha1Hash.update(`${key}.${distinctId}${salt}`)
   return parseInt(sha1Hash.digest('hex').slice(0, 15), 16) / LONG_SCALE
 }

--- a/posthog-node/src/types/rusha.d.ts
+++ b/posthog-node/src/types/rusha.d.ts
@@ -1,0 +1,23 @@
+// Adjusted from type definitions for rusha 0.8
+// Project: https://github.com/srijs/rusha#readme
+// Definitions by: Jacopo Scazzosi <https://github.com/jacoscaz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 4.0
+
+/// <reference types="node" />
+
+interface Hash {
+  update(value: string | number[] | ArrayBuffer | Buffer): Hash
+  digest(encoding?: undefined): ArrayBuffer
+  digest(encoding: 'hex'): string
+}
+
+interface Rusha {
+  createHash(): Hash
+}
+
+declare const Rusha: Rusha
+
+declare module 'rusha' {
+  export = Rusha
+}

--- a/posthog-node/tsconfig.json
+++ b/posthog-node/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node", "rusha"],
+    "typeRoots": ["./node_modules/@types", "../node_modules/@types", "./src/types"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8529,6 +8529,11 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+rusha@^0.8.14:
+  version "0.8.14"
+  resolved "https://registry.yarnpkg.com/rusha/-/rusha-0.8.14.tgz#a977d0de9428406138b7bb90d3de5dcd024e2f68"
+  integrity sha512-cLgakCUf6PedEu15t8kbsjnwIFFR2D4RfL+W3iWFJ4iac7z4B0ZI8fxy4R3J956kAI68HclCFGL8MPoUVC3qVA==
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"


### PR DESCRIPTION
## Problem

Replaces `crypto.createHash` with `rusha.createHash`, which is pure JS and thus compatible with Cloudflare Workers, and also making it work in the Next.js edge runtime.

I also checked that `crypto.createHash` and `rusha.createHash` create the same output.

Fixes #67

## Changes

I added `rusha` from https://github.com/srijs/rusha

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Replace sha1 library with pure JS implementation
