### PR TITLE
Add releasing markdown with releasing instructions

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,9 @@
+Releasing
+=========
+
+ 1. Update the `CHANGELOG.md` with the version and date (each package has its own `CHANGELOG.md`).
+ 2. Update the `version` in the `package.json` file (each package has its own `package.json`).
+ 3. Open a PR with the changes.
+ 4. After merging the PR, The GH Action (release.yml) is doing everything else automatically.
+    1. For React Native, the `scripts.prebuild` (`package.json`) is generating a `version.ts` file with the version which is used at runtime.
+ 5. Done.


### PR DESCRIPTION
## Problem

There are no releasing instructions

## Changes

Add releasing instructions

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [X] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

