### PR TITLE
fix: logging typo from `enable` to `optIn`

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -396,7 +396,7 @@ export abstract class PostHogCoreStateless {
    ***/
   protected enqueue(type: string, _message: any, options?: PosthogCaptureOptions): void {
     if (this.optedOut) {
-      this._events.emit(type, `Library is disabled. Not sending event. To re-enable, call posthog.enable()`)
+      this._events.emit(type, `Library is disabled. Not sending event. To re-enable, call posthog.optIn()`)
       return
     }
 


### PR DESCRIPTION
## Problem

fix: logging typo from `enable` to `optIn`
Relates to https://github.com/PostHog/posthog-js-lite/issues/133

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
