### PR TITLE
Set initial currentSessionId, log only with debug flag on.

### DIFF
--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -2073,8 +2073,8 @@ describe('match properties', () => {
     ['is_date_after', '1h', new Date('2022-05-30'), true],
     ['is_date_after', '1h', '2022-04-30', false],
     // # Try all possible relative dates
-    ['is_date_before', '1h', '2022-05-01 00:00:00', false],
-    ['is_date_before', '1h', '2022-04-30 22:00:00', true],
+    ['is_date_before', '1h', '2022-05-01 00:00:00 GMT', false],
+    ['is_date_before', '1h', '2022-04-30 22:00:00 GMT', true],
     ['is_date_before', '-1d', '2022-04-29 23:59:00 GMT', true],
     ['is_date_before', '-1d', '2022-04-30 00:00:01 GMT', false],
     ['is_date_before', '1w', '2022-04-23 00:00:00 GMT', true],

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -2073,8 +2073,8 @@ describe('match properties', () => {
     ['is_date_after', '1h', new Date('2022-05-30'), true],
     ['is_date_after', '1h', '2022-04-30', false],
     // # Try all possible relative dates
-    ['is_date_before', '1h', '2022-05-01 00:00:00 GMT', false],
-    ['is_date_before', '1h', '2022-04-30 22:00:00 GMT', true],
+    ['is_date_before', '1h', '2022-05-01 00:00:00', false],
+    ['is_date_before', '1h', '2022-04-30 22:00:00', true],
     ['is_date_before', '-1d', '2022-04-29 23:59:00 GMT', true],
     ['is_date_before', '-1d', '2022-04-30 00:00:01 GMT', false],
     ['is_date_before', '1w', '2022-04-23 00:00:00 GMT', true],

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.6.2 - 2025-01-13
+
+1. fix: Set initial currentSessionId, log only with debug flag on
+
 # 3.6.1 - 2024-12-17
 
 1. fix: os_name was not being set correctly for some devices using expo-device

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -248,9 +248,11 @@ export class PostHog extends PostHogCore {
       }
       this._currentSessionId = sessionId
     } else {
-      console.log(
-        'PostHog Debug',
-        `Session replay session id not rotated, sessionId ${sessionId} and currentSessionId ${this._currentSessionId}.`
+      this.logMsgIfDebug(() =>
+        console.log(
+          'PostHog Debug',
+          `Session replay session id not rotated, sessionId ${sessionId} and currentSessionId ${this._currentSessionId}.`
+        )
       )
     }
 
@@ -368,6 +370,7 @@ export class PostHog extends PostHogCore {
               console.log('PostHog Debug', `Session replay already started with sessionId ${sessionId}.`)
             )
           }
+          this._currentSessionId = sessionId
         } catch (e) {
           this.logMsgIfDebug(() => console.error('PostHog Debug', `Session replay failed to start: ${e}.`))
         }


### PR DESCRIPTION
## Problem

We are seeing constant logs about the replay session Id not being rotated and it appeared to be a something going wrong. In reality it seems that this was just meant to be debug info so I wrapped it in that flag. Upon closer inspection it seems that the currentSessionId will never have a value so this is now being set after the session replay starts with a session Id the first time.

## Changes

1. Now setting a value to currentSessionId after session replay starts with one the first time.
2. Wrapped the log so its debug only.
 
## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [x] posthog-react-native

### Changelog notes

- Fixed currentSessionId initialization and logging
