### PR TITLE
Update package.json repository fields

### DIFF
--- a/posthog-core/package.json
+++ b/posthog-core/package.json
@@ -1,5 +1,10 @@
 {
   "name": "posthog-core",
   "version": "2.1.0",
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/PostHog/posthog-js-lite.git",
+    "directory": "posthog-core"
+  }
 }

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -2,7 +2,11 @@
   "name": "posthog-node",
   "version": "3.2.1",
   "description": "PostHog Node.js integration",
-  "repository": "PostHog/posthog-node",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/PostHog/posthog-js-lite.git",
+    "directory": "posthog-node"
+  },
   "scripts": {
     "prepublishOnly": "cd .. && yarn build"
   },

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -5,6 +5,11 @@
   "files": [
     "lib/"
   ],
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/PostHog/posthog-js-lite.git",
+    "directory": "posthog-react-native"
+  },
   "scripts": {
     "pretest": "npm run prebuild",
     "test": "jest -c jest.config.js",

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -4,6 +4,11 @@
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/PostHog/posthog-js-lite.git",
+    "directory": "posthog-web"
+  },
   "scripts": {
     "test": "jest -c jest.config.js",
     "prepublishOnly": "cd .. && yarn build"


### PR DESCRIPTION
## Problem

Tools such as Renovate can use the repository field to point to changes in new releases; posthog-node's repository field was out of date, causing Renovate to link to [the old 1.x repository](https://github.com/posthog/posthog-node).

## Changes

Update package.json repository fields. See https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [X] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Update package.json repository fields
