### PR TITLE
fix: Enforce the shutdown timeout 

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -708,14 +708,14 @@ export abstract class PostHogCoreStateless {
     }
 
     return Promise.race([
-      doShutdown(),
       new Promise<void>((_, reject) => {
         safeSetTimeout(() => {
           this.logMsgIfDebug(() => console.error('Timed out while shutting down PostHog'))
           hasTimedOut = true
-          reject()
+          reject('Timeout while shutting down PostHog. Some events may not have been sent.')
         }, shutdownTimeoutMs)
       }),
+      doShutdown(),
     ])
   }
 }

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -709,9 +709,9 @@ export abstract class PostHogCoreStateless {
 
     return Promise.race([
       doShutdown(),
-      new Promise<void>((resolve, reject) => {
+      new Promise<void>((_, reject) => {
         safeSetTimeout(() => {
-          this.logMsgIfDebug(() => console.error('Timedout while shutting down PostHog'))
+          this.logMsgIfDebug(() => console.error('Timed out while shutting down PostHog'))
           hasTimedOut = true
           reject()
         }, shutdownTimeoutMs)

--- a/posthog-core/test/posthog.shutdown.spec.ts
+++ b/posthog-core/test/posthog.shutdown.spec.ts
@@ -21,5 +21,22 @@ describe('PostHog Core', () => {
       await posthog.shutdown()
       expect(mocks.fetch).toHaveBeenCalledTimes(1)
     })
+
+    it.only('respects timeout', async () => {
+      mocks.fetch.mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        console.log('FETCH RETURNED')
+        return {
+          status: 200,
+          text: () => Promise.resolve('ok'),
+          json: () => Promise.resolve({ status: 'ok' }),
+        }
+      })
+
+      posthog.capture('test-event')
+
+      await expect(posthog.shutdown(100)).rejects.toThrow('Timeout')
+      expect(mocks.fetch).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/posthog-core/test/posthog.shutdown.spec.ts
+++ b/posthog-core/test/posthog.shutdown.spec.ts
@@ -35,7 +35,14 @@ describe('PostHog Core', () => {
 
       posthog.capture('test-event')
 
-      await expect(posthog.shutdown(100)).rejects.toThrow('Timeout')
+      await posthog
+        .shutdown(100)
+        .then(() => {
+          throw new Error('Should not resolve')
+        })
+        .catch((e) => {
+          expect(e).toEqual('Timeout while shutting down PostHog. Some events may not have been sent.')
+        })
       expect(mocks.fetch).toHaveBeenCalledTimes(1)
     })
   })

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 4.2.2 - 2024-11-18
+
+1. fix: Shutdown will now respect the timeout and forcefully return rather than returning after the next fetch.
+
 # 4.2.1 - 2024-10-14
 
 1. fix: only log messages if debug is enabled

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

The shutdown timeout is misleading. If a fetch request is timing out we may still sit on it as we only do the check after it is done.

## Changes

Change to a timeout based solution. It's a little complex but i think thats just _the way_.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-react-native

### Changelog notes

- Shutdown will now respect the timeout and forcefully return rather than returning after the next fetch.
