### PR TITLE
Update README.md about Releasing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,3 @@ cd examples/example-node
 yarn && yarn start
 # example-expo has some buttons that will talk to this server
 ```
-
-## Publishing a new version
-
-1. Go to the appropriate `package.json` file. For example, for `posthog-node`, this is `posthog-node/package.json`.
-2. Bump the version number in the file.
-3. Add to `CHANGELOG.md` the relevant changes.
-4. On merge, a new version is published automatically thanks to the CI pipeline.


### PR DESCRIPTION
Releasing instructions is moved to https://github.com/PostHog/posthog-js-lite/blob/main/RELEASING.md md.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
