### PR TITLE
fix: should attempt localstorage correctly before falling back to session storage

### DIFF
--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,4 +1,10 @@
-# Next
+# 3.0.2 - 2024-06-14
+
+## Fixed
+
+1. Fixed and error that prevented localstorage from ever being used and instead falling back to sessionstorage for persistence
+
+## Changed
 
 1. chore: change host to new address.
 

--- a/posthog-web/src/storage.ts
+++ b/posthog-web/src/storage.ts
@@ -145,7 +145,7 @@ const createMemoryStorage = (): PostHogStorage => {
 
 export const getStorage = (type: PostHogOptions['persistence'], window: Window | undefined): PostHogStorage => {
   if (window) {
-    if (!localStorage) {
+    if (!localStore) {
       const _localStore = createStorageLike(window.localStorage)
       localStore = checkStoreIsSupported(_localStore) ? _localStore : undefined
     }


### PR DESCRIPTION
## Problem

Usage in the browser will always fallback to session storage rather than localstorage due to a simple logical conditional error.
When local storage is available it should be used when requested before falling back to sessionstorage.

## Changes

Corrects faulty condition so availability of local storage is evaluated correctly

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- use localstorage over sessionstorage where available
