### PR TITLE
feat(flags): Add local props and flags to all calls

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -477,8 +477,6 @@ export abstract class PostHogCoreStateless {
       sent_at: currentISOTime(),
     }
 
-    const promiseUUID = generateUUID()
-
     const done = (err?: any): void => {
       if (err) {
         this._events.emit('error', err)

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -519,13 +519,13 @@ export abstract class PostHogCoreStateless {
             body: payload,
           }
     const requestPromise = this.fetchWithRetry(url, fetchOptions)
-    this.addPendingPromise(requestPromise)
-
-    requestPromise
-      .then(() => done())
-      .catch((err) => {
-        done(err)
-      })
+    this.addPendingPromise(
+      requestPromise
+        .then(() => done())
+        .catch((err) => {
+          done(err)
+        })
+    )
   }
 
   private async fetchWithRetry(

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -249,7 +249,7 @@ export abstract class PostHogCoreStateless {
     return this.fetchWithRetry(url, fetchOptions)
       .then((response) => response.json() as Promise<PostHogDecideResponse>)
       .catch((error) => {
-        console.error('Error fetching feature flags', error)
+        this._events.emit('error', error)
         return undefined
       })
   }

--- a/posthog-core/test/test-utils/test-utils.ts
+++ b/posthog-core/test/test-utils/test-utils.ts
@@ -5,9 +5,13 @@ export const wait = async (t: number): Promise<void> => {
 }
 
 export const waitForPromises = async (): Promise<void> => {
-  jest.useRealTimers()
-  await new Promise((resolve) => setTimeout(resolve, 100) as any)
-  jest.useFakeTimers()
+  await new Promise((resolve) => {
+    // IMPORTANT: Only enable real timers for this promise - allows us to pass a short amount of ticks
+    // whilst keeping any timers made during other promises as fake timers
+    jest.useRealTimers()
+    setTimeout(resolve, 10)
+    jest.useFakeTimers()
+  })
 }
 
 export const parseBody = (mockCall: any): any => {

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.5.0 - 2024-01-09
+
+1. When local evaluation is enabled, we automatically add flag information to all events sent to PostHog, whenever possible. This makes it easier to use these events in experiments.
+2. Fixes a bug where in some rare cases we may drop events when send_feature_flags is enabled on capture.
+
 # 3.4.0 - 2024-01-09
 
 1. Numeric property handling for feature flags now does the expected: When passed in a number, we do a numeric comparison. When passed in a string, we do a string comparison. Previously, we always did a string comparison.

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -211,14 +211,18 @@ class FeatureFlagsPoller {
       const groupName = this.groupTypeMapping[String(aggregation_group_type_index)]
 
       if (!groupName) {
-        console.warn(
-          `[FEATURE FLAGS] Unknown group type index ${aggregation_group_type_index} for feature flag ${flag.key}`
-        )
+        if (this.debugMode) {
+          console.warn(
+            `[FEATURE FLAGS] Unknown group type index ${aggregation_group_type_index} for feature flag ${flag.key}`
+          )
+        }
         throw new InconclusiveMatchError('Flag has unknown group type index')
       }
 
       if (!(groupName in groups)) {
-        console.warn(`[FEATURE FLAGS] Can't compute group feature flag: ${flag.key} without group names passed in`)
+        if (this.debugMode) {
+          console.warn(`[FEATURE FLAGS] Can't compute group feature flag: ${flag.key} without group names passed in`)
+        }
         return false
       }
 

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -121,7 +121,7 @@ class FeatureFlagsPoller {
             console.debug(`InconclusiveMatchError when computing flag locally: ${key}: ${e}`)
           }
         } else if (e instanceof Error) {
-          console.error(`Error computing flag locally: ${key}: ${e}`)
+          this.onError?.(new Error(`Error computing flag locally: ${key}: ${e}`))
         }
       }
     }
@@ -383,7 +383,7 @@ class FeatureFlagsPoller {
 
       const responseJson = await res.json()
       if (!('flags' in responseJson)) {
-        console.error(`Invalid response when getting feature flags: ${JSON.stringify(responseJson)}`)
+        this.onError?.(new Error(`Invalid response when getting feature flags: ${JSON.stringify(responseJson)}`))
       }
 
       this.featureFlags = responseJson.flags || []

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -132,6 +132,9 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
         .catch(() => {
           _capture({ ...properties, $groups: groups })
         })
+        .finally(() => {
+          delete this.pendingPromises[promiseUUID]
+        })
     } else if ((this.featureFlagsPoller?.featureFlags?.length || 0) > 0) {
       const groupsWithStringValues: Record<string, string> = {}
       for (const [key, value] of Object.entries(groups || {})) {
@@ -168,6 +171,9 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
         })
         .catch(() => {
           _capture({ ...properties, $groups: groups })
+        })
+        .finally(() => {
+          delete this.pendingPromises[promiseUUID]
         })
     } else {
       _capture({ ...properties, $groups: groups })

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -105,70 +105,54 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
       super.captureStateless(distinctId, event, props, { timestamp, disableGeoip })
     }
 
