### PR TITLE
fix: only tries to read device context from react-native-device-info if expo libs are not available

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+# 3.3.5 - 2024-10-15
+
 1. fix: only tries to read device context from react-native-device-info if expo libs are not available
 
 # 3.3.4 - 2024-10-14

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+1. fix: only tries to read device context from react-native-device-info if expo libs are not available
+
 # 3.3.4 - 2024-10-14
 
 1. fix: only log messages if debug is enabled

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/src/native-deps.tsx
+++ b/posthog-react-native/src/native-deps.tsx
@@ -25,6 +25,11 @@ export const getAppProperties = (): PostHogCustomAppProperties => {
     properties.$app_name = OptionalExpoApplication.applicationName
     properties.$app_namespace = OptionalExpoApplication.applicationId
     properties.$app_version = OptionalExpoApplication.nativeApplicationVersion
+  } else if (OptionalReactNativeDeviceInfo) {
+    properties.$app_build = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getBuildNumber())
+    properties.$app_name = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getApplicationName())
+    properties.$app_namespace = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getBundleId())
+    properties.$app_version = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getVersion())
   }
 
   if (OptionalExpoDevice) {
@@ -33,23 +38,17 @@ export const getAppProperties = (): PostHogCustomAppProperties => {
     properties.$device_name = OptionalExpoDevice.modelName
     properties.$os_name = OptionalExpoDevice.osName
     properties.$os_version = OptionalExpoDevice.osVersion
-  }
-
-  if (OptionalExpoLocalization) {
-    properties.$locale = OptionalExpoLocalization.locale
-    properties.$timezone = OptionalExpoLocalization.timezone
-  }
-
-  if (OptionalReactNativeDeviceInfo) {
-    properties.$app_build = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getBuildNumber())
-    properties.$app_name = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getApplicationName())
-    properties.$app_namespace = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getBundleId())
-    properties.$app_version = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getVersion())
+  } else if (OptionalReactNativeDeviceInfo) {
     properties.$device_manufacturer = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getManufacturerSync())
     // react-native-device-info already maps the device model identifier to a human readable name
     properties.$device_name = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getModel())
     properties.$os_name = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getSystemName())
     properties.$os_version = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getSystemVersion())
+  }
+
+  if (OptionalExpoLocalization) {
+    properties.$locale = OptionalExpoLocalization.locale
+    properties.$timezone = OptionalExpoLocalization.timezone
   }
 
   return properties


### PR DESCRIPTION
## Problem

Relates to https://posthoghelp.zendesk.com/agent/tickets/19293

## Changes

Found a follow-up as well https://github.com/PostHog/posthog-js-lite/issues/286

Tries to read device context from Expo libs, if not available, tries to read from react-native-device-info, but not from both.
They overwrite each other values and just cause unnecessary issues.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
