### PR TITLE
fix: PostHogProvider initialization logic

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 1. Sets `User-Agent` headers with SDK name and version for RN
+2. fix: PostHogProvider initialization that requires client `or` apiKey and not `and`.
 
 # 3.0.0-beta.2 - 2024-03-12
 

--- a/posthog-react-native/src/PostHogProvider.tsx
+++ b/posthog-react-native/src/PostHogProvider.tsx
@@ -42,7 +42,7 @@ export const PostHogProvider = ({
   style,
   debug = false,
 }: PostHogProviderProps): JSX.Element | null => {
-  if (!client || !apiKey) {
+  if (!client && !apiKey) {
     throw new Error(
       'Either a PostHog client or an apiKey is required. If want to use the PostHogProvider without a client, please provide an apiKey and the options={ disabled: true }.'
     )
@@ -55,7 +55,7 @@ export const PostHogProvider = ({
       )
     }
 
-    return client ?? new PostHog(apiKey, options)
+    return client ?? new PostHog(apiKey!, options)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, apiKey])
 

--- a/posthog-react-native/src/PostHogProvider.tsx
+++ b/posthog-react-native/src/PostHogProvider.tsx
@@ -55,7 +55,7 @@ export const PostHogProvider = ({
       )
     }
 
-    return client ?? new PostHog(apiKey!, options)
+    return client ?? new PostHog(apiKey ?? '', options)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, apiKey])
 


### PR DESCRIPTION
## Problem

A regression introduced by #189 requires a client and apiKey to initialize a PostHogProvider even though the error message says only one is required.

## Changes

The error condition logic is fixed and a non null assertion is made.

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

- Fix: PostHogProvider initialization
