### PR TITLE
feat: Add react native autocapture lifecycle events

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -93,6 +93,10 @@ export abstract class PostHogCoreStateless {
     }
     this.requestTimeout = options?.requestTimeout ?? 10000 // 10 seconds
     this.disableGeoip = options?.disableGeoip ?? true
+
+    if (options?.__onConstructed) {
+      options.__onConstructed(this)
+    }
   }
 
   protected getCommonEventProperties(): any {

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -93,10 +93,6 @@ export abstract class PostHogCoreStateless {
     }
     this.requestTimeout = options?.requestTimeout ?? 10000 // 10 seconds
     this.disableGeoip = options?.disableGeoip ?? true
-
-    if (options?.__onConstructed) {
-      options.__onConstructed(this)
-    }
   }
 
   protected getCommonEventProperties(): any {

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -44,6 +44,8 @@ export enum PostHogPersistedProperty {
   SessionLastTimestamp = 'session_timestamp',
   PersonProperties = 'person_properties',
   GroupProperties = 'group_properties',
+  InstalledAppBuild = 'installed_app_build', // only used by posthog-react-native
+  InstalledAppVersion = 'installed_app_version', // only used by posthog-react-native
 }
 
 export type PostHogFetchOptions = {

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -1,5 +1,3 @@
-import type { PostHogCoreStateless } from './index'
-
 export type PosthogCoreOptions = {
   // PostHog API host (https://app.posthog.com by default)
   host?: string
@@ -31,9 +29,6 @@ export type PosthogCoreOptions = {
   // Whether to post events to PostHog in JSON or compressed format
   captureMode?: 'json' | 'form'
   disableGeoip?: boolean
-
-  // For testing purposes only, called at the end of the PostHogCoreStateless constructor
-  __onConstructed?: (posthog: PostHogCoreStateless) => void
 }
 
 export enum PostHogPersistedProperty {

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -1,3 +1,5 @@
+import type { PostHogCoreStateless } from './index'
+
 export type PosthogCoreOptions = {
   // PostHog API host (https://app.posthog.com by default)
   host?: string
@@ -29,6 +31,9 @@ export type PosthogCoreOptions = {
   // Whether to post events to PostHog in JSON or compressed format
   captureMode?: 'json' | 'form'
   disableGeoip?: boolean
+
+  // For testing purposes only, called at the end of the PostHogCoreStateless constructor
+  __onConstructed?: (posthog: PostHogCoreStateless) => void
 }
 
 export enum PostHogPersistedProperty {

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -22,7 +22,7 @@ export type PostHogOptions = PosthogCoreOptions & {
     | PostHogCustomAppProperties
     | ((properties: PostHogCustomAppProperties) => PostHogCustomAppProperties)
   customAsyncStorage?: PostHogCustomAsyncStorage
-  autoCaptureInstallationEvents?: boolean
+  captureNativeAppLifecycleEvents?: boolean
 }
 
 const clientMap = new Map<string, Promise<PostHog>>()
@@ -105,8 +105,8 @@ export class PostHog extends PostHogCore {
         this.reloadFeatureFlags()
       }
 
-      if (options?.autoCaptureInstallationEvents) {
-        this.autoCaptureNativeAppLifecycleEvents()
+      if (options?.captureNativeAppLifecycleEvents) {
+        await this.captureNativeAppLifecycleEvents()
       }
     }
 
@@ -166,7 +166,7 @@ export class PostHog extends PostHogCore {
     return withReactNativeNavigation(this, options)
   }
 
-  async autoCaptureNativeAppLifecycleEvents(): Promise<void> {
+  async captureNativeAppLifecycleEvents(): Promise<void> {
     // See the other implementations for reference:
     // ios: https://github.com/PostHog/posthog-ios/blob/3a6afc24d6bde730a19470d4e6b713f44d076ad9/PostHog/Classes/PHGPostHog.m#L140
     // android: https://github.com/PostHog/posthog-android/blob/09940e6921bafa9e01e7d68b8c9032671a21ae73/posthog/src/main/java/com/posthog/android/PostHog.java#L278

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -117,6 +117,7 @@ export class PostHog extends PostHogCore {
           await this.captureNativeAppLifecycleEvents()
         }
       }
+      await this.persistAppVersion()
     }
 
     this._setupPromise = setupAsync()
@@ -231,7 +232,11 @@ export class PostHog extends PostHogCore {
         this.capture('Application Backgrounded')
       }
     })
+  }
 
+  async persistAppVersion(): Promise<void> {
+    const appBuild = this._appProperties.$app_build
+    const appVersion = this._appProperties.$app_version
     this.setPersistedProperty(PostHogPersistedProperty.InstalledAppBuild, appBuild)
     this.setPersistedProperty(PostHogPersistedProperty.InstalledAppVersion, appVersion)
   }

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -109,7 +109,13 @@ export class PostHog extends PostHogCore {
       }
 
       if (options?.captureNativeAppLifecycleEvents) {
-        await this.captureNativeAppLifecycleEvents()
+        if (this._persistence === 'memory') {
+          console.warn(
+            'PostHog was initialised with persistence set to "memory", capturing native app events is not supported.'
+          )
+        } else {
+          await this.captureNativeAppLifecycleEvents()
+        }
       }
     }
 

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -32,6 +32,7 @@ export class PostHog extends PostHogCore {
   private _memoryStorage = new PostHogMemoryStorage()
   private _semiAsyncStorage?: SemiAsyncStorage
   private _appProperties: PostHogCustomAppProperties = {}
+  private _setupPromise?: Promise<void>
 
   static _resetClientCache(): void {
     // NOTE: this method is intended for testing purposes only
@@ -56,7 +57,9 @@ export class PostHog extends PostHogCore {
       console.warn('PostHog.initAsync called twice with the same apiKey. The first instance will be used.')
     }
 
-    return posthog
+    const resolved = await posthog
+    await resolved._setupPromise
+    return resolved
   }
 
   constructor(apiKey: string, options?: PostHogOptions, storage?: SemiAsyncStorage) {
@@ -110,7 +113,7 @@ export class PostHog extends PostHogCore {
       }
     }
 
-    void setupAsync()
+    this._setupPromise = setupAsync()
   }
 
   getPersistedProperty<T>(key: PostHogPersistedProperty): T | undefined {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
     "baseUrl": "./", // this must be specified if "paths" is specified.
     "rootDir": "./",
     "lib": ["ES2015", "ES2022.Error"],
-    "types": ["node", "jest"],
     "jsx": "react"
   },
   "exclude": ["**/dist/**", "node_modules", "dist", "**/*.spec.*"]


### PR DESCRIPTION
## Problem
Fixes https://github.com/PostHog/posthog-js-lite/issues/107

~Note: please merge https://github.com/PostHog/posthog-js-lite/pull/109 first, as this depends upon that.~
## Changes

Adds these events that were present in v1. I put it behind an options flag, so that users will need to opt-in. This will prevent people from getting an unexpected surge of these events when updating the sdk.

Note: I found that due to ignoring the returned promise on line https://github.com/PostHog/posthog-js-lite/blob/54178fc167362f550c7f5703f2931abc487f8134/posthog-react-native/src/posthog-rn.ts#L108 , `initAsync` would return before `setupAsync` had completed. This is something that is a bit awkward to get right, when there in a constructor which needs to do something async. I fixed this by storing the promise and awaiting it in `initAsync`.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [x] posthog-react-native

### Changelog notes

- Added an options flag `captureNativeAppLifecycleEvents` which, when set, will cause the SDK to automatically capture 'Application Installed', 'Application Updated', 'Application Opened', and 'Application Backgrounded'.
