### PR TITLE
feat: Added historical migration option

### DIFF
--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -39,6 +39,8 @@ export type PostHogCoreOptions = {
   /** Whether to post events to PostHog in JSON or compressed format. Defaults to 'form' */
   captureMode?: 'json' | 'form'
   disableGeoip?: boolean
+  /** Special flag to indicate ingested data is for a historical migration. */
+  historicalMigration?: boolean
 }
 
 export enum PostHogPersistedProperty {

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Next
 
+# 4.2.0 - 2024-08-26
+
+1. Added `historicalMigration` option for use in tools that are migrating large data to PostHog
+
 # 4.1.1 - 2024-08-20
 
 1. Local evaluation returns correct results on `undefined/null` values
+
 # 4.1.0 - 2024-08-14
 
 1. chore: change host to new address.

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

We have an optimisation flag for historical migrated data documented here but we don't expose a way of configuring it.

## Changes

* Adds the option

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-react-native