### PR TITLE
chore: remove PostHog.initAsync warning

### DIFF
--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -64,8 +64,6 @@ export class PostHog extends PostHogCore {
       }
 
       clientMap.set(apiKey, posthog)
-    } else {
-      console.warn('PostHog.initAsync called twice with the same apiKey. The first instance will be used.')
     }
 
     const resolved = await posthog


### PR DESCRIPTION
## Problem

The recommended way to set up PostHog for React Native is to use the PostHogProvider. Indeed that is true
However while using it like that we are facing console warning which annoys and distracts from really important things.

Folks [here](https://github.com/PostHog/posthog-js-lite/issues/114) already reported about this problem

## Changes

Just removed console.warn. It more harms than helps, you already did a great job to prevent re-initialization, so I don't think that warning helps

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [x] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Removed "PostHog.initAsync called twice with the same apiKey" console warning
