### PR TITLE
GH codeowner for RN

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/posthog-react-native/       @marandaneto

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-/posthog-react-native/                         @marandaneto
-/examples/example-react-native/       @marandaneto
-/posthog-core/                                      @marandaneto
+/posthog-react-native/              @marandaneto
+/examples/example-react-native/     @marandaneto
+/posthog-core/                      @marandaneto

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-/posthog-react-native/       @marandaneto
+/posthog-react-native/                         @marandaneto
+/examples/example-react-native/       @marandaneto
+/posthog-core/                                      @marandaneto

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask in the forums
+    url: https://posthog.com/questions
+    about: A place to ask questions.

--- a/.github/ISSUE_TEMPLATE/maintainer-blank.yml
+++ b/.github/ISSUE_TEMPLATE/maintainer-blank.yml
@@ -1,0 +1,10 @@
+name: Blank Issue
+description: Blank Issue. Reserved for maintainers.
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please describe the issue.
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Problem

I have to check every PR to see if there's anything related to RN
Allowing empty issues/PRs usually allows low barriers and low-quality descriptions.
GH Actions have to be manually upgraded

## Changes

RN PRs automatically assigned to me
Only allow using PR and Issues templates, blank just for PH people.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
