### PR TITLE
fix: Promise comparison issue

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 1. `$device_name` was set to the device's user name (eg Max's iPhone) for all events wrongly, it's now set to the device's name (eg iPhone 12), this happened only if using `react-native-device-info` library.
+2. Fixes an issue related to other dependencies patching the global Promise object that could lead to crashes
 
 # 2.11.5 - 2024-02-20
 
@@ -10,7 +11,7 @@
 
 1. fix: using `captureMode=form` won't throw an error and retry unnecessarily
 2. `$app_build` was returning the OS internal build number instead of the app's build number.
-  1. This flag was used to track app versions, you might experience a sudden increase of `Application Updated` events, but only if you're using the `react-native-device-info` library.
+3. This flag was used to track app versions, you might experience a sudden increase of `Application Updated` events, but only if you're using the `react-native-device-info` library.
 
 # 2.11.3 - 2024-02-08
 


### PR DESCRIPTION
## Problem

See https://github.com/PostHog/posthog-js-lite/issues/182

Potentially the issue comes from a race condition with other SDKs patching the global Promise object in a way that breaks the `instanceof` check.

## Changes

* Swaps to use a simpler ".then" check instead which is more than good enough for our use case.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [x] posthog-react-native

### Changelog notes

(Added)