### PR TITLE
fix: session replay forces the session id if the SDK is already enabled

### DIFF
--- a/examples/example-expo-latest/package.json
+++ b/examples/example-expo-latest/package.json
@@ -21,7 +21,7 @@
     "expo-localization": "~15.0.3",
     "expo-status-bar": "~1.12.1",
     "posthog-react-native": "file:.yalc/posthog-react-native",
-    "posthog-react-native-session-replay": "^0.1.2",
+    "posthog-react-native-session-replay": "^0.1.6",
     "react": "18.2.0",
     "react-native": "0.74.5"
   },

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+# 3.3.13 - 2024-11-18
+
 # 3.3.12 - 2024-11-18
 
 1. fix: session replay forces the session id if the SDK is already enabled

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Next
 
-# 3.3.13 - 2024-11-18
-
 # 3.3.12 - 2024-11-18
 
 1. fix: session replay forces the session id if the SDK is already enabled

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.3.12 - 2024-11-18
+
+1. fix: session replay forces the session id if the SDK is already enabled
+
 # 3.3.11 - 2024-11-13
 
 1. fix: respect the given propsToCapture autocapture option

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -216,9 +216,9 @@ export class PostHog extends PostHogCore {
     return !this.isDisabled && (this._enableSessionReplay ?? false)
   }
 
-  _resetSessionId(sessionId: string): void {
-    OptionalReactNativeSessionReplay.endSession()
-    OptionalReactNativeSessionReplay.startSession(sessionId)
+  _resetSessionId(reactNativeSessionReplay: OptionalReactNativeSessionReplay, sessionId: string): void {
+    reactNativeSessionReplay.endSession()
+    reactNativeSessionReplay.startSession(sessionId)
   }
 
   getSessionId(): string {
@@ -232,7 +232,7 @@ export class PostHog extends PostHogCore {
     if (sessionId.length > 0 && this._currentSessionId && sessionId !== this._currentSessionId) {
       if (OptionalReactNativeSessionReplay) {
         try {
-          this._resetSessionId(sessionId)
+          this._resetSessionId(OptionalReactNativeSessionReplay, sessionId)
           this.logMsgIfDebug(() => console.info('PostHog Debug', `Session replay started with sessionId ${sessionId}.`))
         } catch (e) {
           this.logMsgIfDebug(() =>
@@ -352,7 +352,7 @@ export class PostHog extends PostHogCore {
             )
           } else {
             // if somehow the SDK is already enabled with a different sessionId, we reset it
-            this._resetSessionId(sessionId)
+            this._resetSessionId(OptionalReactNativeSessionReplay, sessionId)
             this.logMsgIfDebug(() =>
               console.log('PostHog Debug', `Session replay already started with sessionId ${sessionId}.`)
             )

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -217,8 +217,8 @@ export class PostHog extends PostHogCore {
   }
 
   _resetSessionId(reactNativeSessionReplay: typeof OptionalReactNativeSessionReplay, sessionId: string): void {
-    reactNativeSessionReplay.endSession()
-    reactNativeSessionReplay.startSession(sessionId)
+    reactNativeSessionReplay?.endSession()
+    reactNativeSessionReplay?.startSession(sessionId)
   }
 
   getSessionId(): string {

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -216,9 +216,15 @@ export class PostHog extends PostHogCore {
     return !this.isDisabled && (this._enableSessionReplay ?? false)
   }
 
-  _resetSessionId(reactNativeSessionReplay: typeof OptionalReactNativeSessionReplay, sessionId: string): void {
-    reactNativeSessionReplay?.endSession()
-    reactNativeSessionReplay?.startSession(sessionId)
+  _resetSessionId(
+    reactNativeSessionReplay: typeof OptionalReactNativeSessionReplay | undefined,
+    sessionId: string
+  ): void {
+    // _resetSessionId is only called if reactNativeSessionReplay not undefined, but the linter wasn't happy
+    if (reactNativeSessionReplay) {
+      reactNativeSessionReplay.endSession()
+      reactNativeSessionReplay.startSession(sessionId)
+    }
   }
 
   getSessionId(): string {

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -216,6 +216,11 @@ export class PostHog extends PostHogCore {
     return !this.isDisabled && (this._enableSessionReplay ?? false)
   }
 
+  _resetSessionId(sessionId: string): void {
+    OptionalReactNativeSessionReplay.endSession()
+    OptionalReactNativeSessionReplay.startSession(sessionId)
+  }
+
   getSessionId(): string {
     const sessionId = super.getSessionId()
 
@@ -227,8 +232,7 @@ export class PostHog extends PostHogCore {
     if (sessionId.length > 0 && this._currentSessionId && sessionId !== this._currentSessionId) {
       if (OptionalReactNativeSessionReplay) {
         try {
-          OptionalReactNativeSessionReplay.endSession()
-          OptionalReactNativeSessionReplay.startSession(sessionId)
+          this._resetSessionId(sessionId)
           this.logMsgIfDebug(() => console.info('PostHog Debug', `Session replay started with sessionId ${sessionId}.`))
         } catch (e) {
           this.logMsgIfDebug(() =>
@@ -237,6 +241,11 @@ export class PostHog extends PostHogCore {
         }
       }
       this._currentSessionId = sessionId
+    } else {
+      console.log(
+        'PostHog Debug',
+        `Session replay session id not rotated, sessionId ${sessionId} and currentSessionId ${this._currentSessionId}.`
+      )
     }
 
     return sessionId
@@ -342,7 +351,11 @@ export class PostHog extends PostHogCore {
               console.info('PostHog Debug', `Session replay started with sessionId ${sessionId}.`)
             )
           } else {
-            this.logMsgIfDebug(() => console.log('PostHog Debug', `Session replay already started.`))
+            // if somehow the SDK is already enabled with a different sessionId, we reset it
+            this._resetSessionId(sessionId)
+            this.logMsgIfDebug(() =>
+              console.log('PostHog Debug', `Session replay already started with sessionId ${sessionId}.`)
+            )
           }
         } catch (e) {
           this.logMsgIfDebug(() => console.error('PostHog Debug', `Session replay failed to start: ${e}.`))

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -216,7 +216,7 @@ export class PostHog extends PostHogCore {
     return !this.isDisabled && (this._enableSessionReplay ?? false)
   }
 
-  _resetSessionId(reactNativeSessionReplay: OptionalReactNativeSessionReplay, sessionId: string): void {
+  _resetSessionId(reactNativeSessionReplay: typeof OptionalReactNativeSessionReplay, sessionId: string): void {
     reactNativeSessionReplay.endSession()
     reactNativeSessionReplay.startSession(sessionId)
   }


### PR DESCRIPTION
## Problem

for some reason, sometimes but not so rarely, the recording does not have associated events but the SDK did capture events, and the session id does not match.
I believe the SDK can be already enabled or the session id rotated wrongly in the native SDK.
Now the hybrid SDK fully controls the session id lifecycle and if the SDK is somehow already enabled, we force the session id again.
Depends on https://github.com/PostHog/posthog-ios/pull/253 as well

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
