### PR TITLE
fix(flags): Handle payloads correctly

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -376,7 +376,7 @@ export abstract class PostHogCoreStateless {
       return null
     }
 
-    return this._parsePayload(response)
+    return response
   }
 
   protected async getFeatureFlagPayloadsStateless(
@@ -398,9 +398,6 @@ export abstract class PostHogCoreStateless {
       )
     ).payloads
 
-    if (payloads) {
-      return Object.fromEntries(Object.entries(payloads).map(([k, v]) => [k, this._parsePayload(v)]))
-    }
     return payloads
   }
 
@@ -453,9 +450,15 @@ export abstract class PostHogCoreStateless {
     const flags = decideResponse?.featureFlags
     const payloads = decideResponse?.featureFlagPayloads
 
+    let parsedPayloads = payloads
+
+    if (payloads) {
+      parsedPayloads = Object.fromEntries(Object.entries(payloads).map(([k, v]) => [k, this._parsePayload(v)]))
+    }
+
     return {
       flags,
-      payloads,
+      payloads: parsedPayloads,
     }
   }
 
@@ -1113,7 +1116,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
               newFeatureFlagPayloads = { ...currentFlagPayloads, ...res.featureFlagPayloads }
             }
             this.setKnownFeatureFlags(newFeatureFlags)
-            this.setKnownFeatureFlagPayloads(newFeatureFlagPayloads)
+            this.setKnownFeatureFlagPayloads(Object.fromEntries(Object.entries(newFeatureFlagPayloads || {}).map(([k, v]) => [k, this._parsePayload(v)])))
           }
 
           return res
@@ -1186,16 +1189,14 @@ export abstract class PostHogCore extends PostHogCoreStateless {
       return null
     }
 
-    return this._parsePayload(response)
+    return response
   }
 
   getFeatureFlagPayloads(): PostHogDecideResponse['featureFlagPayloads'] | undefined {
     const payloads = this.getPersistedProperty<PostHogDecideResponse['featureFlagPayloads']>(
       PostHogPersistedProperty.FeatureFlagPayloads
     )
-    if (payloads) {
-      return Object.fromEntries(Object.entries(payloads).map(([k, v]) => [k, this._parsePayload(v)]))
-    }
+
     return payloads
   }
 

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -16,12 +16,11 @@ describe('PostHog Core', () => {
     'json-payload': true,
   })
 
-  // NOTE: Aren't these supposed to be strings?
   const createMockFeatureFlagPayloads = (): any => ({
-    'feature-1': {
+    'feature-1': JSON.stringify({
       color: 'blue',
-    },
-    'feature-variant': 5,
+    }),
+    'feature-variant': JSON.stringify([5]),
     'json-payload': '{"a":"payload"}',
   })
 
@@ -111,7 +110,7 @@ describe('PostHog Core', () => {
       })
 
       it('should return payload of matched flags only', async () => {
-        expect(posthog.getFeatureFlagPayload('feature-variant')).toEqual(5)
+        expect(posthog.getFeatureFlagPayload('feature-variant')).toEqual([5])
         expect(posthog.getFeatureFlagPayload('feature-1')).toEqual({
           color: 'blue',
         })
@@ -583,7 +582,7 @@ describe('PostHog Core', () => {
         expect(posthog.getFeatureFlagPayload('feature-1')).toEqual({
           color: 'blue',
         })
-        expect(posthog.getFeatureFlagPayload('feature-variant')).toEqual(5)
+        expect(posthog.getFeatureFlagPayload('feature-variant')).toEqual([5])
       })
     })
   })

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+# 4.0.1 - 2024-04-24
+
+1. Prevent double JSON parsing of feature flag payloads, which would convert the payload [1] into 1.
+
 # 4.0.0 - 2024-03-18
 
 ## Added

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -340,12 +340,7 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
         disableGeoip
       )
     }
-
-    try {
-      return JSON.parse(response as any)
-    } catch {
-      return response
-    }
+    return response
   }
 
   async isFeatureEnabled(

--- a/posthog-node/src/types.ts
+++ b/posthog-node/src/types.ts
@@ -54,7 +54,7 @@ export type PostHogFeatureFlag = {
         rollout_percentage: number
       }[]
     }
-    payloads?: Record<string, JsonType>
+    payloads?: Record<string, string>
   }
   deleted: boolean
   active: boolean

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -466,11 +466,14 @@ describe('PostHog Node.js', () => {
         'feature-2': true,
         'feature-variant': 'variant',
         'disabled-flag': false,
+        'feature-array': true,
       }
 
+      // these are stringified in apiImplementation
       const mockFeatureFlagPayloads = {
         'feature-1': { color: 'blue' },
         'feature-variant': 2,
+        'feature-array': [1],
       }
 
       const multivariateFlag = {
@@ -497,7 +500,7 @@ describe('PostHog Node.js', () => {
               { key: 'third-variant', name: 'Third Variant', rollout_percentage: 25 },
             ],
           },
-          payloads: { 'first-variant': 'some-payload', 'third-variant': { a: 'json' } },
+          payloads: { 'first-variant': 'some-payload', 'third-variant': JSON.stringify({ a: 'json' }) },
         },
       }
       const basicFlag = {
@@ -520,7 +523,7 @@ describe('PostHog Node.js', () => {
               rollout_percentage: 100,
             },
           ],
-          payloads: { true: 300 },
+          payloads: { true: '300' },
         },
       }
       const falseFlag = {
@@ -536,7 +539,24 @@ describe('PostHog Node.js', () => {
               rollout_percentage: 0,
             },
           ],
-          payloads: { true: 300 },
+          payloads: { true: '300' },
+        },
+      }
+
+      const arrayFlag = {
+        id: 5,
+        name: 'Beta Feature',
+        key: 'feature-array',
+        active: true,
+        filters: {
+          groups: [
+            {
+              properties: [
+              ],
+              rollout_percentage: 100,
+            },
+          ],
+          payloads: { true: JSON.stringify([1]) },
         },
       }
 
