### PR TITLE
fix: Unhandled error when background fetching flags

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.1 - 2023-12-15
+
+1. Fixes issue where a background refresh of feature flags could throw an unhandled error. It now emits to be detected by `.on('error', ...)`
+
 # 3.2.0 - 2023-12-05
 
 1. Fixes issues with Axios imports for non-node environments like Cloudflare workers

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "PostHog Node.js integration",
   "repository": "PostHog/posthog-node",
   "scripts": {

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -56,6 +56,9 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
         timeout: options.requestTimeout ?? 10000, // 10 seconds
         host: this.host,
         fetch: options.fetch,
+        onError: (err: Error) => {
+          this._events.emit('error', err)
+        },
       })
     }
     this.distinctIdHasSentFlagCalls = {}


### PR DESCRIPTION
## Problem

Reported issues where failing API requests can crash the process ([see here](https://posthog.com/questions/catching-error-on-initialization-in-node-js))

## Changes

Don't throw but rather report up to the emitter

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-react-native
