### PR TITLE
feat: allow a caller to override the generated session id

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -677,7 +677,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
       ...this.sessionProps, // Followed by session properties
       ...(properties || {}), // Followed by user specified properties
       ...this.getCommonEventProperties(), // Followed by FF props
-      $session_id: this.getSessionId(),
+      $session_id: properties?.['$session_id'] || this.getSessionId(),
     }
   }
 

--- a/posthog-core/test/posthog.capture.spec.ts
+++ b/posthog-core/test/posthog.capture.spec.ts
@@ -1,5 +1,6 @@
 import { parseBody } from './test-utils/test-utils'
 import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from './test-utils/PostHogCoreTestClient'
+import { PostHogPersistedProperty } from '../src'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient
@@ -42,6 +43,55 @@ describe('PostHog Core', () => {
         ],
         sent_at: '2022-01-01T00:00:00.000Z',
       })
+    })
+
+    it('uses the persisted session id when fresh', async () => {
+      jest.setSystemTime(new Date('2022-01-01'))
+
+      posthog.setPersistedProperty(PostHogPersistedProperty.SessionId, 'the persisted session id')
+      posthog.setPersistedProperty(PostHogPersistedProperty.SessionLastTimestamp, Date.now())
+      posthog.capture('custom-event')
+
+      const body = parseBody(mocks.fetch.mock.calls[0])
+
+      expect(body['batch'][0].properties.$session_id).toEqual('the persisted session id')
+    })
+
+    it('refreshes the persisted session id when it has expired', async () => {
+      jest.setSystemTime(new Date('2022-01-01'))
+
+      posthog.setPersistedProperty(PostHogPersistedProperty.SessionId, 'the persisted session id')
+      posthog.setPersistedProperty(PostHogPersistedProperty.SessionLastTimestamp, Date.now() - 1801 * 1000)
+      posthog.capture('custom-event')
+
+      const body = parseBody(mocks.fetch.mock.calls[0])
+
+      const eventSessionId = body['batch'][0].properties.$session_id
+      // the session id should have been refreshed
+      expect(eventSessionId).not.toEqual('the persisted session id')
+      expect(eventSessionId).toEqual(expect.any(String))
+      expect(eventSessionId).toHaveLength(36) // i.e. it's a UUID
+      // it was stored and its timestamp updated
+      expect(eventSessionId).toEqual(posthog.getPersistedProperty(PostHogPersistedProperty.SessionId))
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.SessionLastTimestamp)).toEqual(Date.now())
+    })
+
+    it('can have an overridden session id from the event', async () => {
+      jest.setSystemTime(new Date('2022-01-01'))
+
+      // a persisted session id with a still valid session timestamp
+      posthog.setPersistedProperty(PostHogPersistedProperty.SessionId, 'the persisted session id')
+      let storedTimestamp = Date.now() - 1500
+      posthog.setPersistedProperty(PostHogPersistedProperty.SessionLastTimestamp, storedTimestamp)
+      posthog.capture('custom-event', { $session_id: 'the overridden session id' })
+
+      const body = parseBody(mocks.fetch.mock.calls[0])
+
+      // the session id should have been refreshed
+      expect(body['batch'][0].properties.$session_id).toEqual('the overridden session id')
+      // the auto-generated session id was not overriden
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.SessionId)).toEqual('the persisted session id')
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.SessionLastTimestamp)).toEqual(storedTimestamp)
     })
 
     it('should allow overridding the timestamp', async () => {


### PR DESCRIPTION
## Problem

see private zendesk ticket: https://posthoghelp.zendesk.com/agent/tickets/5224

A posthog-node user was explicitly setting `$session_id` on events and we were silently ignoring it.

## Changes

Allows a caller to override $session_id

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

 - Added support for explicitly overriding $session_id
