### PR TITLE
feat: Save the $screen_name on every event

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -619,7 +619,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
   }
 
   // NOTE: Props are lazy loaded from localstorage hence the complex getter setter logic
-  private get props(): PostHogEventProperties {
+  public get props(): PostHogEventProperties {
     if (!this._props) {
       this._props = this.getPersistedProperty<PostHogEventProperties>(PostHogPersistedProperty.Props)
     }
@@ -707,12 +707,15 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     return this.getPersistedProperty<string>(PostHogPersistedProperty.DistinctId) || this.getAnonymousId()
   }
 
-  register(properties: { [key: string]: any }): void {
+  register(properties: { [key: string]: any }, options?: { persist: boolean }): void {
+    const persist = options?.persist ?? true
     this.props = {
       ...this.props,
       ...properties,
     }
-    this.setPersistedProperty<PostHogEventProperties>(PostHogPersistedProperty.Props, this.props)
+    if (persist) {
+      this.setPersistedProperty<PostHogEventProperties>(PostHogPersistedProperty.Props, this.props)
+    }
   }
 
   unregister(property: string): void {

--- a/posthog-core/test/posthog.register.spec.ts
+++ b/posthog-core/test/posthog.register.spec.ts
@@ -13,24 +13,30 @@ describe('PostHog Core', () => {
   describe('register', () => {
     it('should register properties to storage', () => {
       posthog.register({ foo: 'bar' })
-      expect(posthog.props).toEqual({ foo: 'bar' })
+      expect(posthog.enrichProperties()).toMatchObject({ foo: 'bar' })
       expect(posthog.getPersistedProperty(PostHogPersistedProperty.Props)).toEqual({ foo: 'bar' })
       posthog.register({ foo2: 'bar2' })
-      expect(posthog.props).toEqual({ foo: 'bar', foo2: 'bar2' })
+      expect(posthog.enrichProperties()).toMatchObject({ foo: 'bar', foo2: 'bar2' })
       expect(posthog.getPersistedProperty(PostHogPersistedProperty.Props)).toEqual({ foo: 'bar', foo2: 'bar2' })
     })
 
     it('should unregister properties from storage', () => {
       posthog.register({ foo: 'bar', foo2: 'bar2' })
       posthog.unregister('foo')
-      expect(posthog.props).toEqual({ foo2: 'bar2' })
+      expect(posthog.enrichProperties().foo).toBeUndefined()
+      expect(posthog.enrichProperties().foo2).toEqual('bar2')
       expect(posthog.getPersistedProperty(PostHogPersistedProperty.Props)).toEqual({ foo2: 'bar2' })
     })
 
-    it('should register properties with optional persistence', () => {
-      posthog.register({ foo: 'bar' }, { persist: false })
-      expect(posthog.props).toEqual({ foo: 'bar' })
+    it('should register properties only for the session', () => {
+      posthog.registerForSession({ foo: 'bar' })
+      expect(posthog.enrichProperties()).toMatchObject({ foo: 'bar' })
       expect(posthog.getPersistedProperty(PostHogPersistedProperty.Props)).toEqual(undefined)
+
+      posthog.register({ foo: 'bar2' })
+      expect(posthog.enrichProperties()).toMatchObject({ foo: 'bar' })
+      posthog.unregisterForSession('foo')
+      expect(posthog.enrichProperties()).toMatchObject({ foo: 'bar2' })
     })
   })
 })

--- a/posthog-core/test/posthog.register.spec.ts
+++ b/posthog-core/test/posthog.register.spec.ts
@@ -1,0 +1,36 @@
+import { PostHogPersistedProperty } from '../src'
+import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from './test-utils/PostHogCoreTestClient'
+
+describe('PostHog Core', () => {
+  let posthog: PostHogCoreTestClient
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let mocks: PostHogCoreTestClientMocks
+
+  beforeEach(() => {
+    ;[posthog, mocks] = createTestClient('TEST_API_KEY', {})
+  })
+
+  describe('register', () => {
+    it('should register properties to storage', () => {
+      posthog.register({ foo: 'bar' })
+      expect(posthog.props).toEqual({ foo: 'bar' })
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.Props)).toEqual({ foo: 'bar' })
+      posthog.register({ foo2: 'bar2' })
+      expect(posthog.props).toEqual({ foo: 'bar', foo2: 'bar2' })
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.Props)).toEqual({ foo: 'bar', foo2: 'bar2' })
+    })
+
+    it('should unregister properties from storage', () => {
+      posthog.register({ foo: 'bar', foo2: 'bar2' })
+      posthog.unregister('foo')
+      expect(posthog.props).toEqual({ foo2: 'bar2' })
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.Props)).toEqual({ foo2: 'bar2' })
+    })
+
+    it('should register properties with optional persistence', () => {
+      posthog.register({ foo: 'bar' }, { persist: false })
+      expect(posthog.props).toEqual({ foo: 'bar' })
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.Props)).toEqual(undefined)
+    })
+  })
+})

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.7.0 - 2023-05-25
+
+1. The `$screen_name` property will be registered for all events whenever `screen` is called
+
 # 2.7.0 - 2023-04-20
 
 1. Fixes a race condition that could occur when initialising PostHog

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -146,6 +146,15 @@ export class PostHog extends PostHogCore {
 
   // Custom methods
   screen(name: string, properties?: any): this {
+    // Screen name is good to know for all other subsequent events
+    this.register(
+      {
+        $screen_name: name,
+      },
+      {
+        persist: false,
+      }
+    )
     return this.capture('$screen', {
       ...properties,
       $screen_name: name,

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -147,14 +147,10 @@ export class PostHog extends PostHogCore {
   // Custom methods
   screen(name: string, properties?: any): this {
     // Screen name is good to know for all other subsequent events
-    this.register(
-      {
-        $screen_name: name,
-      },
-      {
-        persist: false,
-      }
-    )
+    this.registerForSession({
+      $screen_name: name,
+    })
+
     return this.capture('$screen', {
       ...properties,
       $screen_name: name,

--- a/posthog-react-native/test/posthog.spec.ts
+++ b/posthog-react-native/test/posthog.spec.ts
@@ -1,3 +1,4 @@
+import { PostHogPersistedProperty } from 'posthog-core'
 import { PostHog, PostHogCustomAsyncStorage } from '../index'
 
 describe('PostHog React Native', () => {
@@ -135,5 +136,22 @@ describe('PostHog React Native', () => {
     expect(posthog).toEqual(otherPostHog)
 
     await otherPostHog.shutdownAsync()
+  })
+
+  describe('screen', () => {
+    it('should set a $screen_name property on screen', async () => {
+      posthog = await PostHog.initAsync('test-token', {
+        customAsyncStorage: mockStorage,
+        flushInterval: 0,
+      })
+
+      posthog.screen('test-screen')
+
+      expect(posthog.props).toEqual({
+        $screen_name: 'test-screen',
+      })
+
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.Props)).toEqual(undefined)
+    })
   })
 })

--- a/posthog-react-native/test/posthog.spec.ts
+++ b/posthog-react-native/test/posthog.spec.ts
@@ -147,7 +147,7 @@ describe('PostHog React Native', () => {
 
       posthog.screen('test-screen')
 
-      expect(posthog.props).toEqual({
+      expect(posthog.enrichProperties()).toMatchObject({
         $screen_name: 'test-screen',
       })
 


### PR DESCRIPTION
## Problem

Customer brought up that autocapture events would be way more useful with the current screen name available.

## Changes

* Registers the $screen_name whenever screen is called for subsequent events

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [x] posthog-react-native

### Changelog notes

- The `$screen_name` property will be registered for all events whenever `screen` is called
