### PR TITLE
chore: Change Application opened to application became active for native events

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+1. If `captureNativeAppLifecycleEvents` is enabled, the event `Application Opened` with the property `from_background: true` is moved to its own event called `Application Became Active`. This event is triggered when the app is opened from the background. The `Application Opened` event is now only triggered when the app is opened from a cold start, aligning with the other integrations such as the `PostHogProvider` with the `captureLifecycleEvents` option and `initReactNativeNavigation` with the `captureLifecycleEvents` option.
+
 # 3.0.0 - 2024-03-18
 
 ## Added

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+## Changed
+
 1. If `captureNativeAppLifecycleEvents` is enabled, the event `Application Opened` with the property `from_background: true` is moved to its own event called `Application Became Active`. This event is triggered when the app is opened from the background. The `Application Opened` event is now only triggered when the app is opened from a cold start, aligning with the other integrations such as the `PostHogProvider` with the `captureLifecycleEvents` option and `initReactNativeNavigation` with the `captureLifecycleEvents` option.
 
 # 3.0.0 - 2024-03-18

--- a/posthog-react-native/src/frameworks/wix-navigation.ts
+++ b/posthog-react-native/src/frameworks/wix-navigation.ts
@@ -23,12 +23,22 @@ export const withReactNativeNavigation = (posthog: PostHog, options: PostHogAuto
       return
     }
 