-    if (sendFeatureFlags) {
-      // :TRICKY: If we flush, or need to shut down, to not lose events we want this promise to resolve before we flush
-      this.addPendingPromise(
-        super
-          .getFeatureFlagsStateless(distinctId, groups, undefined, undefined, disableGeoip)
-          .then((flags) => {
-            const featureVariantProperties: Record<string, string | boolean> = {}
-            if (flags) {
-              for (const [feature, variant] of Object.entries(flags)) {
-                if (variant !== false) {
-                  featureVariantProperties[`$feature/${feature}`] = variant
-                }
-              }
-            }
-            const activeFlags = Object.keys(flags || {}).filter((flag) => flags?.[flag] !== false)
-            const flagProperties = {
-              $active_feature_flags: activeFlags || undefined,
-              ...featureVariantProperties,
-            }
-            _capture({ ...properties, $groups: groups, ...flagProperties })
-          })
-          .catch(() => {
-            _capture({ ...properties, $groups: groups })
-          })
-      )
-    } else if ((this.featureFlagsPoller?.featureFlags?.length || 0) > 0) {
-      const groupsWithStringValues: Record<string, string> = {}
-      for (const [key, value] of Object.entries(groups || {})) {
-        groupsWithStringValues[key] = String(value)
-      }
+    // :TRICKY: If we flush, or need to shut down, to not lose events we want this promise to resolve before we flush
+    const capturePromise = Promise.resolve()
+      .then(async () => {
+        if (sendFeatureFlags) {
+          // If we are sending feature flags, we need to make sure we have the latest flags
+          return await super.getFeatureFlagsStateless(distinctId, groups, undefined, undefined, disableGeoip)
+        }
 
-      // :TRICKY: If we flush, or need to shut down, to not lose events we want this promise to resolve before we flush
-      this.addPendingPromise(
-        this.getAllFlags(distinctId, {
-          groups: groupsWithStringValues,
-          disableGeoip,
-          onlyEvaluateLocally: true,
-        })
-          .then((flags) => {
-            const featureVariantProperties: Record<string, string | boolean> = {}
-            if (flags) {
-              for (const [feature, variant] of Object.entries(flags)) {
-                featureVariantProperties[`$feature/${feature}`] = variant
-              }
-            }
-            const activeFlags = Object.keys(flags || {}).filter((flag) => flags?.[flag] !== false)
-            let flagProperties: Record<string, any> = {
-              ...featureVariantProperties,
-            }
-            if (activeFlags.length > 0) {
-              flagProperties = {
-                ...flagProperties,
-                $active_feature_flags: activeFlags,
-              }
-            }
-            _capture({ ...flagProperties, ...properties, $groups: groups })
+        if ((this.featureFlagsPoller?.featureFlags?.length || 0) > 0) {
+          // Otherwise we may as well check for the flags locally and include them if there
+          const groupsWithStringValues: Record<string, string> = {}
+          for (const [key, value] of Object.entries(groups || {})) {
+            groupsWithStringValues[key] = String(value)
+          }
+
+          return await this.getAllFlags(distinctId, {
+            groups: groupsWithStringValues,
+            disableGeoip,
+            onlyEvaluateLocally: true,
           })
-          .catch(() => {
-            _capture({ ...properties, $groups: groups })
-          })
-      )
-    } else {
-      _capture({ ...properties, $groups: groups })
-    }
+        }
+        return {}
+      })
+      .then((flags) => {
+        // Derive the relevant flag properties to add
+        const additionalProperties: Record<string, any> = {}
+        if (flags) {
+          for (const [feature, variant] of Object.entries(flags)) {
+            additionalProperties[`$feature/${feature}`] = variant
+          }
+        }
+        const activeFlags = Object.keys(flags || {}).filter((flag) => flags?.[flag] !== false)
+        if (activeFlags.length > 0) {
+          additionalProperties['$active_feature_flags'] = activeFlags
+        }
+
+        return additionalProperties
+      })
+      .catch(() => {
+        // Something went wrong getting the flag info - we should capture the event anyways
+        return {}
+      })
+      .then((additionalProperties) => {
+        // No matter what - capture the event
+        _capture({ ...additionalProperties, ...properties, $groups: groups })
+      })
+
+    this.addPendingPromise(capturePromise)
   }
 
   identify({ distinctId, properties, disableGeoip }: IdentifyMessageV1): void {

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -136,11 +136,16 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
             }
           }
           const activeFlags = Object.keys(flags || {}).filter((flag) => flags?.[flag] !== false)
