### PR TITLE
fix: Renamed some properties to match posthog-js

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -915,7 +915,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     this.setPersistedProperty<PostHogEventProperties>(PostHogPersistedProperty.GroupProperties, {})
   }
 
-  /** @deprecated - Renamed to setPersonPropertiesForFlags */
+  /** @deprecated - Renamed to setGroupPropertiesForFlags */
   groupProperties(properties: { [type: string]: Record<string, string> }): this {
     return this.setGroupPropertiesForFlags(properties)
   }

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -867,7 +867,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
   /***
    * PROPERTIES
    ***/
-  personProperties(properties: { [type: string]: string }): this {
+  setPersonPropertiesForFlags(properties: { [type: string]: string }): this {
     // Get persisted person properties
     const existingProperties =
       this.getPersistedProperty<Record<string, string>>(PostHogPersistedProperty.PersonProperties) || {}
@@ -880,7 +880,16 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     return this
   }
 
-  groupProperties(properties: { [type: string]: Record<string, string> }): this {
+  resetPersonPropertiesForFlags(): void {
+    this.setPersistedProperty<PostHogEventProperties>(PostHogPersistedProperty.PersonProperties, {})
+  }
+
+  /** @deprecated - Renamed to setPersonPropertiesForFlags */
+  personProperties(properties: { [type: string]: string }): this {
+    return this.setPersonPropertiesForFlags(properties)
+  }
+
+  setGroupPropertiesForFlags(properties: { [type: string]: Record<string, string> }): this {
     // Get persisted group properties
     const existingProperties =
       this.getPersistedProperty<Record<string, Record<string, string>>>(PostHogPersistedProperty.GroupProperties) || {}
@@ -900,6 +909,15 @@ export abstract class PostHogCore extends PostHogCoreStateless {
       ...properties,
     })
     return this
+  }
+
+  resetGroupPropertiesForFlags(): void {
+    this.setPersistedProperty<PostHogEventProperties>(PostHogPersistedProperty.GroupProperties, {})
+  }
+
+  /** @deprecated - Renamed to setPersonPropertiesForFlags */
+  groupProperties(properties: { [type: string]: Record<string, string> }): this {
+    return this.setGroupPropertiesForFlags(properties)
   }
 
   /***

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.9.0 - 2023-12-04
+
+1.  Renamed `personProperties` to `setPersonPropertiesForFlags` to match `posthog-js` and more clearly indicated what it does
+2.  Renamed `groupProperties` to `setGroupPropertiesForFlags` to match `posthog-js` and more clearly indicated what it does
+
 # 2.8.1 - 2023-10-09
 
 1. Fixes a type generation issue

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.5.0 - 2023-12-04
+
+1.  Renamed `personProperties` to `setPersonPropertiesForFlags` to match `posthog-js` and more clearly indicated what it does
+2.  Renamed `groupProperties` to `setGroupPropertiesForFlags` to match `posthog-js` and more clearly indicated what it does
+
 # 2.4.0 - 2023-04-20
 
 1. Fixes a race condition that could occur when initialising PostHog

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-js-lite",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Problem

[Someone pointed out](https://github.com/PostHog/posthog-js/issues/917) that the posthog-js methods aren't available in RN. They are actually there just with slightly outdated naming

## Changes
* Updates the naming to match

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-web
- [ ] posthog-node
- [x] posthog-react-native

### Changelog notes
- Renamed `personProperties` to `setPersonPropertiesForFlags` to match `posthog-js` and more clearly indicated what it does
- Renamed `groupProperties` to `setGroupPropertiesForFlags` to match `posthog-js` and more clearly indicated what it does