### PR TITLE
fix: rollback module to ESNext

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.3.9 - 2024-10-26
+
+1. fix: rollback module to ESNext
+
 # 3.3.8 - 2024-10-25
 
 1. chore: change androidDebouncerDelayMs default from 500ms to 1000ms (1s)

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/tsconfig.json
+++ b/posthog-react-native/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "jsx": "react-native",
     "lib": ["ESNext"],
-    "module": "node16",
+    "module": "ESNext",
     "moduleResolution": "node16",
     "noEmitOnError": true,
     "outDir": "./lib",


### PR DESCRIPTION
## Problem

re https://github.com/PostHog/posthog-js-lite/pull/294#discussion_r1815663690
Closes https://github.com/PostHog/posthog-js-lite/issues/298 ?
Everything works locally just fine but that was the only change that could make that happen


## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
