### PR TITLE
Revert "fix(flags): send `feature_flag_called` events with correct payload data in the event that we need to fetch the payloads from the server"

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Next
 
+# 4.3.2 - 2024-12-11
+
+1. Revert: Fix bug where this SDK incorrectly sent `$feature_flag_called` events with null values when using `getFeatureFlagPayload`.
+
+# 4.3.1 - 2024-11-26
+
+1. Fix bug where this SDK incorrectly sent `$feature_flag_called` events with null values when using `getFeatureFlagPayload`.
+
 # 4.3.0 - 2024-11-25
 
 1. Add Sentry v8 support to the Sentry integration

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Next
 
-# 4.3.1 - 2024-11-26
-
-1. Fix bug where this SDK incorrectly sent `$feature_flag_called` events with null values when using `getFeatureFlagPayload`.
-
 # 4.3.0 - 2024-11-25
 
 1. Add Sentry v8 support to the Sentry integration

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 4.3.2 - 2024-12-11
 
-1. Revert: Fix bug where this SDK incorrectly sent `$feature_flag_called` events with null values when using `getFeatureFlagPayload`.
+1. REVERT: Fix bug where this SDK incorrectly sent `$feature_flag_called` events with null values when using `getFeatureFlagPayload`.
 
 # 4.3.1 - 2024-11-26
 

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.3.1",
+  "version": "4.3.0",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.3.0",
+  "version": "4.3.2",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/src/types.ts
+++ b/posthog-node/src/types.ts
@@ -158,7 +158,7 @@ export type PostHogNodeV1 = {
 
   /**
    * @description Retrieves payload associated with the specified flag and matched value that is passed in.
-   * (Expected to be used in conjuction with getFeatureFlag but allows for manual lookup).
+   * (Expected to be used in conjunction with getFeatureFlag but allows for manual lookup).
    * If matchValue isn't passed, getFeatureFlag is called implicitly.
    * Will try to evaluate for payload locally first otherwise default to network call if allowed
    *


### PR DESCRIPTION
Reverts PostHog/posthog-js-lite#315