### PR TITLE
fix: if react-native-device-info is available for the Web target, do not set unknown for all properties

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+1. if `react-native-device-info` is available for the Web target, do not set `unknown` for all properties.
+
 # 2.10.0 - 2024-01-08
 
 1. `$device_type` is now set to `Mobile`, `Desktop`, or `Web` for all events

--- a/posthog-react-native/src/native-deps.tsx
+++ b/posthog-react-native/src/native-deps.tsx
@@ -40,17 +40,25 @@ export const getAppProperties = (): PostHogCustomAppProperties => {
   }
 
   if (OptionalReactNativeDeviceInfo) {
-    properties.$app_build = OptionalReactNativeDeviceInfo.getBuildIdSync()
-    properties.$app_name = OptionalReactNativeDeviceInfo.getApplicationName()
-    properties.$app_namespace = OptionalReactNativeDeviceInfo.getBundleId()
-    properties.$app_version = OptionalReactNativeDeviceInfo.getVersion()
-    properties.$device_manufacturer = OptionalReactNativeDeviceInfo.getManufacturerSync()
-    properties.$device_name = OptionalReactNativeDeviceInfo.getDeviceNameSync()
-    properties.$os_name = OptionalReactNativeDeviceInfo.getSystemName()
-    properties.$os_version = OptionalReactNativeDeviceInfo.getSystemVersion()
+    properties.$app_build = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getBuildIdSync())
+    properties.$app_name = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getApplicationName())
+    properties.$app_namespace = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getBundleId())
+    properties.$app_version = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getVersion())
+    properties.$device_manufacturer = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getManufacturerSync())
+    properties.$device_name = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getDeviceNameSync())
+    properties.$os_name = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getSystemName())
+    properties.$os_version = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getSystemVersion())
   }
 
   return properties
+}
+
+// react-native-device-info returns 'unknown' if the property is not available (Web target)
+const returnPropertyIfNotUnknown = (value: string | null): string | null => {
+  if (value !== 'unknown') {
+    return value
+  }
+  return null
 }
 
 export const buildOptimisiticAsyncStorage = (): PostHogCustomAsyncStorage => {

--- a/posthog-react-native/src/optional/OptionalExpoFileSystem.ts
+++ b/posthog-react-native/src/optional/OptionalExpoFileSystem.ts
@@ -3,5 +3,5 @@ import type ExpoFileSystem from 'expo-file-system'
 export let OptionalExpoFileSystem: typeof ExpoFileSystem | undefined = undefined
 
 try {
-  OptionalExpoFileSystem = require('expo-file-system')
+  OptionalExpoFileSystem = require('expo-file-system') // No Web support
 } catch (e) {}

--- a/posthog-react-native/src/optional/OptionalReactNativeDeviceInfo.ts
+++ b/posthog-react-native/src/optional/OptionalReactNativeDeviceInfo.ts
@@ -3,5 +3,5 @@ import type ReactNativeDeviceInfo from 'react-native-device-info'
 export let OptionalReactNativeDeviceInfo: typeof ReactNativeDeviceInfo | undefined = undefined
 
 try {
-  OptionalReactNativeDeviceInfo = require('react-native-device-info')
+  OptionalReactNativeDeviceInfo = require('react-native-device-info')  // No Web support
 } catch (e) {}

--- a/posthog-react-native/src/optional/OptionalReactNativeDeviceInfo.ts
+++ b/posthog-react-native/src/optional/OptionalReactNativeDeviceInfo.ts
@@ -3,5 +3,5 @@ import type ReactNativeDeviceInfo from 'react-native-device-info'
 export let OptionalReactNativeDeviceInfo: typeof ReactNativeDeviceInfo | undefined = undefined
 
 try {
-  OptionalReactNativeDeviceInfo = require('react-native-device-info')  // No Web support
+  OptionalReactNativeDeviceInfo = require('react-native-device-info') // No Web support
 } catch (e) {}


### PR DESCRIPTION
## Problem
<img width="1040" alt="Screenshot 2024-01-22 at 16 34 50" src="https://github.com/PostHog/posthog-js-lite/assets/5731772/1b87651f-2ff2-4db9-9b3f-8f0b752bbab4">

fix: if react-native-device-info is available for the Web target, do not set unknown for all properties
Relates to https://github.com/PostHog/posthog-js-lite/issues/140

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
