### PR TITLE
device_name was set to devices user name for all events wrongly

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+1. `$device_name` was set to the device's user name (eg Max's iPhone) for all events wrongly, it's now set to the device's name (eg iPhone 12), this happened only if using `react-native-device-info` library.
+
 # 2.11.5 - 2024-02-20
 
 1. fix: undefined posthog in hooks

--- a/posthog-react-native/src/native-deps.tsx
+++ b/posthog-react-native/src/native-deps.tsx
@@ -29,6 +29,7 @@ export const getAppProperties = (): PostHogCustomAppProperties => {
 
   if (OptionalExpoDevice) {
     properties.$device_manufacturer = OptionalExpoDevice.manufacturer
+    // expo-device already maps the device model identifier to a human readable name
     properties.$device_name = OptionalExpoDevice.modelName
     properties.$os_name = OptionalExpoDevice.osName
     properties.$os_version = OptionalExpoDevice.osVersion
@@ -45,7 +46,8 @@ export const getAppProperties = (): PostHogCustomAppProperties => {
     properties.$app_namespace = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getBundleId())
     properties.$app_version = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getVersion())
     properties.$device_manufacturer = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getManufacturerSync())
-    properties.$device_name = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getDeviceNameSync())
+    // react-native-device-info already maps the device model identifier to a human readable name
+    properties.$device_name = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getModel())
     properties.$os_name = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getSystemName())
     properties.$os_version = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getSystemVersion())
   }

--- a/posthog-react-native/src/types.ts
+++ b/posthog-react-native/src/types.ts
@@ -31,8 +31,10 @@ export interface PostHogCustomAppProperties {
   $app_version?: string | null
   /** Manufacturer like "Apple", "Samsung" or "Android" */
   $device_manufacturer?: string | null
-  /** Readable model name like "iPhone 12" */
+  /** Readable model name like "iPhone 12" or "Samsung Galaxy S24" */
   $device_name?: string | null
+  /** Model identifier like "iPhone13,2" or "SM-S921B" */
+  $device_model?: string | null
   /** Device type ("Mobile" | "Desktop" | "Web") */
   $device_type?: string | null
   /** Operating system name like iOS or Android */


### PR DESCRIPTION
## Problem

https://github.com/react-native-device-info/react-native-device-info/blob/e46a5d4dba4e7d1f5e1da8b17c82829600f84d77/ios/RNDeviceInfo/RNDeviceInfo.m#L310-L333 is the correct method.
Instead of 

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
