### PR TITLE
feat(llm-observability): metric and feedback methods

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -1443,7 +1443,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
    * @param metricName The name of the metric to capture.
    * @param metricValue The value of the metric to capture.
    */
-  captureTraceMetric(traceId: string | number, metricName: string, metricValue: string | number): void {
+  captureTraceMetric(traceId: string | number, metricName: string, metricValue: string | number | boolean): void {
     this.capture('$ai_metric', {
       $ai_metric_name: metricName,
       $ai_metric_value: String(metricValue),

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -1432,7 +1432,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
    */
   captureTraceFeedback(traceId: string | number, userFeedback: string): void {
     this.capture('$ai_feedback', {
-      $ai_feedback: userFeedback,
+      $ai_feedback_text: userFeedback,
       $ai_trace_id: String(traceId),
     })
   }

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -1424,6 +1424,32 @@ export abstract class PostHogCore extends PostHogCoreStateless {
 
     this.capture('$exception', properties)
   }
+
+  /**
+   * Capture written user feedback for a LLM trace. Numeric values are converted to strings.
+   * @param traceId The trace ID to capture feedback for.
+   * @param userFeedback The feedback to capture.
+   */
+  captureTraceFeedback(traceId: string | number, userFeedback: string): void {
+    this.capture('$ai_feedback', {
+      $ai_feedback: userFeedback,
+      $ai_trace_id: String(traceId),
+    })
+  }
+
+  /**
+   * Capture a metric for a LLM trace. Numeric values are converted to strings.
+   * @param traceId The trace ID to capture the metric for.
+   * @param metricName The name of the metric to capture.
+   * @param metricValue The value of the metric to capture.
+   */
+  captureTraceMetric(traceId: string | number, metricName: string, metricValue: string | number): void {
+    this.capture('$ai_metric', {
+      $ai_metric_name: metricName,
+      $ai_metric_value: String(metricValue),
+      $ai_trace_id: String(traceId),
+    })
+  }
 }
 
 export * from './types'

--- a/posthog-core/test/posthog.ai.spec.ts
+++ b/posthog-core/test/posthog.ai.spec.ts
@@ -26,7 +26,7 @@ describe('PostHog Core', () => {
           {
             event: '$ai_feedback',
             properties: {
-              $ai_feedback: 'feedback',
+              $ai_feedback_text: 'feedback',
               $ai_trace_id: 'trace-id',
             },
           },
@@ -48,7 +48,7 @@ describe('PostHog Core', () => {
           {
             event: '$ai_feedback',
             properties: {
-              $ai_feedback: 'feedback',
+              $ai_feedback_text: 'feedback',
               $ai_trace_id: '10',
             },
           },

--- a/posthog-core/test/posthog.ai.spec.ts
+++ b/posthog-core/test/posthog.ai.spec.ts
@@ -1,0 +1,105 @@
+import { parseBody, waitForPromises } from './test-utils/test-utils'
+import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from './test-utils/PostHogCoreTestClient'
+
+describe('PostHog Core', () => {
+  let posthog: PostHogCoreTestClient
+  let mocks: PostHogCoreTestClientMocks
+
+  jest.useFakeTimers()
+
+  beforeEach(() => {
+    ;[posthog, mocks] = createTestClient('TEST_API_KEY', { flushAt: 1 })
+  })
+
+  describe('ai', () => {
+    it('should capture feedback', async () => {
+      jest.setSystemTime(new Date('2022-01-01'))
+
+      posthog.captureTraceFeedback('trace-id', 'feedback')
+
+      await waitForPromises()
+      expect(mocks.fetch).toHaveBeenCalledTimes(1)
+      const body = parseBody(mocks.fetch.mock.calls[0])
+
+      expect(body).toMatchObject({
+        batch: [
+          {
+            event: '$ai_feedback',
+            properties: {
+              $ai_feedback: 'feedback',
+              $ai_trace_id: 'trace-id',
+            },
+          },
+        ],
+      })
+    })
+
+    it('should convert numeric traceId in captureTraceFeedback', async () => {
+      jest.setSystemTime(new Date('2022-01-01'))
+
+      posthog.captureTraceFeedback(10, 'feedback')
+
+      await waitForPromises()
+      expect(mocks.fetch).toHaveBeenCalledTimes(1)
+      const body = parseBody(mocks.fetch.mock.calls[0])
+
+      expect(body).toMatchObject({
+        batch: [
+          {
+            event: '$ai_feedback',
+            properties: {
+              $ai_feedback: 'feedback',
+              $ai_trace_id: '10',
+            },
+          },
+        ],
+      })
+    })
+
+    it('should capture a metric', async () => {
+      jest.setSystemTime(new Date('2022-01-01'))
+
+      posthog.captureTraceMetric('trace-id', 'metric-name', 'good')
+
+      await waitForPromises()
+      expect(mocks.fetch).toHaveBeenCalledTimes(1)
+      const body = parseBody(mocks.fetch.mock.calls[0])
+
+      expect(body).toMatchObject({
+        batch: [
+          {
+            event: '$ai_metric',
+            properties: {
+              $ai_metric_name: 'metric-name',
+              $ai_metric_value: 'good',
+              $ai_trace_id: 'trace-id',
+            },
+          },
+        ],
+      })
+    })
+
+    it('should convert numeric arguments in captureTraceMetric', async () => {
+      jest.setSystemTime(new Date('2022-01-01'))
+
+      posthog.captureTraceMetric(10, 'metric-name', 1)
+
+      await waitForPromises()
+      expect(mocks.fetch).toHaveBeenCalledTimes(1)
+      const body = parseBody(mocks.fetch.mock.calls[0])
+
+      expect(body).toMatchObject({
+        batch: [
+          {
+            event: '$ai_metric',
+            properties: {
+              $ai_metric_name: 'metric-name',
+              $ai_metric_value: '1',
+              $ai_trace_id: '10',
+            },
+          },
+        ],
+      })
+    })
+  })
+})

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Next
 
+# 4.7.0 - 2025-02-20
+
+## Added
+
+1. Adds the ability to capture user feedback in LLM Observability using the `captureTraceFeedback` and `captureTraceMetric` methods.
+
 # 4.6.0 - 2025-02-12
 
 ## Added

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.6.0",
+  "version": "4.5.0",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.5.0",
+  "version": "4.7.0",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Next
 
+# 3.10.0 - 2025-02-20
+
+## Added
+
+1. Adds the ability to capture user feedback in LLM Observability using the `captureTraceFeedback` and `captureTraceMetric` methods.
+
 # 3.9.1 - 2025-02-13
 
 1. fix: ensure feature flags are reloaded after reset() to prevent undefined values

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.9.1",
+  "version": "3.7.0",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.7.0",
+  "version": "3.10.0",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Next
 
+# 3.4.0 - 2025-02-20
+
+## Added
+
+1. Adds the ability to capture user feedback in LLM Observability using the `captureTraceFeedback` and `captureTraceMetric` methods.
+
 # 3.3.0 - 2025-02-06
 
 ## Added

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-js-lite",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Problem

It should be straightforward to capture a LLM metric or feedback.

## Changes

- Add methods to capture user feedback and metrics.
- Convert values like numbers and booleans to strings to unify the property type.

@k11kirky please check the naming. I thought about `captureAIFeedback`, but I don't like three capital letters in a row. `captureFeedback` and `captureMetric` are probably too generic.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

- Added `captureTraceMetric` and `captureTraceFeedback` methods for LLM Observability.
