### PR TITLE
fix: remove uuidv7 dep since its vendored

### DIFF
--- a/posthog-core/package.json
+++ b/posthog-core/package.json
@@ -6,8 +6,5 @@
     "type": "git",
     "url": "https://github.com/PostHog/posthog-js-lite.git",
     "directory": "posthog-core"
-  },
-  "dependencies": {
-    "uuidv7": "^0.6.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10227,11 +10227,6 @@ uuid@^8.0.0, uuid@^8.3.2:
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuidv7@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/uuidv7/-/uuidv7-0.6.3.tgz#2abcfa683b4ad4a0cbbbaedffc3ef940c110cf10"
-  integrity sha512-zV3eW2NlXTsun/aJ7AixxZjH/byQcH/r3J99MI0dDEkU2cJIBJxhEWUHDTpOaLPRNhebPZoeHuykYREkI9HafA==
-
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"


### PR DESCRIPTION
## Problem

its vendored already https://github.com/PostHog/posthog-js-lite/blob/main/posthog-core/src/vendor/uuidv7.ts
the dep was just an oversight

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [X] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
