### PR TITLE
fix: session replay respect linked feature flags

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.6.3 - 2025-01-16
+
+1. fix: session replay respect linked feature flags
+
 # 3.6.2 - 2025-01-13
 
 1. fix: Set initial currentSessionId, log only with debug flag on

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -351,7 +351,9 @@ export class PostHog extends PostHogCore {
         const value = decideFeatureFlags[flag]
         if (value) {
           recordingActive = value === variant
-          this.logMsgIfDebug(() => console.log('PostHog Debug', `Session replay ${flag} linked flag value: ${value}`))
+          this.logMsgIfDebug(() =>
+            console.log('PostHog Debug', `Session replay ${flag} linked flag variant: ${variant} and value ${value}`)
+          )
         }
       }
     }


### PR DESCRIPTION
## Problem

replay flags were not evaluated on the SDK level, now they are.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
