### PR TITLE
Remove Debug Statement when SessionReplay doesn't load

### DIFF
--- a/posthog-react-native/src/optional/OptionalSessionReplay.ts
+++ b/posthog-react-native/src/optional/OptionalSessionReplay.ts
@@ -10,7 +10,4 @@ try {
     web: undefined,
     default: require('posthog-react-native-session-replay'), // Only Android and iOS
   })
-} catch (e) {
-  // do nothing
-  console.warn('PostHog Debug', `Error loading posthog-react-native-session-replay: ${e}`)
-}
+} catch (e) { }


### PR DESCRIPTION
This brings the structure in line with the other optional dependencies, ensuring that logs stay quiet

## Problem

When SessionReplay isn't installed, it produces a warning log. This is inconsistent with the other optional dependencies.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Removed a warning log when posthog-react-native-session-replay is not installed
