### PR TITLE
fix: all sdkReplayConfig should have a default value

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.3.6 - 2024-10-19
+
+1. fix: all sdkReplayConfig should have a default value
+
 # 3.3.5 - 2024-10-15
 
 1. fix: only tries to read device context from react-native-device-info if expo libs are not available

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -278,13 +278,22 @@ export class PostHog extends PostHogCore {
       return
     }
 
-    const sdkReplayConfig = options?.sessionReplayConfig ?? {
-      maskAllTextInputs: true,
-      maskAllImages: true,
-      captureLog: true,
-      captureNetworkTelemetry: true,
-      iOSdebouncerDelayMs: 1000,
-      androidDebouncerDelayMs: 500,
+    const {
+      maskAllTextInputs = true,
+      maskAllImages = true,
+      captureLog = true,
+      captureNetworkTelemetry = true,
+      iOSdebouncerDelayMs = 1000,
+      androidDebouncerDelayMs = 500,
+    } = options?.sessionReplayConfig ?? {}
+
+    const sdkReplayConfig = {
+      maskAllTextInputs,
+      maskAllImages,
+      captureLog,
+      captureNetworkTelemetry,
+      iOSdebouncerDelayMs,
+      androidDebouncerDelayMs,
     }
 
     this.logMsgIfDebug(() =>


### PR DESCRIPTION
## Problem

https://posthog.com/questions/installing-session-replay-and-updating-posthog-crashes-the-app

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
