### PR TITLE
chore: release next major beta.2

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.0.0-beta.2 - 2024-03-12
 
-- `flushAsync` and `shutdownAsnc` are removed with `flush` and `shutdown` now being the async methods.
+- `flushAsync` and `shutdownAsync` are removed with `flush` and `shutdown` now being the async methods.
 - Fixed an issue where `shutdown` would potentially exit early if a flush was already in progress
 - Flushes will now try to flush up to `maxBatchSize` (default 100) in one go
 

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,4 +1,4 @@
-# NEXT
+# 4.0.0-beta.2 - 2024-03-12
 
 - `flushAsync` and `shutdownAsnc` are removed with `flush` and `shutdown` now being the async methods.
 - Fixed an issue where `shutdown` would potentially exit early if a flush was already in progress

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,4 +1,4 @@
-# NEXT
+# 3.0.0-beta.2 - 2024-03-12
 
 - `flushAsync` and `shutdownAsnc` are removed with `flush` and `shutdown` now being the async methods.
 - Fixed an issue where `shutdownAsync` would potentially exit early if a flush was already in progress

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 3.0.0-beta.2 - 2024-03-12
 
-- `flushAsync` and `shutdownAsnc` are removed with `flush` and `shutdown` now being the async methods.
+- `flushAsync` and `shutdownAsync` are removed with `flush` and `shutdown` now being the async methods.
 - Fixed an issue where `shutdownAsync` would potentially exit early if a flush was already in progress
 - Flushes will now try to flush up to `maxBatchSize` (default 100) in one go
 

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,4 +1,4 @@
-# NEXT
+# 3.0.0-beta.2 - 2024-03-12
 
 - `flushAsync` and `shutdownAsnc` are removed with `flush` and `shutdown` now being the async methods.
 - Fixed an issue where `shutdownAsync` would potentially exit early if a flush was already in progress

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 3.0.0-beta.2 - 2024-03-12
 
-- `flushAsync` and `shutdownAsnc` are removed with `flush` and `shutdown` now being the async methods.
+- `flushAsync` and `shutdownAsync` are removed with `flush` and `shutdown` now being the async methods.
 - Fixed an issue where `shutdownAsync` would potentially exit early if a flush was already in progress
 - Flushes will now try to flush up to `maxBatchSize` (default 100) in one go
 

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-js-lite",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Problem

Another beta since there were no tests nor reports from customers, no more changes expected either, after this one, we can cut a stable version.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [X] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
