### PR TITLE
build: add posthog core to rollup

### DIFF
--- a/posthog-core/index.ts
+++ b/posthog-core/index.ts
@@ -1,0 +1,1 @@
+export * from './src/index'

--- a/posthog-core/package.json
+++ b/posthog-core/package.json
@@ -1,7 +1,9 @@
 {
   "name": "posthog-core",
   "version": "2.1.0",
-  "main": "src/index.ts",
+  "main": "lib/index.cjs.js",
+  "module": "lib/index.esm.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/PostHog/posthog-js-lite.git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ const extensions = ['.js', '.jsx', '.ts', '.tsx']
 
 let globalExternal = Object.keys(pkg.dependencies || {}).concat(Object.keys(pkg.peerDependencies || {}))
 
-const configs = ['posthog-node', 'posthog-web'].reduce((acc, x) => {
+const configs = ['posthog-node', 'posthog-web', 'posthog-core'].reduce((acc, x) => {
   const localPkg = require(`./${x}/package.json`)
   let external = [...globalExternal]
     .concat(Object.keys(localPkg.dependencies || {}))


### PR DESCRIPTION
## Problem

The PostHogCore package is not available when using `posthog-js-lite` as a dependency.

## Changes

The `posthog-core` package is added to the Rollup config

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [X] Minor
- [ ] Patch

### Libraries affected

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native
- [X] posthog-core

### Changelog notes

- Added `posthog-core` as an exported package