@@ -544,7 +564,7 @@ describe('PostHog Node.js', () => {
         apiImplementation({
           decideFlags: mockFeatureFlags,
           decideFlagPayloads: mockFeatureFlagPayloads,
-          localFlags: { flags: [multivariateFlag, basicFlag, falseFlag] },
+          localFlags: { flags: [multivariateFlag, basicFlag, falseFlag, arrayFlag] },
         })
       )
 
@@ -603,9 +623,10 @@ describe('PostHog Node.js', () => {
           distinct_id: 'distinct_id',
           event: 'node test event',
           properties: expect.objectContaining({
-            $active_feature_flags: ['feature-1', 'feature-2', 'feature-variant'],
+            $active_feature_flags: ['feature-1', 'feature-2', 'feature-variant', 'feature-array'],
             '$feature/feature-1': true,
             '$feature/feature-2': true,
+            '$feature/feature-array': true,
             '$feature/feature-variant': 'variant',
             $lib: 'posthog-node',
             $lib_version: '1.2.3',
@@ -659,8 +680,9 @@ describe('PostHog Node.js', () => {
           distinct_id: 'distinct_id',
           event: 'node test event',
           properties: expect.objectContaining({
-            $active_feature_flags: ['beta-feature-local'],
+            $active_feature_flags: ['beta-feature-local', 'feature-array'],
             '$feature/beta-feature-local': 'third-variant',
+            '$feature/feature-array': true,
             '$feature/false-flag': false,
             $lib: 'posthog-node',
             $lib_version: '1.2.3',
@@ -756,9 +778,10 @@ describe('PostHog Node.js', () => {
       )
 
       expect(getLastBatchEvents()?.[0].properties).toEqual({
-        $active_feature_flags: ['feature-1', 'feature-2', 'feature-variant'],
+        $active_feature_flags: ['feature-1', 'feature-2', 'feature-variant', 'feature-array'],
         '$feature/feature-1': true,
         '$feature/feature-2': true,
+        '$feature/feature-array': true,
         '$feature/disabled-flag': false,
         '$feature/feature-variant': 'variant',
         $lib: 'posthog-node',
@@ -1001,6 +1024,50 @@ describe('PostHog Node.js', () => {
       await expect(
         posthog.getFeatureFlagPayload('feature-variant', '123', 'variant', { groups: { org: '123' } })
       ).resolves.toEqual(2)
+      expect(mockedFetch).toHaveBeenCalledTimes(1)
+      expect(mockedFetch).toHaveBeenCalledWith(
+        'http://example.com/decide/?v=3',
+        expect.objectContaining({ method: 'POST', body: expect.stringContaining('"geoip_disable":true') })
+      )
+    })
+
+    it('should not double parse json with getFeatureFlagPayloads and local eval', async () => {
+      expect(mockedFetch).toHaveBeenCalledTimes(0)
+
+      posthog = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        flushAt: 1,
+        fetchRetryCount: 0,
+        personalApiKey: 'TEST_PERSONAL_API_KEY',
+      })
+
+      mockedFetch.mockClear()
+      expect(mockedFetch).toHaveBeenCalledTimes(0)
+
+      await expect(
+        posthog.getFeatureFlagPayload('feature-array', '123', true, { onlyEvaluateLocally: true })
+      ).resolves.toEqual([1])
+      expect(mockedFetch).toHaveBeenCalledTimes(1)
+      expect(mockedFetch).toHaveBeenCalledWith(...anyLocalEvalCall)
+
+      mockedFetch.mockClear()
+
+      await expect(
+        posthog.getFeatureFlagPayload('feature-array', '123')
+      ).resolves.toEqual([1])
+      expect(mockedFetch).toHaveBeenCalledTimes(0)
+
+      await expect(
+        posthog.getFeatureFlagPayload('false-flag', '123', true)
+      ).resolves.toEqual(300)
+      expect(mockedFetch).toHaveBeenCalledTimes(0)
+    })
+
+    it('should not double parse json with getFeatureFlagPayloads and server eval', async () => {
+      expect(mockedFetch).toHaveBeenCalledTimes(0)
+      await expect(
+        posthog.getFeatureFlagPayload('feature-array', '123', undefined, { groups: { org: '123' } })
+      ).resolves.toEqual([1])
       expect(mockedFetch).toHaveBeenCalledTimes(1)
       expect(mockedFetch).toHaveBeenCalledWith(
         'http://example.com/decide/?v=3',

--- a/posthog-node/test/test-utils.ts
+++ b/posthog-node/test/test-utils.ts
@@ -20,7 +20,7 @@ export const apiImplementation = ({
           } else {
             return Promise.resolve({
               featureFlags: decideFlags,
-              featureFlagPayloads: decideFlagPayloads,
+              featureFlagPayloads: Object.fromEntries(Object.entries(decideFlagPayloads || {}).map(([k, v]) => [k, JSON.stringify(v)])),
             })
           }
         },

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.1.1 - 2024-04-24
+
+1. Prevent double JSON parsing of feature flag payloads, which would convert the payload [1] into 1.
+
 # 3.1.0 - 2024-03-27
 
 ## Changed

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/21768

Noticed payloads are handled very messily, and some existing tests for these were wrong 🫠. Now always simulates how things should be in production, with the decide response returning stringified payloads.

The code now always parses payloads once: when we get the response from decide (or local eval), and everything else can assume the payload is an object. This means we don't need to faff around parsing everywhere, which is nice.

Ran locally against production and can confirm everything works nicely now.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
