### PR TITLE
fix: only logging if debug enabled

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -113,11 +113,15 @@ export abstract class PostHogCoreStateless {
     this._isInitialized = true
   }
 
+  protected logMsgIfDebug(fn: () => void): void {
+    if (this.isDebug) {
+      fn()
+    }
+  }
+
   protected wrap(fn: () => void): void {
     if (this.disabled) {
-      if (this.isDebug) {
-        console.warn('[PostHog] The client is disabled')
-      }
+      this.logMsgIfDebug(() => console.warn('[PostHog] The client is disabled'))
       return
     }
 
@@ -500,7 +504,7 @@ export abstract class PostHogCoreStateless {
 
       if (queue.length >= this.maxQueueSize) {
         queue.shift()
-        console.info('Queue is full, the oldest event is dropped.')
+        this.logMsgIfDebug(() => console.info('Queue is full, the oldest event is dropped.'))
       }
 
       queue.push({ message })
@@ -695,7 +699,7 @@ export abstract class PostHogCoreStateless {
       if (!isPostHogFetchError(e)) {
         throw e
       }
-      console.error('Error while shutting down PostHog', e)
+      this.logMsgIfDebug(() => console.error('Error while shutting down PostHog', e))
     }
   }
 }
@@ -1167,9 +1171,11 @@ export abstract class PostHogCore extends PostHogCoreStateless {
             const sessionReplay = res?.sessionRecording
             if (sessionReplay) {
               this.setPersistedProperty(PostHogPersistedProperty.SessionReplay, sessionReplay)
-              console.log('PostHog Debug', 'Session replay config: ', JSON.stringify(sessionReplay))
+              this.logMsgIfDebug(() =>
+                console.log('PostHog Debug', 'Session replay config: ', JSON.stringify(sessionReplay))
+              )
             } else {
-              console.info('PostHog Debug', 'Session replay config disabled.')
+              this.logMsgIfDebug(() => console.info('PostHog Debug', 'Session replay config disabled.'))
               this.setPersistedProperty(PostHogPersistedProperty.SessionReplay, null)
             }
           }
@@ -1310,7 +1316,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
       .catch((e) => {
         cb?.(e, undefined)
         if (!cb) {
-          console.log('[PostHog] Error reloading feature flags', e)
+          this.logMsgIfDebug(() => console.log('[PostHog] Error reloading feature flags', e))
         }
       })
   }

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 4.2.1 - 2024-10-14
+
+1. fix: only log messages if debug is enabled
+
 # 4.2.0 - 2024-08-26
 
 1. Added `historicalMigration` option for use in tools that are migrating large data to PostHog

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -90,6 +90,12 @@ class FeatureFlagsPoller {
     this.debugMode = enabled
   }
 
