### PR TITLE
feat(ai): allow user to override values for model and provider

### DIFF
--- a/posthog-ai/package.json
+++ b/posthog-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@posthog/ai",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "PostHog Node.js AI integrations",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

some providers do not send back friendly names for the model or provider in vercel.

we can allow the user to specify these in those cases

## Changes

add override params

