### PR TITLE
fix: Type issue with RN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,16 @@ jobs:
       - run: yarn compile
       - run: yarn lint
       - run: yarn prettier:check
+
+  type-check:
+    timeout-minutes: 3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - run: |
+          cd examples/example-expo
+          yarn
+          yarn tsc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           node-version: 16
       - run: |
+          yarn
           cd examples/example-expo
           yarn global add yalc
           yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,6 @@ jobs:
           node-version: 16
       - run: |
           cd examples/example-expo
+          yarn global add yalc
           yarn
           yarn tsc

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -36,6 +36,8 @@ class PostHogFetchNetworkError extends Error {
   name = 'PostHogFetchNetworkError'
 
   constructor(public error: unknown) {
+    // TRICKY: "cause" is a newer property but is just ignored otherwise. Cast to any to ignore the type issue.
+    // @ts-ignore
     super('Network error while fetching PostHog', error instanceof Error ? { cause: error } : {})
   }
 }

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.8.1 - 2023-10-09
+
+1. Fixes a type generation issue
+
 # 2.8.0 - 2023-10-06
 
 1. Added new `const [flag, payload] = useFeatureFlagWithPayload('my-flag-name')` hook that returns the flag result and it's payload if it has one.

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -6,7 +6,7 @@ import {
   PostHogFetchOptions,
   PostHogFetchResponse,
   PostHogPersistedProperty,
-} from '../../posthog-core'
+} from '../../posthog-core/src'
 import { PostHogMemoryStorage } from '../../posthog-core/src/storage-memory'
 import { getLegacyValues } from './legacy'
 import { SemiAsyncStorage } from './storage'


### PR DESCRIPTION
## Problem

Might fix https://github.com/PostHog/posthog-js-lite/issues/117

## Changes

Seems like we have some weird typing import issues that happened.  Not sure why or how, so need to validate this and ideally add a test...

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [x] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
