### PR TITLE
fix: update Sentry Integration

### DIFF
--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -27,6 +27,7 @@
     "rusha": "^0.8.14"
   },
   "devDependencies": {
+    "@sentry/types": "^8.38.0",
     "@types/node": "^18.0.0",
     "commander": "^9.3.0"
   },

--- a/posthog-node/test/extensions/sentry-integration.spec.ts
+++ b/posthog-node/test/extensions/sentry-integration.spec.ts
@@ -93,6 +93,7 @@ describe('PostHogSentryIntegration', () => {
     expect(mockedFetch).toHaveBeenCalledTimes(0)
 
     const mockSentry = {
+			addEventProcessor: (fn) => (processorFunction = fn),
       getClient: () => ({
         getDsn: () => ({
           projectId: 123,
@@ -102,10 +103,12 @@ describe('PostHogSentryIntegration', () => {
 
     let processorFunction: any
 
-    posthogSentry.setupOnce(
-      (fn) => (processorFunction = fn),
-      () => mockSentry
-    )
+    // posthogSentry.setupOnce(
+    //   (fn) => (processorFunction = fn),
+    //   () => mockSentry
+    // )
+
+		posthogSentry.setup(mockSentry)
 
     processorFunction(createMockSentryException())
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2370,6 +2370,11 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
+"@sentry/types@^8.38.0":
+  version "8.38.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.38.0.tgz#9c48734a8b4055bfd553a0141efec78e9680ed09"
+  integrity sha512-fP5H9ZX01W4Z/EYctk3mkSHi7d06cLcX2/UWqwdWbyPWI+pL2QpUPICeO/C+8SnmYx//wFj3qWDhyPCh1PdFAA==
+
 "@sideway/address@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"


### PR DESCRIPTION
## Problem

In the current version of Sentry, they have changed their Integration type. In the current state, when trying to add the Posthog Integration to Sentry it's throwing an error:

```
Type 'PostHogSentryIntegration' is not assignable to type 'Integration'.
  Types of property 'setupOnce' are incompatible.
    Type '(addGlobalEventProcessor: (callback: any) => void, getCurrentHub: () => any) => void' is not assignable to type '() => void'.
      Target signature provides too few arguments. Expected 2 or more, but got 0.ts(2322)
```

[A couple other users on the PostHog integration page have also been running into this issue](https://posthog.com/docs/libraries/node) mentioned by Ariel and Vitor.

This is related to two breaking changes in Sentry's updated Integration:
1. The `setupOnce()` method no longer passes any functions.
2. `getCurrentHub()` is being [deprecated](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-getcurrenthub)

The PostHog sentry-integration now needs a different way to get the projectId and add events coming from Sentry, which are used in capture events in posthog.

Last thing I'll say is that this is my first open source contribution! So apologies if something is messy or not right :) Please let me know if there's anything I can improve!

## Changes

Since the method `setupOnce()` no longer passes the current functions used for events and hub, we need to use `setup()` which passes the Sentry `client()` class. Using that class, we have access to `addEventProcessor(event)` function and `getDsn().projectId` that was previously being used. That satisfies the information needed by PostHog.

We also no longer need the specific _SentryIntegration interface.

I've also updated the tests to account for the new `setup()` class with the `addEventProcessor()` function. It's currently passing on my local machine.

## Release info Sub-libraries affected

As noted in the integration, we don't import `@sentry/types`, but the latest ones were used to check everything in development.

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Fixed the PostHog Sentry Integration to support the latest version of Sentry (v8)