+  private logMsgIfDebug(fn: () => void): void {
+    if (this.debugMode) {
+      fn()
+    }
+  }
+
   async getFeatureFlag(
     key: string,
     distinctId: string,
@@ -99,7 +105,7 @@ class FeatureFlagsPoller {
   ): Promise<string | boolean | undefined> {
     await this.loadFeatureFlags()
 
-    let response = undefined
+    let response: string | boolean | PromiseLike<string | boolean | undefined> | undefined = undefined
     let featureFlag = undefined
 
     if (!this.loadedSuccessfullyOnce) {
@@ -116,14 +122,10 @@ class FeatureFlagsPoller {
     if (featureFlag !== undefined) {
       try {
         response = this.computeFlagLocally(featureFlag, distinctId, groups, personProperties, groupProperties)
-        if (this.debugMode) {
-          console.debug(`Successfully computed flag locally: ${key} -> ${response}`)
-        }
+        this.logMsgIfDebug(() => console.debug(`Successfully computed flag locally: ${key} -> ${response}`))
       } catch (e) {
         if (e instanceof InconclusiveMatchError) {
-          if (this.debugMode) {
-            console.debug(`InconclusiveMatchError when computing flag locally: ${key}: ${e}`)
-          }
+          this.logMsgIfDebug(() => console.debug(`InconclusiveMatchError when computing flag locally: ${key}: ${e}`))
         } else if (e instanceof Error) {
           this.onError?.(new Error(`Error computing flag locally: ${key}: ${e}`))
         }
@@ -219,18 +221,18 @@ class FeatureFlagsPoller {
       const groupName = this.groupTypeMapping[String(aggregation_group_type_index)]
 
       if (!groupName) {
-        if (this.debugMode) {
+        this.logMsgIfDebug(() =>
           console.warn(
             `[FEATURE FLAGS] Unknown group type index ${aggregation_group_type_index} for feature flag ${flag.key}`
           )
-        }
+        )
         throw new InconclusiveMatchError('Flag has unknown group type index')
       }
 
       if (!(groupName in groups)) {
-        if (this.debugMode) {
+        this.logMsgIfDebug(() =>
           console.warn(`[FEATURE FLAGS] Can't compute group feature flag: ${flag.key} without group names passed in`)
-        }
+        )
         return false
       }
 
@@ -307,9 +309,7 @@ class FeatureFlagsPoller {
   ): boolean {
     const rolloutPercentage = condition.rollout_percentage
     const warnFunction = (msg: string): void => {
-      if (this.debugMode) {
-        console.warn(msg)
-      }
+      this.logMsgIfDebug(() => console.warn(msg))
     }
     if ((condition.properties || []).length > 0) {
       for (const prop of condition.properties) {
@@ -590,6 +590,7 @@ function matchCohort(
 }
 
 function matchPropertyGroup(
+  this: any,
   propertyGroup: PropertyGroup,
   propertyValues: Record<string, any>,
   cohortProperties: FeatureFlagsPoller['cohorts'],
@@ -626,9 +627,7 @@ function matchPropertyGroup(
         }
       } catch (err) {
         if (err instanceof InconclusiveMatchError) {
-          if (debugMode) {
-            console.debug(`Failed to compute property ${prop} locally: ${err}`)
-          }
+          this.logMsgIfDebug(() => console.debug(`Failed to compute property ${prop} locally: ${err}`))
           errorMatchingLocally = true
         } else {
           throw err
@@ -672,9 +671,7 @@ function matchPropertyGroup(
         }
       } catch (err) {
         if (err instanceof InconclusiveMatchError) {
-          if (debugMode) {
-            console.debug(`Failed to compute property ${prop} locally: ${err}`)
-          }
+          this.logMsgIfDebug(() => console.debug(`Failed to compute property ${prop} locally: ${err}`))
           errorMatchingLocally = true
         } else {
           throw err

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -105,7 +105,7 @@ class FeatureFlagsPoller {
   ): Promise<string | boolean | undefined> {
     await this.loadFeatureFlags()
 
-    let response: string | boolean | PromiseLike<string | boolean | undefined> | undefined = undefined
+    let response: string | boolean | undefined = undefined
     let featureFlag = undefined
 
     if (!this.loadedSuccessfullyOnce) {
@@ -590,7 +590,6 @@ function matchCohort(
 }
 
 function matchPropertyGroup(
-  this: any,
   propertyGroup: PropertyGroup,
   propertyValues: Record<string, any>,
   cohortProperties: FeatureFlagsPoller['cohorts'],
@@ -627,7 +626,9 @@ function matchPropertyGroup(
         }
       } catch (err) {
         if (err instanceof InconclusiveMatchError) {
-          this.logMsgIfDebug(() => console.debug(`Failed to compute property ${prop} locally: ${err}`))
+          if (debugMode) {
+            console.debug(`Failed to compute property ${prop} locally: ${err}`)
+          }
           errorMatchingLocally = true
         } else {
           throw err
@@ -671,7 +672,9 @@ function matchPropertyGroup(
         }
       } catch (err) {
         if (err instanceof InconclusiveMatchError) {
-          this.logMsgIfDebug(() => console.debug(`Failed to compute property ${prop} locally: ${err}`))
+          if (debugMode) {
+            console.debug(`Failed to compute property ${prop} locally: ${err}`)
+          }
           errorMatchingLocally = true
         } else {
           throw err

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.3.4 - 2024-10-14
+
+1. fix: only log messages if debug is enabled
+
 # 3.3.3 - 2024-10-11
 
 1. fix: bootstrap flags do not overwrite the current values

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog-react-native-session-replay/issues/7

## Changes

Only logs message if debug is enabled

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [x] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
