### PR TITLE
fix: os_name was not being set correctly for some devices using expo-device

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.6.1 - 2024-12-17
+
+1. fix: os_name was not being set correctly for some devices using expo-device
+
 # 3.6.0 - 2024-12-12
 
 1. Add new debugging property `$feature_flag_bootstrapped_response`, `$feature_flag_bootstrapped_payload` and `$used_bootstrap_value` to `$feature_flag_called` event

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/src/native-deps.tsx
+++ b/posthog-react-native/src/native-deps.tsx
@@ -36,7 +36,16 @@ export const getAppProperties = (): PostHogCustomAppProperties => {
     properties.$device_manufacturer = OptionalExpoDevice.manufacturer
     // expo-device already maps the device model identifier to a human readable name
     properties.$device_name = OptionalExpoDevice.modelName
-    properties.$os_name = OptionalExpoDevice.osName
+
+    // https://github.com/expo/expo/issues/6990
+    // some devices return a value similar to:
+    // HUAWEI/SNE-LX1/HWSNE:8.1.0/HUAWEISNE-LX1/131(C432):user/release-keys
+    if (Platform.OS === 'android') {
+      properties.$os_name = 'Android'
+    } else {
+      properties.$os_name = OptionalExpoDevice.osName
+    }
+
     properties.$os_version = OptionalExpoDevice.osVersion
   } else if (OptionalReactNativeDeviceInfo) {
     properties.$device_manufacturer = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getManufacturerSync())


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
