### PR TITLE
chore: change androidDebouncerDelayMs default from 500ms to 1000ms (1s)

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.3.8 - 2024-10-25
+
+1. chore: change androidDebouncerDelayMs default from 500ms to 1000ms (1s)
+
 # 3.3.7 - 2024-10-25
 
 1. fix: session replay respects the `disabled` flag

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"
@@ -33,7 +33,7 @@
     "react-native": "^0.69.1",
     "react-native-device-info": "^10.3.0",
     "react-native-navigation": "^6.0.0",
-    "posthog-react-native-session-replay": "^0.1.5"
+    "posthog-react-native-session-replay": "^0.1.6"
   },
   "peerDependencies": {
     "@react-native-async-storage/async-storage": ">=1.0.0",
@@ -44,7 +44,7 @@
     "expo-localization": ">= 11.0.0",
     "react-native-device-info": ">= 10.0.0",
     "react-native-navigation": ">=6.0.0",
-    "posthog-react-native-session-replay": "^0.1.5"
+    "posthog-react-native-session-replay": "^0.1.6"
   },
   "peerDependenciesMeta": {
     "@react-native-async-storage/async-storage": {

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -288,7 +288,7 @@ export class PostHog extends PostHogCore {
       captureLog = true,
       captureNetworkTelemetry = true,
       iOSdebouncerDelayMs = 1000,
-      androidDebouncerDelayMs = 500,
+      androidDebouncerDelayMs = 1000,
     } = options?.sessionReplayConfig ?? {}
 
     const sdkReplayConfig = {

--- a/posthog-react-native/src/types.ts
+++ b/posthog-react-native/src/types.ts
@@ -78,7 +78,8 @@ export type PostHogSessionReplayConfig = {
    * Deboucer delay used to reduce the number of snapshots captured and reduce performance impact
    * This is used for capturing the view as a screenshot
    * The lower the number more snapshots will be captured but higher the performance impact
-   * Defaults to 0.5s
+   * Defaults to 1000ms (1s)
+   * Ps: it was 500ms (0.5s) by default until version 3.3.7
    */
   androidDebouncerDelayMs?: number
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -8551,10 +8551,10 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
   integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
 
-posthog-react-native-session-replay@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/posthog-react-native-session-replay/-/posthog-react-native-session-replay-0.1.5.tgz#85af854b40b8f94edf0a847d4622afa5b3888891"
-  integrity sha512-roFi9JDrJ8Nd2yvp7FqEbleHQV3Jv+Gh0cKHXYs98HDHuPy3ELnXOgcBU5BG0GmRVPxF9GLOaxbSiak6kaVQbg==
+posthog-react-native-session-replay@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/posthog-react-native-session-replay/-/posthog-react-native-session-replay-0.1.6.tgz#23674ff31cedbf305c73bd725385cb938054617b"
+  integrity sha512-QheDjtUvUsrQoW2SUZSxpLKWiMLvz9NTPeFgdB2bXRi8RrJaqHyZjlF/hIw1NxomLVl0XddZDGaIKiTsTx95Og==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Problem

Relates to https://github.com/PostHog/posthog-react-native-session-replay/issues/10

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