-    posthog.capture('Application Opened')
+    const appProperties = posthog.getAppProperties()
+    const appBuild = appProperties.$app_build
+    const appVersion = appProperties.$app_version
+
+    posthog.capture('Application Opened', {
+      version: appVersion,
+      build: appBuild,
+    })
 
     AppState.addEventListener('change', (nextAppState) => {
       switch (nextAppState) {
         case 'active':
-          return posthog.capture('Application Became Active')
+          return posthog.capture('Application Became Active', {
+            version: appVersion,
+            build: appBuild,
+          })
         case 'background':
           return posthog.capture('Application Backgrounded')
         default:

--- a/posthog-react-native/src/frameworks/wix-navigation.ts
+++ b/posthog-react-native/src/frameworks/wix-navigation.ts
@@ -27,6 +27,7 @@ export const withReactNativeNavigation = (posthog: PostHog, options: PostHogAuto
     const appBuild = appProperties.$app_build
     const appVersion = appProperties.$app_version
 
+    // TODO: add missing initialUrl
     posthog.capture('Application Opened', {
       version: appVersion,
       build: appBuild,

--- a/posthog-react-native/src/frameworks/wix-navigation.ts
+++ b/posthog-react-native/src/frameworks/wix-navigation.ts
@@ -23,23 +23,12 @@ export const withReactNativeNavigation = (posthog: PostHog, options: PostHogAuto
       return
     }
 
-    const appProperties = posthog.getAppProperties()
-    const appBuild = appProperties.$app_build
-    const appVersion = appProperties.$app_version
-
-    // TODO: add missing initialUrl
-    posthog.capture('Application Opened', {
-      version: appVersion,
-      build: appBuild,
-    })
+    posthog.capture('Application Opened')
 
     AppState.addEventListener('change', (nextAppState) => {
       switch (nextAppState) {
         case 'active':
-          return posthog.capture('Application Became Active', {
-            version: appVersion,
-            build: appBuild,
-          })
+          return posthog.capture('Application Became Active')
         case 'background':
           return posthog.capture('Application Backgrounded')
         default:

--- a/posthog-react-native/src/hooks/useLifecycleTracker.ts
+++ b/posthog-react-native/src/hooks/useLifecycleTracker.ts
@@ -9,25 +9,15 @@ export function useLifecycleTracker(client?: PostHog): void {
   const posthog = client || contextClient
 
   return useEffect(() => {
-    const appProperties = posthog.getAppProperties()
-    const appBuild = appProperties.$app_build
-    const appVersion = appProperties.$app_version
-
     if (!openTrackedRef.current) {
       openTrackedRef.current = true
       // TODO: add missing initialUrl
-      posthog.capture('Application Opened', {
-        version: appVersion,
-        build: appBuild,
-      })
+      posthog.capture('Application Opened')
     }
     const subscription = AppState.addEventListener('change', (nextAppState) => {
       switch (nextAppState) {
         case 'active':
-          return posthog.capture('Application Became Active', {
-            version: appVersion,
-            build: appBuild,
-          })
+          return posthog.capture('Application Became Active')
         case 'background':
           return posthog.capture('Application Backgrounded')
         default:

--- a/posthog-react-native/src/hooks/useLifecycleTracker.ts
+++ b/posthog-react-native/src/hooks/useLifecycleTracker.ts
@@ -9,14 +9,24 @@ export function useLifecycleTracker(client?: PostHog): void {
   const posthog = client || contextClient
 
   return useEffect(() => {
+    const appProperties = posthog.getAppProperties()
+    const appBuild = appProperties.$app_build
+    const appVersion = appProperties.$app_version
+
     if (!openTrackedRef.current) {
       openTrackedRef.current = true
-      posthog.capture('Application Opened')
+      posthog.capture('Application Opened', {
+        version: appVersion,
+        build: appBuild,
+      })
     }
     const subscription = AppState.addEventListener('change', (nextAppState) => {
       switch (nextAppState) {
         case 'active':
-          return posthog.capture('Application Became Active')
+          return posthog.capture('Application Became Active', {
+            version: appVersion,
+            build: appBuild,
+          })
         case 'background':
           return posthog.capture('Application Backgrounded')
         default:

--- a/posthog-react-native/src/hooks/useLifecycleTracker.ts
+++ b/posthog-react-native/src/hooks/useLifecycleTracker.ts
@@ -15,6 +15,7 @@ export function useLifecycleTracker(client?: PostHog): void {
 
     if (!openTrackedRef.current) {
       openTrackedRef.current = true
+      // TODO: add missing initialUrl
       posthog.capture('Application Opened', {
         version: appVersion,
         build: appBuild,

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -152,10 +152,6 @@ export class PostHog extends PostHogCore {
     }
   }
 
-  getAppProperties(): PostHogCustomAppProperties {
-    return this._appProperties
-  }
-
   // Custom methods
   async screen(name: string, properties?: { [key: string]: any }, options?: PostHogCaptureOptions): Promise<void> {
     await this._initPromise

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -195,12 +195,16 @@ export class PostHog extends PostHogCore {
     if (appBuild) {
       if (!prevAppBuild) {
         // new app install
+        // version and build are deprecated, but we keep them for compatibility
+        // use $app_version and $app_build instead
         this.capture('Application Installed', {
           version: appVersion,
           build: appBuild,
         })
       } else if (prevAppBuild !== appBuild) {
         // app updated
+        // version and build are deprecated, but we keep them for compatibility
+        // use $app_version and $app_build instead
         this.capture('Application Updated', {
           previous_version: prevAppVersion,
           previous_build: prevAppBuild,
@@ -212,6 +216,8 @@ export class PostHog extends PostHogCore {
 
     const initialUrl = (await Linking.getInitialURL()) ?? undefined
 
+    // version and build are deprecated, but we keep them for compatibility
+    // use $app_version and $app_build instead
     this.capture('Application Opened', {
       version: appVersion,
       build: appBuild,
@@ -220,6 +226,8 @@ export class PostHog extends PostHogCore {
 
     AppState.addEventListener('change', (state) => {
       if (state === 'active') {
+        // version and build are deprecated, but we keep them for compatibility
+        // use $app_version and $app_build instead
         this.capture('Application Became Active', {
           version: appVersion,
           build: appBuild,

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -31,7 +31,7 @@ export type PostHogOptions = PostHogCoreOptions & {
   customStorage?: PostHogCustomStorage
 
   // customAsyncStorage?: PostHogCustomAsyncStorage
-  /** Captures native app lifecycle events such as Application Installed, Application Updated, Application Opened and Application Backgrounded.
+  /** Captures native app lifecycle events such as Application Installed, Application Updated, Application Opened, Application Became Active and Application Backgrounded.
    * By default is false.
    * If you're already using the 'captureLifecycleEvents' options with 'withReactNativeNavigation' or 'PostHogProvider, you should not set this to true, otherwise you may see duplicated events.
    */
@@ -146,7 +146,7 @@ export class PostHog extends PostHogCore {
   getCommonEventProperties(): any {
     return {
       ...super.getCommonEventProperties(),
-      ...getAppProperties(),
+      ...this._appProperties,
       $screen_height: Dimensions.get('screen').height,
       $screen_width: Dimensions.get('screen').width,
     }

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -146,10 +146,14 @@ export class PostHog extends PostHogCore {
   getCommonEventProperties(): any {
     return {
       ...super.getCommonEventProperties(),
-      ...this._appProperties,
+      ...getAppProperties(),
       $screen_height: Dimensions.get('screen').height,
       $screen_width: Dimensions.get('screen').width,
     }
+  }
+
+  getAppProperties(): PostHogCustomAppProperties {
+    return this._appProperties
   }
 
   // Custom methods
@@ -215,16 +219,14 @@ export class PostHog extends PostHogCore {
     this.capture('Application Opened', {
       version: appVersion,
       build: appBuild,
-      from_background: false,
       url: initialUrl,
     })
 
     AppState.addEventListener('change', (state) => {
       if (state === 'active') {
-        this.capture('Application Opened', {
+        this.capture('Application Became Active', {
           version: appVersion,
           build: appBuild,
-          from_background: true,
         })
       } else if (state === 'background') {
         this.capture('Application Backgrounded')

--- a/posthog-react-native/test/posthog.spec.ts
+++ b/posthog-react-native/test/posthog.spec.ts
@@ -304,7 +304,7 @@ describe('PostHog React Native', () => {
           },
         })
         expect(onCapture.mock.calls[3][0]).toMatchObject({
-          event: 'Application Opened',
+          event: 'Application Became Active',
           properties: {
             $app_build: '1',
             $app_version: '1.0.0',

--- a/posthog-react-native/test/posthog.spec.ts
+++ b/posthog-react-native/test/posthog.spec.ts
@@ -169,7 +169,6 @@ describe('PostHog React Native', () => {
           properties: {
             $app_build: '1',
             $app_version: '1.0.0',
-            from_background: false,
           },
         })
       })
@@ -221,7 +220,6 @@ describe('PostHog React Native', () => {
           properties: {
             $app_build: '2',
             $app_version: '2.0.0',
-            from_background: false,
           },
         })
       })
@@ -266,7 +264,6 @@ describe('PostHog React Native', () => {
           properties: {
             $app_build: '1',
             $app_version: '1.0.0',
-            from_background: false,
             url: 'https://example.com',
           },
         })
@@ -311,7 +308,6 @@ describe('PostHog React Native', () => {
           properties: {
             $app_build: '1',
             $app_version: '1.0.0',
-            from_background: true,
           },
         })
       })


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog-js-lite/issues/144
https://posthoghelp.zendesk.com/agent/tickets/11961
Depend on the SDK config, the dashboard should use different event names, its better to align that within the SDK

## Changes

Technically a breaking change but I don't see many people using `captureNativeAppLifecycleEvents` anyways, it's written in the changelog.
It's hard for support to figure out the multiple scenarios depending on the SDK configuration.
Our mobile dashboard templates don't even consider the `from_background` property anyway, so now using this config (captureNativeAppLifecycleEvents) will match our templates.
Added the app version and build to the other integrations.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [X] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
