### PR TITLE
fix: set the right sdk name and version for recordings

### DIFF
--- a/examples/example-expo-latest/package.json
+++ b/examples/example-expo-latest/package.json
@@ -21,7 +21,7 @@
     "expo-localization": "~15.0.3",
     "expo-status-bar": "~1.12.1",
     "posthog-react-native": "file:.yalc/posthog-react-native",
-    "posthog-react-native-session-replay": "^0.1.1",
+    "posthog-react-native-session-replay": "^0.1.2",
     "react": "18.2.0",
     "react-native": "0.74.5"
   },

--- a/examples/example_rn/package.json
+++ b/examples/example_rn/package.json
@@ -24,7 +24,7 @@
     "react-native": "0.73.2",
     "react-native-device-info": "^10.12.0",
     "react-native-navigation": "^7.37.2",
-    "posthog-react-native-session-replay": ">=0.1.1"
+    "posthog-react-native-session-replay": "^0.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Next
 
+# 3.3.1 - 2024-09-30
+
+## Changed
+
+1. set the right sdk name and version for recordings
+
 # 3.3.0 - 2024-09-24
 
 ## Changed

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Changed
 
-1. set the right sdk name and version for recordings
+1. fix: set the right sdk name and version for recordings
 
 # 3.3.0 - 2024-09-24
 

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -33,7 +33,7 @@
     "react-native": "^0.69.1",
     "react-native-device-info": "^10.3.0",
     "react-native-navigation": "^6.0.0",
-    "posthog-react-native-session-replay": ">=0.1.1"
+    "posthog-react-native-session-replay": "^0.1.2"
   },
   "peerDependencies": {
     "@react-native-async-storage/async-storage": ">=1.0.0",
@@ -44,7 +44,7 @@
     "expo-localization": ">= 11.0.0",
     "react-native-device-info": ">= 10.0.0",
     "react-native-navigation": ">=6.0.0",
-    "posthog-react-native-session-replay": ">=0.1.1"
+    "posthog-react-native-session-replay": "^0.1.2"
   },
   "peerDependenciesMeta": {
     "@react-native-async-storage/async-storage": {

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -305,6 +305,7 @@ export class PostHog extends PostHogCore {
           debug: this.isDebug,
           distinctId: this.getDistinctId(),
           anonymousId: this.getAnonymousId(),
+          sdkVersion: this.getLibraryVersion(),
         }
 
         console.log('PostHog Debug', `Session replay sdk options: ${JSON.stringify(sdkOptions)}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8597,10 +8597,10 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
   integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
 
-posthog-react-native-session-replay@>=0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/posthog-react-native-session-replay/-/posthog-react-native-session-replay-0.1.1.tgz#4efb14734274c7866a418b8ac60669764b73c539"
-  integrity sha512-kMKTGOOxgZJAtx8qnIOd7frqe0WYCiY1ynkl/MZUf55k/m69udmbsdTqIcJXctsnfBANgmvryEo3kZPWaq5r7A==
+posthog-react-native-session-replay@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/posthog-react-native-session-replay/-/posthog-react-native-session-replay-0.1.2.tgz#082d0a7269e418fab9a3df1546b63fc1836f4a6f"
+  integrity sha512-UeVZjO0XHBBQ3LY8kz37dXEkHiD93GkIs2NgYAkjnfT/kEqW29N3RRvVdS4dSqfCJejijCN2YjxrHx949oALDw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Problem

Depends on https://github.com/PostHog/posthog-react-native-session-replay/pull/5/files

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
