### PR TITLE
feat: Add eventId overriding options

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -414,7 +414,7 @@ export abstract class PostHogCoreStateless {
       library: this.getLibraryId(),
       library_version: this.getLibraryVersion(),
       timestamp: options?.timestamp ? options?.timestamp : currentISOTime(),
-      uuid: options?.eventId ? options.eventId : generateUUID(globalThis),
+      uuid: options?.uuid ? options.uuid : generateUUID(globalThis),
     }
 
     const addGeoipDisableProperty = options?.disableGeoip ?? this.disableGeoip

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -416,6 +416,10 @@ export abstract class PostHogCoreStateless {
       timestamp: options?.timestamp ? options?.timestamp : currentISOTime(),
     }
 
+    if (options?.eventId) {
+      message['event_id'] = options.eventId
+    }
+
     const addGeoipDisableProperty = options?.disableGeoip ?? this.disableGeoip
     if (addGeoipDisableProperty) {
       if (!message.properties) {

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -414,10 +414,7 @@ export abstract class PostHogCoreStateless {
       library: this.getLibraryId(),
       library_version: this.getLibraryVersion(),
       timestamp: options?.timestamp ? options?.timestamp : currentISOTime(),
-    }
-
-    if (options?.eventId) {
-      message['event_id'] = options.eventId
+      uuid: options?.eventId ? options.eventId : generateUUID(globalThis),
     }
 
     const addGeoipDisableProperty = options?.disableGeoip ?? this.disableGeoip

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -7,7 +7,7 @@ import {
   PosthogCoreOptions,
   PostHogEventProperties,
   PostHogPersistedProperty,
-  PosthogCaptureOptions,
+  PostHogCaptureOptions,
   JsonType,
 } from './types'
 import {
@@ -155,7 +155,7 @@ export abstract class PostHogCoreStateless {
   protected identifyStateless(
     distinctId: string,
     properties?: PostHogEventProperties,
-    options?: PosthogCaptureOptions
+    options?: PostHogCaptureOptions
   ): this {
     // The properties passed to identifyStateless are event properties.
     // To add person properties, pass in all person properties to the `$set` key.
@@ -176,7 +176,7 @@ export abstract class PostHogCoreStateless {
     distinctId: string,
     event: string,
     properties?: { [key: string]: any },
-    options?: PosthogCaptureOptions
+    options?: PostHogCaptureOptions
   ): this {
     const payload = this.buildPayload({ distinct_id: distinctId, event, properties })
     this.enqueue('capture', payload, options)
@@ -188,7 +188,7 @@ export abstract class PostHogCoreStateless {
     alias: string,
     distinctId: string,
     properties?: { [key: string]: any },
-    options?: PosthogCaptureOptions
+    options?: PostHogCaptureOptions
   ): this {
     const payload = this.buildPayload({
       event: '$create_alias',
@@ -211,7 +211,7 @@ export abstract class PostHogCoreStateless {
     groupType: string,
     groupKey: string | number,
     groupProperties?: PostHogEventProperties,
-    options?: PosthogCaptureOptions,
+    options?: PostHogCaptureOptions,
     distinctId?: string,
     eventProperties?: PostHogEventProperties
   ): this {
@@ -402,7 +402,7 @@ export abstract class PostHogCoreStateless {
   /***
    *** QUEUEING AND FLUSHING
    ***/
-  protected enqueue(type: string, _message: any, options?: PosthogCaptureOptions): void {
+  protected enqueue(type: string, _message: any, options?: PostHogCaptureOptions): void {
     if (this.optedOut) {
       this._events.emit(type, `Library is disabled. Not sending event. To re-enable, call posthog.optIn()`)
       return
@@ -748,7 +748,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
   /***
    *** TRACKING
    ***/
-  identify(distinctId?: string, properties?: PostHogEventProperties, options?: PosthogCaptureOptions): this {
+  identify(distinctId?: string, properties?: PostHogEventProperties, options?: PostHogCaptureOptions): this {
     const previousDistinctId = this.getDistinctId()
     distinctId = distinctId || previousDistinctId
 
@@ -775,7 +775,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     return this
   }
 
-  capture(event: string, properties?: { [key: string]: any }, options?: PosthogCaptureOptions): this {
+  capture(event: string, properties?: { [key: string]: any }, options?: PostHogCaptureOptions): this {
     const distinctId = this.getDistinctId()
 
     if (properties?.$groups) {
@@ -802,7 +802,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     eventType: string,
     elements: PostHogAutocaptureElement[],
     properties: PostHogEventProperties = {},
-    options?: PosthogCaptureOptions
+    options?: PostHogCaptureOptions
   ): this {
     const distinctId = this.getDistinctId()
     const payload = {
@@ -845,7 +845,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     groupType: string,
     groupKey: string | number,
     groupProperties?: PostHogEventProperties,
-    options?: PosthogCaptureOptions
+    options?: PostHogCaptureOptions
   ): this {
     this.groups({
       [groupType]: groupKey,
@@ -862,7 +862,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     groupType: string,
     groupKey: string | number,
     groupProperties?: PostHogEventProperties,
-    options?: PosthogCaptureOptions
+    options?: PostHogCaptureOptions
   ): this {
     const distinctId = this.getDistinctId()
 

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -60,7 +60,7 @@ export type PostHogFetchOptions = {
 // Check out posthog-js for these additional options and try to keep them in sync
 export type PosthogCaptureOptions = {
   /** If provided overrides the auto-generated event ID */
-  eventId?: string
+  uuid?: string
   /** If provided overrides the auto-generated timestamp */
   timestamp?: Date
   disableGeoip?: boolean

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -59,6 +59,9 @@ export type PostHogFetchOptions = {
 
 // Check out posthog-js for these additional options and try to keep them in sync
 export type PosthogCaptureOptions = {
+  /** If provided overrides the auto-generated event ID */
+  eventId?: string
+  /** If provided overrides the auto-generated timestamp */
   timestamp?: Date
   disableGeoip?: boolean
 }

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -58,7 +58,7 @@ export type PostHogFetchOptions = {
 }
 
 // Check out posthog-js for these additional options and try to keep them in sync
-export type PosthogCaptureOptions = {
+export type PostHogCaptureOptions = {
   /** If provided overrides the auto-generated event ID */
   uuid?: string
   /** If provided overrides the auto-generated timestamp */

--- a/posthog-core/test/posthog.identify.spec.ts
+++ b/posthog-core/test/posthog.identify.spec.ts
@@ -38,6 +38,7 @@ describe('PostHog Core', () => {
               },
             },
             timestamp: '2022-01-01T00:00:00.000Z',
+            uuid: expect.any(String),
             type: 'identify',
           },
         ],

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.6.0 - 2024-01-18
+
+1. Adds support for overriding the event `uuid`
+
 # 3.5.0 - 2024-01-09
 
 1. When local evaluation is enabled, we automatically add flag information to all events sent to PostHog, whenever possible. This makes it easier to use these events in experiments.

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -10,7 +10,7 @@ import {
   PostHogPersistedProperty,
 } from '../../posthog-core/src'
 import { PostHogMemoryStorage } from '../../posthog-core/src/storage-memory'
-import { EventMessageV1, GroupIdentifyMessage, IdentifyMessageV1, PostHogNodeV1 } from './types'
+import { EventMessage, GroupIdentifyMessage, IdentifyMessage, PostHogNodeV1 } from './types'
 import { FeatureFlagsPoller } from './feature-flags'
 import fetch from './fetch'
 
@@ -100,9 +100,18 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
     this.featureFlagsPoller?.debug(enabled)
   }
 
-  capture({ distinctId, event, properties, groups, sendFeatureFlags, timestamp, disableGeoip }: EventMessageV1): void {
-    const _capture = (props: EventMessageV1['properties']): void => {
-      super.captureStateless(distinctId, event, props, { timestamp, disableGeoip })
+  capture({
+    distinctId,
+    event,
+    properties,
+    groups,
+    sendFeatureFlags,
+    timestamp,
+    disableGeoip,
+    uuid,
+  }: EventMessage): void {
+    const _capture = (props: EventMessage['properties']): void => {
+      super.captureStateless(distinctId, event, props, { timestamp, disableGeoip, uuid })
     }
 
     // :TRICKY: If we flush, or need to shut down, to not lose events we want this promise to resolve before we flush
@@ -155,7 +164,7 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
     this.addPendingPromise(capturePromise)
   }
 
-  identify({ distinctId, properties, disableGeoip }: IdentifyMessageV1): void {
+  identify({ distinctId, properties, disableGeoip }: IdentifyMessage): void {
     // Catch properties passed as $set and move them to the top level
     const personProperties = properties?.$set || properties
 

--- a/posthog-node/src/types.ts
+++ b/posthog-node/src/types.ts
@@ -1,16 +1,17 @@
 import { JsonType } from '../../posthog-core/src'
 
-export interface IdentifyMessageV1 {
+export interface IdentifyMessage {
   distinctId: string
   properties?: Record<string | number, any>
   disableGeoip?: boolean
 }
 
-export interface EventMessageV1 extends IdentifyMessageV1 {
+export interface EventMessage extends IdentifyMessage {
   event: string
   groups?: Record<string, string | number> // Mapping of group type to group id
   sendFeatureFlags?: boolean
   timestamp?: Date
+  uuid?: string
 }
 
 export interface GroupIdentifyMessage {
@@ -75,7 +76,7 @@ export type PostHogNodeV1 = {
    * @param groups OPTIONAL | object of what groups are related to this event, example: { company: 'id:5' }. Can be used to analyze companies instead of users.
    * @param sendFeatureFlags OPTIONAL | Used with experiments. Determines whether to send feature flag values with the event.
    */
-  capture({ distinctId, event, properties, groups, sendFeatureFlags }: EventMessageV1): void
+  capture({ distinctId, event, properties, groups, sendFeatureFlags }: EventMessage): void
 
   /**
    * @description Identify lets you add metadata on your users so you can more easily identify who they are in PostHog,
@@ -84,7 +85,7 @@ export type PostHogNodeV1 = {
    * @param distinctId which uniquely identifies your user
    * @param properties with a dict with any key: value pairs
    */
-  identify({ distinctId, properties }: IdentifyMessageV1): void
+  identify({ distinctId, properties }: IdentifyMessage): void
 
   /**
    * @description To marry up whatever a user does before they sign up or log in with what they do after you need to make an alias call.

--- a/posthog-node/test/extensions/sentry-integration.spec.ts
+++ b/posthog-node/test/extensions/sentry-integration.spec.ts
@@ -146,6 +146,7 @@ describe('PostHogSentryIntegration', () => {
         library: 'posthog-node',
         library_version: '1.2.3',
         timestamp: expect.any(String),
+        uuid: expect.any(String),
       },
     ])
   })

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -4,6 +4,7 @@ jest.mock('../src/fetch')
 import fetch from '../src/fetch'
 import { anyDecideCall, anyLocalEvalCall, apiImplementation } from './feature-flags.spec'
 import { waitForPromises, wait } from '../../posthog-core/test/test-utils/test-utils'
+import { generateUUID } from 'posthog-core/src/utils'
 
 jest.mock('../package.json', () => ({ version: '1.2.3' }))
 
@@ -66,6 +67,7 @@ describe('PostHog Node.js', () => {
             $lib: 'posthog-node',
             $lib_version: '1.2.3',
           },
+          uuid: expect.any(String),
           timestamp: expect.any(String),
           type: 'capture',
           library: 'posthog-node',
@@ -185,6 +187,24 @@ describe('PostHog Node.js', () => {
           distinct_id: '123',
           timestamp: '2021-02-03T00:00:00.000Z',
           event: 'custom-time',
+          uuid: expect.any(String),
+        },
+      ])
+    })
+
+    it('should allow overriding uuid', async () => {
+      expect(mockedFetch).toHaveBeenCalledTimes(0)
+      const uuid = generateUUID()
+      posthog.capture({ event: 'custom-time', distinctId: '123', uuid })
+      await waitForPromises()
+      jest.runOnlyPendingTimers()
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents).toMatchObject([
+        {
+          distinct_id: '123',
+          timestamp: expect.any(String),
+          event: 'custom-time',
+          uuid: uuid,
         },
       ])
     })

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.11.0 - 2024-01-18
+
+1. Adds support for overriding the event `uuid` via capture options
+
 # 2.10.1 - 2024-01-15
 
 1. The `tag_name` property of auto-captured events now uses the nearest `ph-label` from parent elements, if present.

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,13 +1,13 @@
 {
   "name": "posthog-react-native",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"
   ],
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/PostHog/posthog-js-lite.git",
+    "type": "git",
+    "url": "https://github.com/PostHog/posthog-js-lite.git",
     "directory": "posthog-react-native"
   },
   "scripts": {

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -1,7 +1,7 @@
 import { AppState, Dimensions, Linking } from 'react-native'
 
 import {
-  PosthogCaptureOptions,
+  PostHogCaptureOptions,
   PostHogCore,
   PosthogCoreOptions,
   PostHogFetchOptions,
@@ -171,7 +171,7 @@ export class PostHog extends PostHogCore {
   }
 
   // Custom methods
-  screen(name: string, properties: { [key: string]: any }, options?: PosthogCaptureOptions): this {
+  screen(name: string, properties?: { [key: string]: any }, options?: PostHogCaptureOptions): this {
     // Screen name is good to know for all other subsequent events
     this.registerForSession({
       $screen_name: name,

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -1,6 +1,7 @@
 import { AppState, Dimensions, Linking } from 'react-native'
 
 import {
+  PosthogCaptureOptions,
   PostHogCore,
   PosthogCoreOptions,
   PostHogFetchOptions,
@@ -170,16 +171,20 @@ export class PostHog extends PostHogCore {
   }
 
   // Custom methods
-  screen(name: string, properties?: any): this {
+  screen(name: string, properties: { [key: string]: any }, options?: PosthogCaptureOptions): this {
     // Screen name is good to know for all other subsequent events
     this.registerForSession({
       $screen_name: name,
     })
 
-    return this.capture('$screen', {
-      ...properties,
-      $screen_name: name,
-    })
+    return this.capture(
+      '$screen',
+      {
+        ...properties,
+        $screen_name: name,
+      },
+      options
+    )
   }
 
   initReactNativeNavigation(options: PostHogAutocaptureOptions): boolean {

--- a/posthog-react-native/src/types.ts
+++ b/posthog-react-native/src/types.ts
@@ -1,6 +1,6 @@
 export type PostHogAutocaptureNavigationTrackerOptions = {
   routeToName?: (name: string, params: any) => string
-  routeToProperties?: (name: string, params: any) => string
+  routeToProperties?: (name: string, params: any) => Record<string, any>
 }
 
 export type PostHogAutocaptureOptions = {

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.6.0 - 2024-01-18
+
+1. Adds support for overriding the event `uuid` via capture options
+
 # 2.5.0 - 2023-12-04
 
 1.  Renamed `personProperties` to `setPersonPropertiesForFlags` to match `posthog-js` and more clearly indicated what it does

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -1,12 +1,12 @@
 {
   "name": "posthog-js-lite",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/PostHog/posthog-js-lite.git",
+    "type": "git",
+    "url": "https://github.com/PostHog/posthog-js-lite.git",
     "directory": "posthog-web"
   },
   "scripts": {


### PR DESCRIPTION
## Problem

Some people want to override the eventId to do things like deduplication

## Changes

* Adds a default uuid
* Accepts the override option

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added the ability to override the event ID via the extra options argument in capture calls
