### PR TITLE
chore: `$device_type` is now set to `Mobile`, `Desktop` or `Web` for all events

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.10.0 - 2024-01-08
+
+1. `$device_type` is now set to `Mobile`, `Desktop`, or `Web` for all events
+
 # 2.9.2 - 2023-12-21
 
 1. If `async-storage` or `expo-file-system` is not installed, the SDK will fallback to `persistence: memory` and log a warning

--- a/posthog-react-native/src/native-deps.tsx
+++ b/posthog-react-native/src/native-deps.tsx
@@ -10,7 +10,7 @@ import { PostHogCustomAppProperties, PostHogCustomAsyncStorage } from './types'
 export const getAppProperties = (): PostHogCustomAppProperties => {
   var deviceType = 'Mobile'
 
-  if (Platform.OS === 'macos' || Platform.OS === 'windows' ) {
+  if (Platform.OS === 'macos' || Platform.OS === 'windows') {
     deviceType = 'Desktop'
   } else if (Platform.OS === 'web') {
     deviceType = 'Web'

--- a/posthog-react-native/src/native-deps.tsx
+++ b/posthog-react-native/src/native-deps.tsx
@@ -8,8 +8,16 @@ import { OptionalReactNativeDeviceInfo } from './optional/OptionalReactNativeDev
 import { PostHogCustomAppProperties, PostHogCustomAsyncStorage } from './types'
 
 export const getAppProperties = (): PostHogCustomAppProperties => {
+  var deviceType = 'Mobile'
+
+  if (Platform.OS === 'macos' || Platform.OS === 'windows' ) {
+    deviceType = 'Desktop'
+  } else if (Platform.OS === 'web') {
+    deviceType = 'Web'
+  }
+
   const properties: PostHogCustomAppProperties = {
-    $device_type: Platform.OS,
+    $device_type: deviceType,
   }
 
   if (OptionalExpoApplication) {

--- a/posthog-react-native/src/types.ts
+++ b/posthog-react-native/src/types.ts
@@ -33,7 +33,7 @@ export interface PostHogCustomAppProperties {
   $device_manufacturer?: string | null
   /** Readable model name like "iPhone 12" */
   $device_name?: string | null
-  /** Same as Platform.OS ("android" | "ios") */
+  /** Device type ("Mobile" | "Desktop" | "Web") */
   $device_type?: string | null
   /** Operating system name like iOS or Android */
   $os_name?: string | null

--- a/posthog-react-native/test/posthog.spec.ts
+++ b/posthog-react-native/test/posthog.spec.ts
@@ -108,7 +108,7 @@ describe('PostHog React Native', () => {
       $app_namespace: 'mock',
       $app_version: 'mock',
       $device_manufacturer: 'mock',
-      $device_type: 'ios',
+      $device_type: 'Mobile',
       // $device_name: 'mock', (deleted)
       $os_name: 'mock',
       $os_version: 'mock',


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog-js-lite/issues/135
Helps with https://github.com/PostHog/posthog/issues/19341

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [X] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
