### PR TITLE
fix: app_build was returning the OS internal build number instead of the app's build number

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Next
+
+1. `$app_build` was returning the OS internal build number instead of the app's build number.
+  1. This this flag was used to track app versions, you might experience a sudden increase of `Application Updated` events.
+
 # 2.11.3 - 2024-02-08
 
 1. Vendor `uuidv7` instead of using peer dependency to avoid the missing crypto issue

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Next
 
 1. `$app_build` was returning the OS internal build number instead of the app's build number.
-  1. This this flag was used to track app versions, you might experience a sudden increase of `Application Updated` events.
+  1. This flag was used to track app versions, you might experience a sudden increase of `Application Updated` events, but only if you're using the `react-native-device-info` library.
 
 # 2.11.3 - 2024-02-08
 

--- a/posthog-react-native/src/native-deps.tsx
+++ b/posthog-react-native/src/native-deps.tsx
@@ -40,7 +40,7 @@ export const getAppProperties = (): PostHogCustomAppProperties => {
   }
 
   if (OptionalReactNativeDeviceInfo) {
-    properties.$app_build = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getBuildIdSync())
+    properties.$app_build = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getBuildNumber())
     properties.$app_name = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getApplicationName())
     properties.$app_namespace = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getBundleId())
     properties.$app_version = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getVersion())


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog-js-lite/pull/172/files#r1481614909

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
