### PR TITLE
fix: Do not try to load the expo-file-system package on the Web target since it's not supported

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+1. Do not try to load the `expo-file-system` package on the Web target since it's not supported.
+
 # 2.10.1 - 2024-01-15
 
 1. The `tag_name` property of auto-captured events now uses the nearest `ph-label` from parent elements, if present.

--- a/posthog-react-native/src/optional/OptionalExpoFileSystem.ts
+++ b/posthog-react-native/src/optional/OptionalExpoFileSystem.ts
@@ -1,7 +1,15 @@
 import type ExpoFileSystem from 'expo-file-system'
+import { Platform } from 'react-native'
 
 export let OptionalExpoFileSystem: typeof ExpoFileSystem | undefined = undefined
 
 try {
-  OptionalExpoFileSystem = require('expo-file-system')
+  // do not try to load expo-file-system on web, otherwise it will throw an error
+  // Error: The method or property expo-file-system.writeAsStringAsync is not available on web
+  // See https://github.com/PostHog/posthog-js-lite/issues/140
+  // Once expo-file-system is supported on web, we can remove this try/catch block
+  // For now, use the react-native-async-storage/async-storage package instead
+  if (Platform.OS !== 'web') {
+    OptionalExpoFileSystem = require('expo-file-system') // No Web support
+  }
 } catch (e) {}


### PR DESCRIPTION
## Problem

fix: Do not try to load the expo-file-system package on the Web target since it's not supported

If the `expo-file-system` target is installed on RN Web, the module is loaded but its methods aren't supported leading to errors.
Closes https://github.com/PostHog/posthog-js-lite/issues/140

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
