### PR TITLE
Added useFeatureFlagWithPayload for react native

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.7.0 - 2023-10-05
+
+1. Added new `const [flag, payload] = useFeatureFlagWithPayload('my-flag-name')` hook that returns the flag result and it's payload if it has one.
+
 # 2.7.0 - 2023-05-25
 
 1. The `$screen_name` property will be registered for all events whenever `screen` is called

--- a/posthog-react-native/src/hooks/useFeatureFlag.ts
+++ b/posthog-react-native/src/hooks/useFeatureFlag.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { usePostHog } from './usePostHog'
+import { JsonType } from 'posthog-core/src'
 
 export function useFeatureFlag(flag: string): string | boolean | undefined {
   const posthog = usePostHog()
@@ -17,4 +18,25 @@ export function useFeatureFlag(flag: string): string | boolean | undefined {
   }, [posthog, flag])
 
   return featureFlag
+}
+
+export type FeatureFlagWithPayload = [boolean | string | undefined, JsonType | undefined];
+
+export function useFeatureFlagWithPayload(flag: string): FeatureFlagWithPayload {
+  const posthog = usePostHog()
+
+  const [featureFlag, setFeatureFlag] = useState<FeatureFlagWithPayload>([undefined, undefined])
+  
+  useEffect(() => {
+    if (!posthog) {
+      return
+    }
+
+    setFeatureFlag([posthog.getFeatureFlag(flag), posthog.getFeatureFlagPayload(flag)])
+    return posthog.onFeatureFlags(() => {
+      setFeatureFlag([posthog.getFeatureFlag(flag), posthog.getFeatureFlagPayload(flag)])
+    })
+  }, [posthog, flag])
+
+  return featureFlag;
 }

--- a/posthog-react-native/src/hooks/useFeatureFlag.ts
+++ b/posthog-react-native/src/hooks/useFeatureFlag.ts
@@ -20,13 +20,13 @@ export function useFeatureFlag(flag: string): string | boolean | undefined {
   return featureFlag
 }
 
-export type FeatureFlagWithPayload = [boolean | string | undefined, JsonType | undefined];
+export type FeatureFlagWithPayload = [boolean | string | undefined, JsonType | undefined]
 
 export function useFeatureFlagWithPayload(flag: string): FeatureFlagWithPayload {
   const posthog = usePostHog()
 
   const [featureFlag, setFeatureFlag] = useState<FeatureFlagWithPayload>([undefined, undefined])
-  
+
   useEffect(() => {
     if (!posthog) {
       return
@@ -38,5 +38,5 @@ export function useFeatureFlagWithPayload(flag: string): FeatureFlagWithPayload 
     })
   }, [posthog, flag])
 
-  return featureFlag;
+  return featureFlag
 }


### PR DESCRIPTION
Enabling feature flags with payload, this should be essential to have...

## Problem

Enables feature flags with payload for react native

## Changes

It just exposes a new hook for this.

## Release info Sub-libraries affected

### Bump level
- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected
- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [x] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for feature flags payload for react native useFeatureFlagWithPayload
