### PR TITLE
chore(ci): fix bundle checker

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: preactjs/compressed-size-action@v2
         with:
-          pattern: '**/lib/**/*.js'
+          pattern: 'posthog-web/lib/**/*.js'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: preactjs/compressed-size-action@v2
         with:
-          pattern: './**/lib/**/*.{js}'
+          pattern: '**/lib/**/*.{js}'
           # Always ignore SourceMaps and node_modules:
           exclude: '{**/*.map,**/node_modules/**}'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -10,6 +10,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: preactjs/compressed-size-action@v2
         with:
-          pattern: '**/lib/**/*.{js}'
-          # Always ignore SourceMaps and node_modules:
-          exclude: '{**/*.map,**/node_modules/**}'
+          pattern: '**/lib/**/*.js'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: preactjs/compressed-size-action@v2
         with:
-          pattern: 'posthog-web/lib/**/*.js'
+          pattern: 'posthog-(web|node)/lib/**/*.js'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: preactjs/compressed-size-action@v2
         with:
-          pattern: 'posthog-(web|node)/lib/**/*.js'
+          pattern: 'posthog-{web,node}/lib/**/*.js'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,17 @@ jobs:
           yarn global add yalc
           yarn
           yarn tsc
+
+  check-bundle:
+    - timeout-minutes: 3
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v1
+        - uses: actions/setup-node@v1
+          with:
+            node-version: 16
+        - run: yarn install
+        - uses: preactjs/compressed-size-action@v2
+          with:
+            build-script: "build-rollup"
+            compression: "none"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,15 +51,15 @@ jobs:
           yarn tsc
 
   check-bundle:
-    - timeout-minutes: 3
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v1
-        - uses: actions/setup-node@v1
-          with:
-            node-version: 16
-        - run: yarn install
-        - uses: preactjs/compressed-size-action@v2
-          with:
-            build-script: "build-rollup"
-            compression: "none"
+    timeout-minutes: 3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - run: yarn install
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          build-script: "build-rollup"
+          compression: "none"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,17 +49,3 @@ jobs:
           yarn global add yalc
           yarn
           yarn tsc
-
-  check-bundle:
-    timeout-minutes: 3
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - run: yarn install
-      - uses: preactjs/compressed-size-action@v2
-        with:
-          build-script: "build-rollup"
-          compression: "none"


### PR DESCRIPTION
spotted the bundle checker wasn't actually checking anything

RN outputs a lot of files,
posthog-node do we care?

fixed the checker and restricted it to only posthog-web

![Screenshot 2024-03-08 at 19 42 27](https://github.com/PostHog/posthog-js-lite/assets/984817/4bacac13-bcb5-4025-a8d0-21edebce8870)
