### PR TITLE
chore: release node v4 beta 3 and rn v3 beta 3

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 4.0.0-beta.3 - 2024-03-13
 
 1. Sets `User-Agent` headers with SDK name and version for RN
 

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.0.0-beta.2",
+  "version": "4.0.0-beta.3",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 3.0.0-beta.3 - 2024-03-13
 
 1. Sets `User-Agent` headers with SDK name and version for RN
 2. fix: PostHogProvider initialization that requires client `or` apiKey and not `and`.

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"


### PR DESCRIPTION
## Problem

Releases https://github.com/PostHog/posthog-js-lite/pull/206 and https://github.com/PostHog/posthog-js-lite/pull/205

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [X] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
