### PR TITLE
Reduce published to npm files

### DIFF
--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -35,5 +35,8 @@
     "stats",
     "analysis",
     "funnels"
+  ],
+  "files": [
+    "lib/index.*"
   ]
 }


### PR DESCRIPTION
## Problem

Many files such as `.ts`, tests and etc. published to npm but not used anywhere

## Changes

`npm publish --dry-run` run output before/after change

#### Before

```sh
npm notice
npm notice 📦  posthog-node@4.3.2
npm notice Tarball Contents
npm notice 9.4kB CHANGELOG.md
npm notice 151B CONTRIBUTING.md
npm notice 257B README.md
npm notice 89B index.ts
npm notice 95.0kB lib/index.cjs.js
npm notice 223.6kB lib/index.cjs.js.map
npm notice 23.5kB lib/index.d.ts
npm notice 94.8kB lib/index.esm.js
npm notice 223.5kB lib/index.esm.js.map
npm notice 261B lib/posthog-core/src/eventemitter.d.ts
npm notice 9.7kB lib/posthog-core/src/index.d.ts
npm notice 378B lib/posthog-core/src/lz-string.d.ts
npm notice 270B lib/posthog-core/src/storage-memory.d.ts
npm notice 5.0kB lib/posthog-core/src/types.d.ts
npm notice 620B lib/posthog-core/src/utils.d.ts
npm notice 7.9kB lib/posthog-core/src/vendor/uuidv7.d.ts
npm notice 91B lib/posthog-node/index.d.ts
npm notice 2.7kB lib/posthog-node/src/extensions/sentry-integration.d.ts
npm notice 3.6kB lib/posthog-node/src/feature-flags.d.ts
npm notice 611B lib/posthog-node/src/fetch.d.ts
npm notice 3.8kB lib/posthog-node/src/posthog-node.d.ts
npm notice 9.4kB lib/posthog-node/src/types.d.ts
npm notice 352B lib/posthog-node/test/test-utils.d.ts
npm notice 832B package.json
npm notice 6.8kB src/extensions/sentry-integration.ts
npm notice 24.7kB src/feature-flags.ts
npm notice 1.6kB src/fetch.ts
npm notice 15.5kB src/posthog-node.ts
npm notice 9.2kB src/types.ts
npm notice 597B src/types/rusha.d.ts
npm notice 5.0kB test/extensions/sentry-integration.spec.ts
npm notice 118.0kB test/feature-flags.spec.ts
npm notice 41.5kB test/posthog-node.spec.ts
npm notice 1.8kB test/test-utils.ts
npm notice 187B tsconfig.json
npm notice Tarball Details
npm notice name: posthog-node
npm notice version: 4.3.2
npm notice filename: posthog-node-4.3.2.tgz
npm notice package size: 180.7 kB
npm notice unpacked size: 940.8 kB
npm notice shasum: ec8484831b68a189f8e72e63d0b727f003c80541
npm notice integrity: sha512-UhJmKwha8RLQN[...]Wrd8/xgUEgtXw==
npm notice total files: 35
npm notice
```


#### After

```sh
npm notice 📦  posthog-node@4.3.2
npm notice Tarball Contents
npm notice 257B README.md
npm notice 95.0kB lib/index.cjs.js
npm notice 223.6kB lib/index.cjs.js.map
npm notice 23.5kB lib/index.d.ts
npm notice 94.8kB lib/index.esm.js
npm notice 223.5kB lib/index.esm.js.map
npm notice 871B package.json
npm notice Tarball Details
npm notice name: posthog-node
npm notice version: 4.3.2
npm notice filename: posthog-node-4.3.2.tgz
npm notice package size: 141.1 kB
npm notice unpacked size: 661.6 kB
npm notice shasum: 5c28b75eb94e1717a860f21da1a042376cf1a1d3
npm notice integrity: sha512-mQZT0b9EQ2BSB[...]ibqF7r6Eu4p1g==
npm notice total files: 7
```

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [X] posthog-node
- [ ] posthog-react-native

### Changelog notes

- Remove unused files from publishing to npm by specifing [`files` field at `package.json`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files)
