### PR TITLE
Add changelog to Release 2.9.1 - RN

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.9.1 - 2023-12-14
+
+1. `getPersistedProperty` uses Nullish Coalescing operator to fallback to `undefined` only if the property is not found
+
 # 2.9.0 - 2023-12-04
 
 1.  Renamed `personProperties` to `setPersonPropertiesForFlags` to match `posthog-js` and more clearly indicated what it does

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add changelog and cut new version

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- `getPersistedProperty` uses Nullish Coalescing operator to fallback to `undefined` only if the property is not found
