### PR TITLE
chore: add retry default comments and fix misconfig default

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -91,9 +91,10 @@ export abstract class PostHogCoreStateless {
     // If enable is explicitly set to false we override the optout
     this.defaultOptIn = options?.defaultOptIn ?? true
 
+    // when changing the default, make sure to update the retriable method as well
     this._retryOptions = {
       retryCount: options?.fetchRetryCount ?? 3,
-      retryDelay: options?.fetchRetryDelay ?? 3000,
+      retryDelay: options?.fetchRetryDelay ?? 3000, // 3 seconds
       retryCheck: isPostHogFetchError,
     }
     this.requestTimeout = options?.requestTimeout ?? 10000 // 10 seconds

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -44,7 +44,7 @@ class PostHogFetchNetworkError extends Error {
 }
 
 function isPostHogFetchError(err: any): boolean {
-  return typeof err === 'object' && (err.name === 'PostHogFetchHttpError' || err.name === 'PostHogFetchNetworkError')
+  return typeof err === 'object' && (err instanceof PostHogFetchHttpError || err instanceof PostHogFetchNetworkError)
 }
 
 export abstract class PostHogCoreStateless {

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -91,7 +91,6 @@ export abstract class PostHogCoreStateless {
     // If enable is explicitly set to false we override the optout
     this.defaultOptIn = options?.defaultOptIn ?? true
 
-    // when changing the default, make sure to update the retriable method as well
     this._retryOptions = {
       retryCount: options?.fetchRetryCount ?? 3,
       retryDelay: options?.fetchRetryDelay ?? 3000, // 3 seconds
@@ -582,11 +581,7 @@ export abstract class PostHogCoreStateless {
     })
   }
 
-  private async fetchWithRetry(
-    url: string,
-    options: PostHogFetchOptions,
-    retryOptions?: RetriableOptions
-  ): Promise<PostHogFetchResponse> {
+  private async fetchWithRetry(url: string, options: PostHogFetchOptions): Promise<PostHogFetchResponse> {
     ;(AbortSignal as any).timeout ??= function timeout(ms: number) {
       const ctrl = new AbortController()
       setTimeout(() => ctrl.abort(), ms)
@@ -614,7 +609,7 @@ export abstract class PostHogCoreStateless {
         }
         return res
       },
-      { ...this._retryOptions, ...retryOptions }
+      { ...this._retryOptions }
     )
   }
 

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -20,9 +20,9 @@ export type PostHogCoreOptions = {
     featureFlags?: Record<string, boolean | string>
     featureFlagPayloads?: Record<string, JsonType>
   }
-  /** How many times we will retry HTTP requests */
+  /** How many times we will retry HTTP requests. Defaults to 3. */
   fetchRetryCount?: number
-  /** The delay between HTTP request retries */
+  /** The delay between HTTP request retries, Defaults to 3 seconds. */
   fetchRetryDelay?: number
   /** Timeout in milliseconds for any calls. Defaults to 10 seconds. */
   requestTimeout?: number

--- a/posthog-core/src/utils.ts
+++ b/posthog-core/src/utils.ts
@@ -15,7 +15,12 @@ export interface RetriableOptions {
 }
 
 export async function retriable<T>(fn: () => Promise<T>, props: RetriableOptions = {}): Promise<T> {
-  const { retryCount = 3, retryDelay = 5000, retryCheck = () => true } = props
+  const {
+    retryCount = 3,
+    // 3s
+    retryDelay = 3000,
+    retryCheck = () => true,
+  } = props
   let lastError = null
 
   for (let i = 0; i < retryCount + 1; i++) {

--- a/posthog-core/src/utils.ts
+++ b/posthog-core/src/utils.ts
@@ -9,24 +9,18 @@ export function removeTrailingSlash(url: string): string {
 }
 
 export interface RetriableOptions {
-  retryCount?: number
-  retryDelay?: number
-  retryCheck?: (err: any) => boolean
+  retryCount: number
+  retryDelay: number
+  retryCheck: (err: any) => boolean
 }
 
-export async function retriable<T>(fn: () => Promise<T>, props: RetriableOptions = {}): Promise<T> {
-  const {
-    retryCount = 3,
-    // 3s
-    retryDelay = 3000,
-    retryCheck = () => true,
-  } = props
+export async function retriable<T>(fn: () => Promise<T>, props: RetriableOptions): Promise<T> {
   let lastError = null
 
-  for (let i = 0; i < retryCount + 1; i++) {
+  for (let i = 0; i < props.retryCount + 1; i++) {
     if (i > 0) {
       // don't wait when it's the last try
-      await new Promise((r) => setTimeout(r, retryDelay))
+      await new Promise((r) => setTimeout(r, props.retryDelay))
     }
 
     try {
@@ -34,7 +28,7 @@ export async function retriable<T>(fn: () => Promise<T>, props: RetriableOptions
       return res
     } catch (e) {
       lastError = e
-      if (!retryCheck(e)) {
+      if (!props.retryCheck(e)) {
         throw e
       }
     }

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -17,7 +17,7 @@ import fetch from './fetch'
 export type PostHogOptions = PostHogCoreOptions & {
   persistence?: 'memory'
   personalApiKey?: string
-  // The interval in milliseconds between polls for refreshing feature flag definitions
+  // The interval in milliseconds between polls for refreshing feature flag definitions. Defaults to 30 seconds.
   featureFlagsPollingInterval?: number
   // Timeout in milliseconds for any calls. Defaults to 10 seconds.
   requestTimeout?: number


### PR DESCRIPTION
## Problem

There was a mismatch of the default retry timeout depending on the code path.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [X] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
