### PR TITLE
chore: change host to new address.

### DIFF
--- a/examples/example_expo_rn_web/App.tsx
+++ b/examples/example_expo_rn_web/App.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, Text, View } from 'react-native'
 import PostHog from 'posthog-react-native'
 
 export const posthog = new PostHog('phc_pQ70jJhZKHRvDIL5ruOErnPy6xiAiWCqlL4ayELj4X8', {
-  host: 'https://app.posthog.com',
+  host: 'https://us.i.posthog.com',
   flushAt: 1,
   captureNativeAppLifecycleEvents: false,
   sendFeatureFlagEvent: false,

--- a/examples/example_rn/posthog.tsx
+++ b/examples/example_rn/posthog.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 export const posthog = new PostHog(
   'phc_pQ70jJhZKHRvDIL5ruOErnPy6xiAiWCqlL4ayELj4X8',
   {
-    host: 'https://app.posthog.com',
+    // host: 'https://us.i.posthog.com',
     // persistence: 'memory',
   },
 );

--- a/examples/example_rn_macos/App.tsx
+++ b/examples/example_rn_macos/App.tsx
@@ -30,7 +30,7 @@ import PostHog from 'posthog-react-native';
 export const posthog = new PostHog(
   'phc_pQ70jJhZKHRvDIL5ruOErnPy6xiAiWCqlL4ayELj4X8',
   {
-    host: 'https://app.posthog.com',
+    // host: 'https://us.i.posthog.com',
     // persistence: 'memory',
   },
 );

--- a/examples/example_rn_new_architecture/App.tsx
+++ b/examples/example_rn_new_architecture/App.tsx
@@ -30,7 +30,7 @@ import PostHog from 'posthog-react-native';
 export const posthog = new PostHog(
   'phc_pQ70jJhZKHRvDIL5ruOErnPy6xiAiWCqlL4ayELj4X8',
   {
-    host: 'https://app.posthog.com',
+    // host: 'https://us.i.posthog.com',
     // persistence: 'memory',
   },
 );

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -87,7 +87,7 @@ export abstract class PostHogCoreStateless {
     assert(apiKey, "You must pass your PostHog project's api key.")
 
     this.apiKey = apiKey
-    this.host = removeTrailingSlash(options?.host || 'https://app.posthog.com')
+    this.host = removeTrailingSlash(options?.host || 'https://us.i.posthog.com')
     this.flushAt = options?.flushAt ? Math.max(options?.flushAt, 1) : 20
     this.maxBatchSize = Math.max(this.flushAt, options?.maxBatchSize ?? 100)
     this.maxQueueSize = Math.max(this.flushAt, options?.maxQueueSize ?? 1000)

--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -1,5 +1,5 @@
 export type PostHogCoreOptions = {
-  /** PostHog API host, usually 'https://app.posthog.com' or 'https://eu.posthog.com' */
+  /** PostHog API host, usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com' */
   host?: string
   /** The number of events to queue before sending to PostHog (flushing) */
   flushAt?: number

--- a/posthog-core/test/posthog.capture.spec.ts
+++ b/posthog-core/test/posthog.capture.spec.ts
@@ -21,7 +21,7 @@ describe('PostHog Core', () => {
       await waitForPromises()
       expect(mocks.fetch).toHaveBeenCalledTimes(1)
       const [url, options] = mocks.fetch.mock.calls[0]
-      expect(url).toMatch(/^https:\/\/app\.posthog\.com\/e\/\?ip=1&_=[0-9]+&v=[0-9.a-z-]+$/)
+      expect(url).toMatch(/^https:\/\/us\.i\.posthog\.com\/e\/\?ip=1&_=[0-9]+&v=[0-9.a-z-]+$/)
       expect(options.method).toBe('POST')
       const body = parseBody(mocks.fetch.mock.calls[0])
 

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -141,7 +141,7 @@ describe('PostHog Core', () => {
         })
 
         it('should return undefined', async () => {
-          expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+          expect(mocks.fetch).toHaveBeenCalledWith('https://us.i.posthog.com/decide/?v=3', {
             body: JSON.stringify({
               token: 'TEST_API_KEY',
               distinct_id: posthog.getDistinctId(),
@@ -212,7 +212,7 @@ describe('PostHog Core', () => {
         })
 
         it('should return combined results', async () => {
-          expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+          expect(mocks.fetch).toHaveBeenCalledWith('https://us.i.posthog.com/decide/?v=3', {
             body: JSON.stringify({
               token: 'TEST_API_KEY',
               distinct_id: posthog.getDistinctId(),
@@ -239,7 +239,7 @@ describe('PostHog Core', () => {
           // now second call to feature flags
           await posthog.reloadFeatureFlagsAsync(false)
 
-          expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+          expect(mocks.fetch).toHaveBeenCalledWith('https://us.i.posthog.com/decide/?v=3', {
             body: JSON.stringify({
               token: 'TEST_API_KEY',
               distinct_id: posthog.getDistinctId(),
@@ -317,7 +317,7 @@ describe('PostHog Core', () => {
         })
 
         it('should return only latest results', async () => {
-          expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+          expect(mocks.fetch).toHaveBeenCalledWith('/decide/?v=3', {
             body: JSON.stringify({
               token: 'TEST_API_KEY',
               distinct_id: posthog.getDistinctId(),
@@ -344,7 +344,7 @@ describe('PostHog Core', () => {
           // now second call to feature flags
           await posthog.reloadFeatureFlagsAsync(false)
 
-          expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+          expect(mocks.fetch).toHaveBeenCalledWith('https://us.i.posthog.com/decide/?v=3', {
             body: JSON.stringify({
               token: 'TEST_API_KEY',
               distinct_id: posthog.getDistinctId(),
@@ -537,7 +537,7 @@ describe('PostHog Core', () => {
       })
 
       it('should load new feature flags', async () => {
-        expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+        expect(mocks.fetch).toHaveBeenCalledWith('https://us.i.posthog.com/decide/?v=3', {
           body: JSON.stringify({
             token: 'TEST_API_KEY',
             distinct_id: posthog.getDistinctId(),
@@ -563,7 +563,7 @@ describe('PostHog Core', () => {
       })
 
       it('should load new feature flag payloads', async () => {
-        expect(mocks.fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+        expect(mocks.fetch).toHaveBeenCalledWith('https://us.i.posthog.com/decide/?v=3', {
           body: JSON.stringify({
             token: 'TEST_API_KEY',
             distinct_id: posthog.getDistinctId(),

--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -317,7 +317,7 @@ describe('PostHog Core', () => {
         })
 
         it('should return only latest results', async () => {
-          expect(mocks.fetch).toHaveBeenCalledWith('/decide/?v=3', {
+          expect(mocks.fetch).toHaveBeenCalledWith('https://us.i.posthog.com/decide/?v=3', {
             body: JSON.stringify({
               token: 'TEST_API_KEY',
               distinct_id: posthog.getDistinctId(),

--- a/posthog-core/test/posthog.init.spec.ts
+++ b/posthog-core/test/posthog.init.spec.ts
@@ -23,7 +23,7 @@ describe('PostHog Core', () => {
     it('should initialise default options', () => {
       expect(posthog as any).toMatchObject({
         apiKey: 'TEST_API_KEY',
-        host: 'https://app.posthog.com',
+        host: 'https://us.i.posthog.com',
         flushAt: 20,
         flushInterval: 10000,
       })

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Next
+
+1. chore: change host to new address.
 
 # 4.0.1 - 2024-04-25
 

--- a/posthog-node/src/extensions/sentry-integration.ts
+++ b/posthog-node/src/extensions/sentry-integration.ts
@@ -70,7 +70,7 @@ export class PostHogSentryIntegration implements _SentryIntegration {
     private readonly organization?: string,
     private readonly prefix?: string
   ) {
-    this.posthogHost = posthog.options.host ?? 'https://app.posthog.com'
+    this.posthogHost = posthog.options.host ?? 'https://us.i.posthog.com'
   }
 
   public setupOnce(

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+1. chore: change host to new address.
+
 # 3.1.1 - 2024-04-25
 
 1. Prevent double JSON parsing of feature flag payloads, which would convert the payload [1] into 1.

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+1. chore: change host to new address.
+
 # 3.0.1 - 2024-04-25
 
 1. Prevent double JSON parsing of feature flag payloads, which would convert the payload [1] into 1.

--- a/posthog-web/test/posthog-web.spec.ts
+++ b/posthog-web/test/posthog-web.spec.ts
@@ -61,7 +61,7 @@ describe('PostHogWeb', () => {
 
       await waitForPromises()
 
-      expect(fetch).toHaveBeenCalledWith('https://app.posthog.com/decide/?v=3', {
+      expect(fetch).toHaveBeenCalledWith('https://us.i.posthog.com/decide/?v=3', {
         body: JSON.stringify({
           token: 'TEST_API_KEY',
           distinct_id: posthog.getDistinctId(),


### PR DESCRIPTION
## Problem

still using the older endpoint https://app.posthog.com/

## Changes

default endpoint is https://us.i.posthog.com

- [X] Android
- [X] iOS
- [X] Flutter
- [X] RN - check

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [X] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
