### PR TITLE
fix: session replay respects the flushAt flag

### DIFF
--- a/examples/example-expo-latest/App.tsx
+++ b/examples/example-expo-latest/App.tsx
@@ -2,11 +2,17 @@ import React, { useState } from 'react'
 import { StatusBar } from 'expo-status-bar'
 import { StyleSheet, Text, View } from 'react-native'
 import PostHog, { PostHogProvider } from 'posthog-react-native'
+// import { WebView } from 'react-native-webview';
 
 export const posthog = new PostHog('phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D', {
   host: 'https://us.i.posthog.com',
   flushAt: 1,
   enableSessionReplay: true,
+  // if using WebView, you have to disable masking for text inputs and images
+  // sessionReplayConfig: {
+  //   maskAllTextInputs: false,
+  //   maskAllImages: false,
+  // },
 })
 posthog.debug(true)
 
@@ -26,6 +32,11 @@ export const SharedPostHogProvider = (props: any) => {
     </PostHogProvider>
   )
 }
+
+// you can use accessibilityLabel='ph-no-capture' to prevent capturing the WebView
+// const MyWebComponent = () => {
+//   return <WebView source={{ uri: 'https://reactnative.dev/' }} style={{ flex: 1 }} />;
+// }
 
 export default function App() {
   const [buttonText, setButtonText] = useState('Open up App.js to start working on your app!')

--- a/examples/example-expo-latest/package.json
+++ b/examples/example-expo-latest/package.json
@@ -21,7 +21,7 @@
     "expo-localization": "~15.0.3",
     "expo-status-bar": "~1.12.1",
     "posthog-react-native": "file:.yalc/posthog-react-native",
-    "posthog-react-native-session-replay": "^0.1.6",
+    "posthog-react-native-session-replay": "^0.1",
     "react": "18.2.0",
     "react-native": "0.74.5",
     "react-native-webview": "^13.12.4"

--- a/examples/example-expo-latest/package.json
+++ b/examples/example-expo-latest/package.json
@@ -23,7 +23,8 @@
     "posthog-react-native": "file:.yalc/posthog-react-native",
     "posthog-react-native-session-replay": "^0.1.6",
     "react": "18.2.0",
-    "react-native": "0.74.5"
+    "react-native": "0.74.5",
+    "react-native-webview": "^13.12.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/examples/example_rn/package.json
+++ b/examples/example_rn/package.json
@@ -24,7 +24,7 @@
     "react-native": "0.73.2",
     "react-native-device-info": "^10.12.0",
     "react-native-navigation": "^7.37.2",
-    "posthog-react-native-session-replay": "^0.1.2"
+    "posthog-react-native-session-replay": "^0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -51,7 +51,7 @@ export abstract class PostHogCoreStateless {
   // options
   readonly apiKey: string
   readonly host: string
-  private flushAt: number
+  readonly flushAt: number
   private maxBatchSize: number
   private maxQueueSize: number
   private flushInterval: number

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+# 3.3.13 - 2024-11-19
+
 1. fix: session replay respects the flushAt flag
 
 # 3.3.12 - 2024-11-18

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+1. fix: session replay respects the flushAt flag
+
 # 3.3.12 - 2024-11-18
 
 1. fix: session replay forces the session id if the SDK is already enabled

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -33,7 +33,7 @@
     "react-native": "^0.69.1",
     "react-native-device-info": "^10.3.0",
     "react-native-navigation": "^6.0.0",
-    "posthog-react-native-session-replay": "^0.1.6"
+    "posthog-react-native-session-replay": "^0.1"
   },
   "peerDependencies": {
     "@react-native-async-storage/async-storage": ">=1.0.0",
@@ -44,7 +44,7 @@
     "expo-localization": ">= 11.0.0",
     "react-native-device-info": ">= 10.0.0",
     "react-native-navigation": ">=6.0.0",
-    "posthog-react-native-session-replay": "^0.1.6"
+    "posthog-react-native-session-replay": "^0.1"
   },
   "peerDependenciesMeta": {
     "@react-native-async-storage/async-storage": {

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -344,6 +344,7 @@ export class PostHog extends PostHogCore {
           distinctId: this.getDistinctId(),
           anonymousId: this.getAnonymousId(),
           sdkVersion: this.getLibraryVersion(),
+          flushAt: this.flushAt,
         }
 
         this.logMsgIfDebug(() =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8551,10 +8551,10 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
   integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
 
-posthog-react-native-session-replay@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/posthog-react-native-session-replay/-/posthog-react-native-session-replay-0.1.6.tgz#23674ff31cedbf305c73bd725385cb938054617b"
-  integrity sha512-QheDjtUvUsrQoW2SUZSxpLKWiMLvz9NTPeFgdB2bXRi8RrJaqHyZjlF/hIw1NxomLVl0XddZDGaIKiTsTx95Og==
+posthog-react-native-session-replay@^0.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/posthog-react-native-session-replay/-/posthog-react-native-session-replay-0.1.7.tgz#07c2c785407d3f6863160c1f0f40c2ff257156bb"
+  integrity sha512-ARau1AtJANnxsJG3dQkEJqD4E49fb0CcqdfK6UalwE4/fTkhzxrItbEYDACss3Lsswo0f8SXCCzWrbQFzha5Lw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Problem

recordings are only flushed when flushAt is at 20 which is the default value on Mobile but not the given flushAt when intiting the RN SDK
Depends on https://github.com/PostHog/posthog-react-native-session-replay/pull/13

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
