### PR TITLE
Fix changelog entries RN

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 2.7.0 - 2023-05-25
+# 2.7.1 - 2023-05-25
 
 1. The `$screen_name` property will be registered for all events whenever `screen` is called
 
-# 2.7.0 - 2023-04-20
+# 2.7.0 - 2023-04-21
 
 1. Fixes a race condition that could occur when initialising PostHog
 2. Fixes an issue where feature flags would not be reloaded after a reset


### PR DESCRIPTION
## Problem

The latest entry/release is 2.7.1 https://github.com/PostHog/posthog-js-lite/releases/tag/posthog-react-native-v2.7.1
The 2.7.0 release was on April 21 https://github.com/PostHog/posthog-js-lite/releases/tag/posthog-react-native-v2.7.0

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

No need.
