### PR TITLE
fix(flags): Add a shorter timeout, disable retries for flags

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -584,7 +584,12 @@ export abstract class PostHogCoreStateless {
     })
   }
 
-  private async fetchWithRetry(url: string, options: PostHogFetchOptions, retryOptions?: Partial<RetriableOptions>, requestTimeout?: number): Promise<PostHogFetchResponse> {
+  private async fetchWithRetry(
+    url: string,
+    options: PostHogFetchOptions,
+    retryOptions?: Partial<RetriableOptions>,
+    requestTimeout?: number
+  ): Promise<PostHogFetchResponse> {
     ;(AbortSignal as any).timeout ??= function timeout(ms: number) {
       const ctrl = new AbortController()
       setTimeout(() => ctrl.abort(), ms)

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -27,7 +27,7 @@ export type PostHogCoreOptions = {
   /** Timeout in milliseconds for any calls. Defaults to 10 seconds. */
   requestTimeout?: number
   /** Timeout in milliseconds for feature flag calls. Defaults to 3 seconds. */
-  featureFlagsRequestTimeout?: number
+  featureFlagsRequestTimeoutMs?: number
   /** For Session Analysis how long before we expire a session (defaults to 30 mins) */
   sessionExpirationTimeSeconds?: number
   /** Whether to post events to PostHog in JSON or compressed format */

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -26,6 +26,8 @@ export type PostHogCoreOptions = {
   fetchRetryDelay?: number
   /** Timeout in milliseconds for any calls. Defaults to 10 seconds. */
   requestTimeout?: number
+  /** Timeout in milliseconds for feature flag calls. Defaults to 3 seconds. */
+  featureFlagsRequestTimeout?: number
   /** For Session Analysis how long before we expire a session (defaults to 30 mins) */
   sessionExpirationTimeSeconds?: number
   /** Whether to post events to PostHog in JSON or compressed format */

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -26,7 +26,7 @@ export type PostHogCoreOptions = {
   fetchRetryDelay?: number
   /** Timeout in milliseconds for any calls. Defaults to 10 seconds. */
   requestTimeout?: number
-  /** Timeout in milliseconds for feature flag calls. Defaults to 3 seconds. */
+  /** Timeout in milliseconds for feature flag calls. Defaults to 10 seconds for stateful clients, and 3 seconds for stateless. */
   featureFlagsRequestTimeoutMs?: number
   /** For Session Analysis how long before we expire a session (defaults to 30 mins) */
   sessionExpirationTimeSeconds?: number

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Adds a `disabled` option and the ability to change it later via `posthog.disabled = true`. Useful for disabling PostHog tracking for example in a testing environment without having complex conditional checking
 - Fixes some typos in types
 - `shutdown` and `shutdownAsync` takes a `shutdownTimeoutMs` param with a default of 30000 (30s). This is the time to wait for flushing events before shutting down the client. If the timeout is reached, the client will be shut down regardless of pending events.
-- Adds a new `featureFlagsRequestTimeout` timeout parameter for feature flags which defaults to 3 seconds, updated from the default 10s for all other API calls.
+- Adds a new `featureFlagsRequestTimeoutMs` timeout parameter for feature flags which defaults to 3 seconds, updated from the default 10s for all other API calls.
 
 # 3.6.3 - 2024-02-15
 

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Adds a `disabled` option and the ability to change it later via `posthog.disabled = true`. Useful for disabling PostHog tracking for example in a testing environment without having complex conditional checking
 - Fixes some typos in types
 - `shutdown` and `shutdownAsync` takes a `shutdownTimeoutMs` param with a default of 30000 (30s). This is the time to wait for flushing events before shutting down the client. If the timeout is reached, the client will be shut down regardless of pending events.
+- Adds a new `featureFlagsRequestTimeout` timeout parameter for feature flags which defaults to 3 seconds, updated from the default 10s for all other API calls.
 
 # 3.6.3 - 2024-02-15
 

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -113,7 +113,11 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
       super.captureStateless(distinctId, event, props, { timestamp, disableGeoip, uuid })
     }
 
-    const _getFlags = (distinctId: EventMessage['distinctId'], groups: EventMessage['groups'], disableGeoip: EventMessage['disableGeoip']): Promise<PostHogDecideResponse['featureFlags'] | undefined> => {
+    const _getFlags = (
+      distinctId: EventMessage['distinctId'],
+      groups: EventMessage['groups'],
+      disableGeoip: EventMessage['disableGeoip']
+    ): Promise<PostHogDecideResponse['featureFlags'] | undefined> => {
       return super.getFeatureFlagsStateless(distinctId, groups, undefined, undefined, disableGeoip)
     }
 

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -4,6 +4,7 @@ import {
   JsonType,
   PostHogCoreOptions,
   PostHogCoreStateless,
+  PostHogDecideResponse,
   PostHogFetchOptions,
   PostHogFetchResponse,
   PostHogFlagsAndPayloadsResponse,
@@ -19,8 +20,6 @@ export type PostHogOptions = PostHogCoreOptions & {
   personalApiKey?: string
   // The interval in milliseconds between polls for refreshing feature flag definitions. Defaults to 30 seconds.
   featureFlagsPollingInterval?: number
-  // Timeout in milliseconds for any calls. Defaults to 10 seconds.
-  requestTimeout?: number
   // Maximum size of cache that deduplicates $feature_flag_called calls per user.
   maxCacheSize?: number
   fetch?: (url: string, options: PostHogFetchOptions) => Promise<PostHogFetchResponse>
@@ -114,12 +113,16 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
       super.captureStateless(distinctId, event, props, { timestamp, disableGeoip, uuid })
     }
 
+    const _getFlags = (distinctId: EventMessage['distinctId'], groups: EventMessage['groups'], disableGeoip: EventMessage['disableGeoip']): Promise<PostHogDecideResponse['featureFlags'] | undefined> => {
+      return super.getFeatureFlagsStateless(distinctId, groups, undefined, undefined, disableGeoip)
+    }
+
     // :TRICKY: If we flush, or need to shut down, to not lose events we want this promise to resolve before we flush
     const capturePromise = Promise.resolve()
       .then(async () => {
         if (sendFeatureFlags) {
           // If we are sending feature flags, we need to make sure we have the latest flags
-          return await super.getFeatureFlagsStateless(distinctId, groups, undefined, undefined, disableGeoip)
+          return await _getFlags(distinctId, groups, disableGeoip)
         }
 
         if ((this.featureFlagsPoller?.featureFlags?.length || 0) > 0) {

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -126,6 +126,7 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
       .then(async () => {
         if (sendFeatureFlags) {
           // If we are sending feature flags, we need to make sure we have the latest flags
+          // return await super.getFeatureFlagsStateless(distinctId, groups, undefined, undefined, disableGeoip)
           return await _getFlags(distinctId, groups, disableGeoip)
         }
 

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Many methods such as `capture` and `identify` no longer return the `this` object instead returning nothing
 - Fixes some typos in types
 - `shutdown` and `shutdownAsync` takes a `shutdownTimeoutMs` param with a default of 30000 (30s). This is the time to wait for flushing events before shutting down the client. If the timeout is reached, the client will be shut down regardless of pending events.
+- Adds a new `featureFlagsRequestTimeout` timeout parameter for feature flags which defaults to 3 seconds, updated from the default 10s for all other API calls.
 
 # 2.11.6 - 2024-02-22
 

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Many methods such as `capture` and `identify` no longer return the `this` object instead returning nothing
 - Fixes some typos in types
 - `shutdown` and `shutdownAsync` takes a `shutdownTimeoutMs` param with a default of 30000 (30s). This is the time to wait for flushing events before shutting down the client. If the timeout is reached, the client will be shut down regardless of pending events.
-- Adds a new `featureFlagsRequestTimeout` timeout parameter for feature flags which defaults to 3 seconds, updated from the default 10s for all other API calls.
+- Adds a new `featureFlagsRequestTimeoutMs` timeout parameter for feature flags which defaults to 10 seconds.
 
 # 2.11.6 - 2024-02-22
 

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Many methods such as `capture` and `identify` no longer return the `this` object instead returning nothing
 - Fixes some typos in types
 - `shutdown` and `shutdownAsync` takes a `shutdownTimeoutMs` param with a default of 30000 (30s). This is the time to wait for flushing events before shutting down the client. If the timeout is reached, the client will be shut down regardless of pending events.
+- Adds a new `featureFlagsRequestTimeout` timeout parameter for feature flags which defaults to 3 seconds, updated from the default 10s for all other API calls.
 
 # 2.6.2 - 2024-02-15
 

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Many methods such as `capture` and `identify` no longer return the `this` object instead returning nothing
 - Fixes some typos in types
 - `shutdown` and `shutdownAsync` takes a `shutdownTimeoutMs` param with a default of 30000 (30s). This is the time to wait for flushing events before shutting down the client. If the timeout is reached, the client will be shut down regardless of pending events.
-- Adds a new `featureFlagsRequestTimeout` timeout parameter for feature flags which defaults to 3 seconds, updated from the default 10s for all other API calls.
+- Adds a new `featureFlagsRequestTimeoutMs` timeout parameter for feature flags which defaults to 10 seconds.
 
 # 2.6.2 - 2024-02-15
 


### PR DESCRIPTION
## Problem

^^ We want a much shorter timeout on flags, since they can block client applications. Also makes this configurable now.

Fixes https://github.com/PostHog/posthog-js-lite/issues/195
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
