### PR TITLE
feat: add uiHost

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -51,6 +51,7 @@ export abstract class PostHogCoreStateless {
   // options
   private apiKey: string
   host: string
+  uiHost?: string
   private flushAt: number
   private flushInterval: number
   private requestTimeout: number

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -1,6 +1,8 @@
 export type PostHogCoreOptions = {
   /** PostHog API host, usually 'https://app.posthog.com' or 'https://eu.posthog.com' */
   host?: string
+  /** PostHog UI host, used for reverse proxying */
+  uiHost?: string
   /** The number of events to queue before sending to PostHog (flushing) */
   flushAt?: number
   /** The interval in milliseconds between periodic flushes */

--- a/posthog-web/src/context.ts
+++ b/posthog-web/src/context.ts
@@ -14,6 +14,8 @@ export function getContext(window: Window): any {
       $device: device(userAgent),
       $current_url: window.location.href,
       $host: window.location.host,
+      // do I need to put something here? eg.
+      // $ui_host: somehow get the ui host from the options
       $pathname: window.location.pathname,
       $browser_version: browserVersion(userAgent, window.navigator.vendor, !!(window as any).opera),
       $screen_height: window.screen.height,

--- a/posthog-web/src/posthog-web.ts
+++ b/posthog-web/src/posthog-web.ts
@@ -13,6 +13,7 @@ export class PostHog extends PostHogCore {
   private _storage: PostHogStorage
   private _storageCache: any
   private _storageKey: string
+  uiHost?: string
 
   constructor(apiKey: string, options?: PostHogOptions) {
     super(apiKey, options)
@@ -20,6 +21,7 @@ export class PostHog extends PostHogCore {
     // posthog-js stores options in one object on
     this._storageKey = options?.persistence_name ? `ph_${options.persistence_name}` : `ph_${apiKey}_posthog`
     this._storage = getStorage(options?.persistence || 'localStorage', window)
+    this.uiHost = options?.uiHost
     this.setupBootstrap(options)
 
     if (options?.preloadFeatureFlags !== false) {


### PR DESCRIPTION
## Problem

We want to reverse proxy our traffic to our flag and capture endpoints so we don't run into issues due to ad blockers. 

Reverse proxy docs say to add ui_host to the init. I think this is where I do it... I haven't committed here before and don't really know how this repo works so I'm mostly just feeling around in the dark here 😅 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds `uiHost` in a variety of places. Pairs with https://github.com/PostHog/posthog/pull/20698

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
