### PR TITLE
fix: update the logic of tag_name to prefer a ph-label from a parent …

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.10.1 - 2024-01-12
+
+1. The `tag_name` property of auto-captured events now uses the nearest `ph-label` from parent elements, if present.
+
 # 2.10.0 - 2024-01-08
 
 1. `$device_type` is now set to `Mobile`, `Desktop`, or `Web` for all events

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.10.1 - 2024-01-12
+# 2.10.1 - 2024-01-15
 
 1. The `tag_name` property of auto-captured events now uses the nearest `ph-label` from parent elements, if present.
 

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/src/autocapture.tsx
+++ b/posthog-react-native/src/autocapture.tsx
@@ -117,7 +117,7 @@ export const autocaptureFromTouchEvent = (e: any, posthog: PostHog, options: Pos
         // this element had a ph-label set, promote it to the lastLabel
         lastLabel = element[elAttrLabelKey]
       }
-      
+
       // if lastLabel is set, update this elements tag_name
       if (lastLabel) {
         element['tag_name'] = lastLabel

--- a/posthog-react-native/src/autocapture.tsx
+++ b/posthog-react-native/src/autocapture.tsx
@@ -105,6 +105,24 @@ export const autocaptureFromTouchEvent = (e: any, posthog: PostHog, options: Pos
   }
 
   if (elements.length) {
+    // The element that was tapped, may be a child (or grandchild of an element with a ph-label)
+    // In this case, the current labels applied obscure the ph-label
+    // To correct this, loop over the elements in reverse, and promote the ph-label
+    const elAttrLabelKey = `attr__${customLabelProp}`
+    let lastLabel: string | undefined = undefined
+
+    for (let i = elements.length - 1; i >= 0; i--) {
+      const element = elements[i]
+      if (element[elAttrLabelKey]) {
+        // this element had a ph-label set, promote it to the lastLabel
+        lastLabel = element[elAttrLabelKey]
+      }
+      
+      // if lastLabel is set, update this elements tag_name
+      if (lastLabel) {
+        element['tag_name'] = lastLabel
+      }
+    }
     posthog.autocapture('touch', elements, {
       $touch_x: e.nativeEvent.pageX,
       $touch_y: e.nativeEvent.pageY,

--- a/posthog-react-native/test/__snapshots__/autocapture.spec.ts.snap
+++ b/posthog-react-native/test/__snapshots__/autocapture.spec.ts.snap
@@ -12,16 +12,16 @@ Array [
     },
     Object {
       "$el_text": "I have the property \\"ph-label\\" which means touching me will be autocaptured with a specific label",
-      "attr__ph-label": "special-text",
       "attr__testID": "example-ph-label",
-      "tag_name": "special-text",
+      "tag_name": "higher-level-element",
     },
     Object {
       "attr__style": "backgroundColor:rgba(0,0,0,.1);padding:15;borderRadius:10;marginBottom:10",
-      "tag_name": "View",
+      "tag_name": "higher-level-element",
     },
     Object {
-      "tag_name": "View",
+      "attr__ph-label": "higher-level-element",
+      "tag_name": "higher-level-element",
     },
     Object {
       "attr__style": "flex:1",

--- a/posthog-react-native/test/data/autocapture-event.json
+++ b/posthog-react-native/test/data/autocapture-event.json
@@ -16,7 +16,6 @@
       "elementType": { "displayName": "Text" },
       "memoizedProps": {
         "testID": "example-ph-label",
-        "ph-label": "special-text",
         "children": "I have the property \"ph-label\" which means touching me will be autocaptured with a specific label"
       },
       "return": {
@@ -40,7 +39,9 @@
                 "memoizedProps": { "value": false },
                 "return": {
                   "elementType": { "displayName": "View" },
-                  "memoizedProps": {},
+                  "memoizedProps": {
+                    "ph-label": "higher-level-element"
+                  },
                   "return": {
                     "elementType": {},
                     "memoizedProps": {},


### PR DESCRIPTION
Improve `tag_name` when touch events are nested

## Problem

This addresses #145 

Specifically; when using react-native-gesture-handler, and the `ph-label` is set on a `TouchableOpacity` or similar, the label is obscured, because the touch event is triggered against a nested child.

An example of such a case:
```
<TouchableOpacity
      ph-label="my-label"
      onPress={() => ...}
    >
      <View style={...}>
        <Text style={...}>
          My Heading
        </Text>
        <Text style={...}>
My sub heading
</Text>
      </View>
    </TouchableOpacity>
```

## Changes

This change adds an additional pass over the selected elements to promote any ph-label from a parent onto a child.
In the case above, this would result in the nested `View` and `Text` children getting the `tag_name` 'my-label' rather than the current inferred value, be it the displayName or similar.

This change also works when there are multiple `ph-label` properties set in the tree, the nearest parent with a label is chosen.

In the case there is no `ph-label` the existing behaviour is preserved.

This change makes the display of these captured touches far more reasonable when viewing them in the dashboard - instead of "My Heading" being the tag_name attached to an event, the intended label is used.

It is worth noting, this could be considered a breaking change. The breaking nature is really quite minor, and it is unlikely the behaviour changing is depended upon, but the information presented in the dashboard could be different for any given touch before and after this release. 

Finally, it is also possible an event receives a tag_name that seems non sensical. Consider the following:

```
<ScrollView
ph-label="my-top-level-scroll"
>
<ManyNestedViews>
<TouchableOpacity
      onPress={() => ...}
    >
      <View style={...}>
        <Text style={...}>
          My Heading
        </Text>
        <Text style={...}>
My sub heading
</Text>
      </View>
    </TouchableOpacity>
</ManyNestedViews>
</ScrollView>
```

Here, when the `TouchableOpacity` receives the touch, the resulting tag_name will be 'my-top-level-scroll'. That could be quite confusing to say the least. This seems like a reasonable trade off since it seems like an anti-pattern to be using ph-label in this way.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
