### PR TITLE
fix: respect the given propsToCapture autocapture option

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.3.11 - 2024-11-13
+
+1. fix: respect the given propsToCapture autocapture option
+
 # 3.3.10 - 2024-11-04
 
 1. fix: capture customLabelProp if set

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/src/autocapture.tsx
+++ b/posthog-react-native/src/autocapture.tsx
@@ -47,8 +47,8 @@ export const autocaptureFromTouchEvent = (e: any, posthog: PostHog, options: Pos
     customLabelProp = defaultPostHogLabelProp,
     maxElementsCaptured = 20,
     ignoreLabels = [],
+    propsToCapture = ['style', 'testID', 'accessibilityLabel', customLabelProp, 'children'],
   } = options
-  const propsToCapture = ['style', 'testID', 'accessibilityLabel', customLabelProp, 'children']
 
   if (!e._targetInst) {
     return


### PR DESCRIPTION
## Problem

follow up https://github.com/PostHog/posthog-js-lite/pull/302/files

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