-          const flagProperties = {
-            $active_feature_flags: activeFlags || undefined,
+          let flagProperties: Record<string, any> = {
             ...featureVariantProperties,
           }
-          _capture({ ...properties, $groups: groups, ...flagProperties })
+          if (activeFlags.length > 0) {
+            flagProperties = {
+              ...flagProperties,
+              $active_feature_flags: activeFlags,
+            }
+          }
+          _capture({ ...flagProperties, ...properties, $groups: groups })
         }
       )
     } else {

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -107,29 +107,29 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
 
     if (sendFeatureFlags) {
       // :TRICKY: If we flush, or need to shut down, to not lose events we want this promise to resolve before we flush
-      const promise = super.getFeatureFlagsStateless(distinctId, groups, undefined, undefined, disableGeoip)
-      this.addPendingPromise(promise)
-
-      promise
-        .then((flags) => {
-          const featureVariantProperties: Record<string, string | boolean> = {}
-          if (flags) {
-            for (const [feature, variant] of Object.entries(flags)) {
-              if (variant !== false) {
-                featureVariantProperties[`$feature/${feature}`] = variant
+      this.addPendingPromise(
+        super
+          .getFeatureFlagsStateless(distinctId, groups, undefined, undefined, disableGeoip)
+          .then((flags) => {
+            const featureVariantProperties: Record<string, string | boolean> = {}
+            if (flags) {
+              for (const [feature, variant] of Object.entries(flags)) {
+                if (variant !== false) {
+                  featureVariantProperties[`$feature/${feature}`] = variant
+                }
               }
             }
-          }
-          const activeFlags = Object.keys(flags || {}).filter((flag) => flags?.[flag] !== false)
-          const flagProperties = {
-            $active_feature_flags: activeFlags || undefined,
-            ...featureVariantProperties,
-          }
-          _capture({ ...properties, $groups: groups, ...flagProperties })
-        })
-        .catch(() => {
-          _capture({ ...properties, $groups: groups })
-        })
+            const activeFlags = Object.keys(flags || {}).filter((flag) => flags?.[flag] !== false)
+            const flagProperties = {
+              $active_feature_flags: activeFlags || undefined,
+              ...featureVariantProperties,
+            }
+            _capture({ ...properties, $groups: groups, ...flagProperties })
+          })
+          .catch(() => {
+            _capture({ ...properties, $groups: groups })
+          })
+      )
     } else if ((this.featureFlagsPoller?.featureFlags?.length || 0) > 0) {
       const groupsWithStringValues: Record<string, string> = {}
       for (const [key, value] of Object.entries(groups || {})) {
@@ -137,35 +137,35 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
       }
 
       // :TRICKY: If we flush, or need to shut down, to not lose events we want this promise to resolve before we flush
-      const promise = this.getAllFlags(distinctId, {
-        groups: groupsWithStringValues,
-        disableGeoip,
-        onlyEvaluateLocally: true,
-      })
-      this.addPendingPromise(promise)
-      promise
-        .then((flags) => {
-          const featureVariantProperties: Record<string, string | boolean> = {}
-          if (flags) {
-            for (const [feature, variant] of Object.entries(flags)) {
-              featureVariantProperties[`$feature/${feature}`] = variant
-            }
-          }
-          const activeFlags = Object.keys(flags || {}).filter((flag) => flags?.[flag] !== false)
-          let flagProperties: Record<string, any> = {
-            ...featureVariantProperties,
-          }
-          if (activeFlags.length > 0) {
-            flagProperties = {
-              ...flagProperties,
-              $active_feature_flags: activeFlags,
-            }
-          }
-          _capture({ ...flagProperties, ...properties, $groups: groups })
+      this.addPendingPromise(
+        this.getAllFlags(distinctId, {
+          groups: groupsWithStringValues,
+          disableGeoip,
+          onlyEvaluateLocally: true,
         })
-        .catch(() => {
-          _capture({ ...properties, $groups: groups })
-        })
+          .then((flags) => {
+            const featureVariantProperties: Record<string, string | boolean> = {}
+            if (flags) {
+              for (const [feature, variant] of Object.entries(flags)) {
+                featureVariantProperties[`$feature/${feature}`] = variant
+              }
+            }
+            const activeFlags = Object.keys(flags || {}).filter((flag) => flags?.[flag] !== false)
+            let flagProperties: Record<string, any> = {
+              ...featureVariantProperties,
+            }
+            if (activeFlags.length > 0) {
+              flagProperties = {
+                ...flagProperties,
+                $active_feature_flags: activeFlags,
+              }
+            }
+            _capture({ ...flagProperties, ...properties, $groups: groups })
+          })
+          .catch(() => {
+            _capture({ ...properties, $groups: groups })
+          })
+      )
     } else {
       _capture({ ...properties, $groups: groups })
     }

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -448,7 +448,7 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
     groups?: Record<string, string>,
     personProperties?: Record<string, string>,
     groupProperties?: Record<string, Record<string, string>>
-  ) {
+  ): { allPersonProperties: Record<string, string>; allGroupProperties: Record<string, Record<string, string>> } {
     const allPersonProperties = { $current_distinct_id: distinctId, ...(personProperties || {}) }
 
     const allGroupProperties: Record<string, Record<string, string>> = {}

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -112,24 +112,26 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
       const promise = super.getFeatureFlagsStateless(distinctId, groups, undefined, undefined, disableGeoip)
       this.pendingPromises[promiseUUID] = promise
 
-      promise.then((flags) => {
-        const featureVariantProperties: Record<string, string | boolean> = {}
-        if (flags) {
-          for (const [feature, variant] of Object.entries(flags)) {
-            if (variant !== false) {
-              featureVariantProperties[`$feature/${feature}`] = variant
+      promise
+        .then((flags) => {
+          const featureVariantProperties: Record<string, string | boolean> = {}
+          if (flags) {
+            for (const [feature, variant] of Object.entries(flags)) {
+              if (variant !== false) {
+                featureVariantProperties[`$feature/${feature}`] = variant
+              }
             }
           }
-        }
-        const activeFlags = Object.keys(flags || {}).filter((flag) => flags?.[flag] !== false)
-        const flagProperties = {
-          $active_feature_flags: activeFlags || undefined,
-          ...featureVariantProperties,
-        }
-        _capture({ ...properties, $groups: groups, ...flagProperties })
-      }).catch(() => {
-        _capture({ ...properties, $groups: groups })
-      })
+          const activeFlags = Object.keys(flags || {}).filter((flag) => flags?.[flag] !== false)
+          const flagProperties = {
+            $active_feature_flags: activeFlags || undefined,
+            ...featureVariantProperties,
+          }
+          _capture({ ...properties, $groups: groups, ...flagProperties })
+        })
+        .catch(() => {
+          _capture({ ...properties, $groups: groups })
+        })
     } else if ((this.featureFlagsPoller?.featureFlags?.length || 0) > 0) {
       const groupsWithStringValues: Record<string, string> = {}
       for (const [key, value] of Object.entries(groups || {})) {
@@ -138,10 +140,14 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
 
       const promiseUUID = generateUUID()
       // :TRICKY: If we flush, or need to shut down, to not lose events we want this promise to resolve before we flush
-      const promise = this.getAllFlags(distinctId, { groups: groupsWithStringValues, disableGeoip, onlyEvaluateLocally: true })
+      const promise = this.getAllFlags(distinctId, {
+        groups: groupsWithStringValues,
+        disableGeoip,
+        onlyEvaluateLocally: true,
+      })
       this.pendingPromises[promiseUUID] = promise
-      promise.then(
-        (flags) => {
+      promise
+        .then((flags) => {
           const featureVariantProperties: Record<string, string | boolean> = {}
           if (flags) {
             for (const [feature, variant] of Object.entries(flags)) {
@@ -159,10 +165,10 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
             }
           }
           _capture({ ...flagProperties, ...properties, $groups: groups })
-        }
-      ).catch(() => {
-        _capture({ ...properties, $groups: groups })
-      })
+        })
+        .catch(() => {
+          _capture({ ...properties, $groups: groups })
+        })
     } else {
       _capture({ ...properties, $groups: groups })
     }

--- a/posthog-node/test/extensions/sentry-integration.spec.ts
+++ b/posthog-node/test/extensions/sentry-integration.spec.ts
@@ -3,6 +3,7 @@ import { PostHog as PostHog } from '../../src/posthog-node'
 import { PostHogSentryIntegration } from '../../src/extensions/sentry-integration'
 jest.mock('../../src/fetch')
 import fetch from '../../src/fetch'
+import { waitForPromises } from 'posthog-core/test/test-utils/test-utils'
 
 jest.mock('../../package.json', () => ({ version: '1.2.3' }))
 
@@ -108,6 +109,7 @@ describe('PostHogSentryIntegration', () => {
 
     processorFunction(createMockSentryException())
 
+    await waitForPromises()
     jest.runOnlyPendingTimers()
     const batchEvents = getLastBatchEvents()
 

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -50,6 +50,17 @@ export const apiImplementation = ({
       }) as any
     }
 
+    if ((url as any).includes('batch/')) {
+      return Promise.resolve({
+        status: 200,
+        text: () => Promise.resolve('ok'),
+        json: () =>
+          Promise.resolve({
+            status: 'ok',
+          }),
+      }) as any
+    }
+
     return Promise.resolve({
       status: 400,
       text: () => Promise.resolve('ok'),
@@ -342,7 +353,11 @@ describe('local evaluation', () => {
           token: 'TEST_API_KEY',
           distinct_id: 'some-distinct-id_outside_rollout?',
           groups: {},
-          person_properties: { region: 'USA', email: 'a@b.com' },
+          person_properties: {
+            $current_distinct_id: 'some-distinct-id_outside_rollout?',
+            region: 'USA',
+            email: 'a@b.com',
+          },
           group_properties: {},
           geoip_disable: true,
         }),
@@ -361,7 +376,7 @@ describe('local evaluation', () => {
           token: 'TEST_API_KEY',
           distinct_id: 'some-distinct-id',
           groups: {},
-          person_properties: { doesnt_matter: '1' },
+          person_properties: { $current_distinct_id: 'some-distinct-id', doesnt_matter: '1' },
           group_properties: {},
           geoip_disable: true,
         }),

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -4,7 +4,6 @@ jest.mock('../src/fetch')
 import fetch from '../src/fetch'
 import { anyDecideCall, anyLocalEvalCall, apiImplementation } from './feature-flags.spec'
 import { waitForPromises, wait } from '../../posthog-core/test/test-utils/test-utils'
-import exp from 'constants'
 
 jest.mock('../package.json', () => ({ version: '1.2.3' }))
 

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -455,7 +455,7 @@ describe('PostHog Node.js', () => {
         apiImplementation({
           decideFlags: mockFeatureFlags,
           decideFlagPayloads: mockFeatureFlagPayloads,
-          // localFlags: { flags: [multivariateFlag, basicFlag, falseFlag] },
+          localFlags: { flags: [multivariateFlag, basicFlag, falseFlag] },
         })
       )
 
@@ -484,7 +484,7 @@ describe('PostHog Node.js', () => {
       expect(mockedFetch).toHaveBeenCalledTimes(2)
     })
 
-    it.skip('captures feature flags when no personal API key is present', async () => {
+    it('captures feature flags when no personal API key is present', async () => {
       mockedFetch.mockClear()
       mockedFetch.mockClear()
       expect(mockedFetch).toHaveBeenCalledTimes(0)
@@ -535,7 +535,7 @@ describe('PostHog Node.js', () => {
       )
     })
 
-    it.skip('captures feature flags with locally evaluated flags', async () => {
+    it('captures feature flags with locally evaluated flags', async () => {
       mockedFetch.mockClear()
       mockedFetch.mockClear()
       expect(mockedFetch).toHaveBeenCalledTimes(0)
@@ -591,7 +591,7 @@ describe('PostHog Node.js', () => {
       await posthog.shutdownAsync()
     })
 
-    it.skip('doesnt add flag properties when locally evaluated flags are empty', async () => {
+    it('doesnt add flag properties when locally evaluated flags are empty', async () => {
       mockedFetch.mockClear()
       expect(mockedFetch).toHaveBeenCalledTimes(0)
       mockedFetch.mockImplementation(
@@ -685,7 +685,7 @@ describe('PostHog Node.js', () => {
       expect(mockedFetch).not.toHaveBeenCalledWith(...anyLocalEvalCall)
     })
 
-    it.skip('manages memory well when sending feature flags', async () => {
+    it('manages memory well when sending feature flags', async () => {
       const flags = {
         flags: [
           {

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -581,8 +581,12 @@ describe('PostHog Node.js', () => {
           }),
         })
       )
-      expect(getLastBatchEvents()?.[0].properties.hasOwnProperty('$feature/beta-feature-local')).toBe(true)
-      expect(getLastBatchEvents()?.[0].properties.hasOwnProperty('$feature/beta-feature')).toBe(false)
+      expect(
+        Object.prototype.hasOwnProperty.call(getLastBatchEvents()?.[0].properties, '$feature/beta-feature-local')
+      ).toBe(true)
+      expect(Object.prototype.hasOwnProperty.call(getLastBatchEvents()?.[0].properties, '$feature/beta-feature')).toBe(
+        false
+      )
 
       await posthog.shutdownAsync()
     })
@@ -632,8 +636,12 @@ describe('PostHog Node.js', () => {
           }),
         })
       )
-      expect(getLastBatchEvents()?.[0].properties.hasOwnProperty('$feature/beta-feature-local')).toBe(false)
-      expect(getLastBatchEvents()?.[0].properties.hasOwnProperty('$feature/beta-feature')).toBe(false)
+      expect(
+        Object.prototype.hasOwnProperty.call(getLastBatchEvents()?.[0].properties, '$feature/beta-feature-local')
+      ).toBe(false)
+      expect(Object.prototype.hasOwnProperty.call(getLastBatchEvents()?.[0].properties, '$feature/beta-feature')).toBe(
+        false
+      )
 
       await posthog.shutdownAsync()
     })

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -43,7 +43,7 @@ describe('PostHog Node.js', () => {
 
   afterEach(async () => {
     // ensure clean shutdown & no test interdependencies
-    // await posthog.shutdownAsync()
+    await posthog.shutdownAsync()
   })
 
   describe('core methods', () => {
@@ -642,8 +642,6 @@ describe('PostHog Node.js', () => {
       expect(Object.prototype.hasOwnProperty.call(getLastBatchEvents()?.[0].properties, '$feature/beta-feature')).toBe(
         false
       )
-
-      await posthog.shutdownAsync()
     })
 
     it('captures feature flags with same geoip setting as capture', async () => {

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -385,76 +385,78 @@ describe('PostHog Node.js', () => {
       }
 
       const multivariateFlag = {
-        "id": 1,
-        "name": "Beta Feature",
-        "key": "beta-feature-local",
-        "is_simple_flag": false,
-        "active": true,
-        "rollout_percentage": 100,
-        "filters": {
-            "groups": [
-                {
-                    "properties": [
-                        {"key": "email", "type": "person", "value": "test@posthog.com", "operator": "exact"}
-                    ],
-                    "rollout_percentage": 100,
-                },
-                {
-                    "rollout_percentage": 50,
-                },
-            ],
-            "multivariate": {
-                "variants": [
-                    {"key": "first-variant", "name": "First Variant", "rollout_percentage": 50},
-                    {"key": "second-variant", "name": "Second Variant", "rollout_percentage": 25},
-                    {"key": "third-variant", "name": "Third Variant", "rollout_percentage": 25},
-                ]
+        id: 1,
+        name: 'Beta Feature',
+        key: 'beta-feature-local',
+        is_simple_flag: false,
+        active: true,
+        rollout_percentage: 100,
+        filters: {
+          groups: [
+            {
+              properties: [{ key: 'email', type: 'person', value: 'test@posthog.com', operator: 'exact' }],
+              rollout_percentage: 100,
             },
-            "payloads": {"first-variant": "some-payload", "third-variant": {"a": "json"}},
+            {
+              rollout_percentage: 50,
+            },
+          ],
+          multivariate: {
+            variants: [
+              { key: 'first-variant', name: 'First Variant', rollout_percentage: 50 },
+              { key: 'second-variant', name: 'Second Variant', rollout_percentage: 25 },
+              { key: 'third-variant', name: 'Third Variant', rollout_percentage: 25 },
+            ],
+          },
+          payloads: { 'first-variant': 'some-payload', 'third-variant': { a: 'json' } },
         },
-    }
+      }
       const basicFlag = {
-        "id": 1,
-        "name": "Beta Feature",
-        "key": "person-flag",
-        "is_simple_flag": true,
-        "active": true,
-        "filters": {
-            "groups": [
+        id: 1,
+        name: 'Beta Feature',
+        key: 'person-flag',
+        is_simple_flag: true,
+        active: true,
+        filters: {
+          groups: [
+            {
+              properties: [
                 {
-                    "properties": [
-                        {
-                            "key": "region",
-                            "operator": "exact",
-                            "value": ["USA"],
-                            "type": "person",
-                        }
-                    ],
-                    "rollout_percentage": 100,
-                }
-            ],
-            "payloads": {"true": 300},
+                  key: 'region',
+                  operator: 'exact',
+                  value: ['USA'],
+                  type: 'person',
+                },
+              ],
+              rollout_percentage: 100,
+            },
+          ],
+          payloads: { true: 300 },
         },
-    }
+      }
       const falseFlag = {
-        "id": 1,
-        "name": "Beta Feature",
-        "key": "false-flag",
-        "is_simple_flag": true,
-        "active": true,
-        "filters": {
-            "groups": [
-                {
-                    "properties": [],
-                    "rollout_percentage": 0,
-                }
-            ],
-            "payloads": {"true": 300},
+        id: 1,
+        name: 'Beta Feature',
+        key: 'false-flag',
+        is_simple_flag: true,
+        active: true,
+        filters: {
+          groups: [
+            {
+              properties: [],
+              rollout_percentage: 0,
+            },
+          ],
+          payloads: { true: 300 },
         },
-    }
-    
+      }
+
       mockedFetch.mockImplementation(
-        apiImplementation({ decideFlags: mockFeatureFlags, decideFlagPayloads: mockFeatureFlagPayloads, localFlags: {flags: [multivariateFlag, basicFlag, falseFlag]} })
+        apiImplementation({
+          decideFlags: mockFeatureFlags,
+          decideFlagPayloads: mockFeatureFlagPayloads,
+          localFlags: { flags: [multivariateFlag, basicFlag, falseFlag] },
+        })
       )
 
       posthog = new PostHog('TEST_API_KEY', {
@@ -583,16 +585,14 @@ describe('PostHog Node.js', () => {
       expect(getLastBatchEvents()?.[0].properties.hasOwnProperty('$feature/beta-feature')).toBe(false)
 
       await posthog.shutdownAsync()
-
     })
 
     it('doesnt add flag properties when locally evaluated flags are empty', async () => {
       mockedFetch.mockClear()
       expect(mockedFetch).toHaveBeenCalledTimes(0)
       mockedFetch.mockImplementation(
-        apiImplementation({ decideFlags: {'a': false, 'b': 'true'}, decideFlagPayloads: {}, localFlags: {flags: []} })
+        apiImplementation({ decideFlags: { a: false, b: 'true' }, decideFlagPayloads: {}, localFlags: { flags: [] } })
       )
-
 
       posthog = new PostHog('TEST_API_KEY', {
         host: 'http://example.com',

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -960,7 +960,7 @@ describe('PostHog Node.js', () => {
         groups: { company: 'id:5', instance: 'app.posthog.com' },
         personProperties: { x1: 'y1' },
         groupProperties: { company: { x: 'y' } },
-        })
+      })
       jest.runOnlyPendingTimers()
 
       expect(mockedFetch).toHaveBeenCalledWith(
@@ -986,7 +986,7 @@ describe('PostHog Node.js', () => {
       mockedFetch.mockClear()
 
       await posthog.getFeatureFlag('random_key', 'some_id', {
-        groups: {company: 'id:5', instance: 'app.posthog.com'},
+        groups: { company: 'id:5', instance: 'app.posthog.com' },
         personProperties: { $current_distinct_id: 'override' },
         groupProperties: { company: { $group_key: 'group_override' } },
       })
@@ -1007,8 +1007,9 @@ describe('PostHog Node.js', () => {
               instance: { $group_key: 'app.posthog.com' },
             },
             geoip_disable: true,
+          }),
         })
-      }))
+      )
 
       mockedFetch.mockClear()
 
@@ -1039,7 +1040,7 @@ describe('PostHog Node.js', () => {
 
       mockedFetch.mockClear()
       await posthog.getAllFlags('some_id', {
-        groups: { company: 'id:5'},
+        groups: { company: 'id:5' },
         personProperties: undefined,
         groupProperties: undefined,
       })
@@ -1051,12 +1052,12 @@ describe('PostHog Node.js', () => {
           body: JSON.stringify({
             token: 'TEST_API_KEY',
             distinct_id: 'some_id',
-            groups: { company: 'id:5'},
+            groups: { company: 'id:5' },
             person_properties: {
               $current_distinct_id: 'some_id',
             },
-            group_properties: { company: { $group_key: 'id:5' }},
-            geoip_disable: true
+            group_properties: { company: { $group_key: 'id:5' } },
+            geoip_disable: true,
           }),
         })
       )

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -342,23 +342,21 @@ describe('PostHog Node.js', () => {
       // all capture calls happen during shutdown
       const batchEvents = getLastBatchEvents()
       expect(batchEvents?.length).toEqual(2)
-      expect(batchEvents?.[batchEvents?.length - 1]).toMatchObject(
-        {
-          // last event in batch
-          distinct_id: '9',
-          event: 'test-event',
-          library: 'posthog-node',
-          library_version: '1.2.3',
-          properties: {
-            $lib: 'posthog-node',
-            $lib_version: '1.2.3',
-            $geoip_disable: true,
-            $active_feature_flags: [],
-          },
-          timestamp: expect.any(String),
-          type: 'capture',
+      expect(batchEvents?.[batchEvents?.length - 1]).toMatchObject({
+        // last event in batch
+        distinct_id: '9',
+        event: 'test-event',
+        library: 'posthog-node',
+        library_version: '1.2.3',
+        properties: {
+          $lib: 'posthog-node',
+          $lib_version: '1.2.3',
+          $geoip_disable: true,
+          $active_feature_flags: [],
         },
-      )
+        timestamp: expect.any(String),
+        type: 'capture',
+      })
       expect(10).toEqual(logSpy.mock.calls.filter((call) => call[1].includes('capture')).length)
       expect(3).toEqual(logSpy.mock.calls.filter((call) => call[1].includes('flush')).length)
       jest.useFakeTimers()


### PR DESCRIPTION
## Problem

Copy of https://github.com/PostHog/posthog-python/pull/106/

This turned out to be a lot trickier than expected, because I noticed a few issues. With the `sendFeatureFlags` capture option, it seems like we were dropping events, since on shutdown the feature flag promises aren't tracked for populating flag information, which means the capture is not enqueued.

I can't yet think of a better way to solve this right now, so we just start tracking flag promises from within capture as well, annnd flush again on shutdown after pending promises have resolved, to make sure all new capture events queued are sent as well.

I'm also moving a few more things that should've been based on the onError emitter, and fixed tests that incorrectly assumed this was working fine.

(cc: @marandaneto @benjackwhite have a look here too please?)
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
