### PR TITLE
fix: changed platform detection method to select

### DIFF
--- a/posthog-react-native/src/optional/OptionalExpoFileSystem.ts
+++ b/posthog-react-native/src/optional/OptionalExpoFileSystem.ts
@@ -9,7 +9,9 @@ try {
   // See https://github.com/PostHog/posthog-js-lite/issues/140
   // Once expo-file-system is supported on web/macos, we can remove this try/catch block
   // For now, use the react-native-async-storage/async-storage package instead
-  if (Platform.OS !== 'web' && Platform.OS !== 'macos') {
-    OptionalExpoFileSystem = require('expo-file-system')
-  }
+  OptionalExpoFileSystem = Platform.select({
+    web: undefined,
+    macos: undefined,
+    default: require('expo-file-system'),
+  })
 } catch (e) {}


### PR DESCRIPTION
## Problem
This PR fixes https://github.com/PostHog/posthog-js-lite/issues/164

## Changes
changed the logic for checking the Platform from the original `Platform.OS` + `if` statement to `Platform.select`.

## Release info Sub-libraries affected
nth
### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [x] posthog-react-native

### Changelog notes
