### PR TITLE
posthog-web support

### DIFF
--- a/extensions/error-tracking/error-conversion.ts
+++ b/extensions/error-tracking/error-conversion.ts
@@ -1,0 +1,241 @@
+import { isError, isErrorEvent, isEvent, isPlainObject } from './type-checking'
+import { defaultStackParser } from './stack-trace'
+
+import {
+  ErrorEvent,
+  ErrorEventArgs,
+  ErrorMetadata,
+  ErrorProperties,
+  Exception,
+  SeverityLevel,
+  severityLevels,
+  StackFrame,
+} from './types'
+import { isEmptyString, isString, isUndefined } from './utils'
+
+/**
+ * based on the very wonderful MIT licensed Sentry SDK
+ */
+
+const ERROR_TYPES_PATTERN =
+  /^(?:[Uu]ncaught (?:exception: )?)?(?:((?:Eval|Internal|Range|Reference|Syntax|Type|URI|)Error): )?(.*)$/i
+
+export function parseStackFrames(ex: Error & { stacktrace?: string }, framesToPop: number = 0): StackFrame[] {
+  // Access and store the stacktrace property before doing ANYTHING
+  // else to it because Opera is not very good at providing it
+  // reliably in other circumstances.
+  const stacktrace = ex.stacktrace || ex.stack || ''
+
+  const skipLines = getSkipFirstStackStringLines(ex)
+
+  try {
+    const frames = defaultStackParser(stacktrace, skipLines)
+    // frames are reversed so we remove the from the back of the array
+    return frames.slice(0, frames.length - framesToPop)
+  } catch {
+    // no-empty
+  }
+
+  return []
+}
+
+const reactMinifiedRegexp = /Minified React error #\d+;/i
+
+/**
+ * Certain known React errors contain links that would be falsely
+ * parsed as frames. This function check for these errors and
+ * returns number of the stack string lines to skip.
+ */
+function getSkipFirstStackStringLines(ex: Error): number {
+  if (ex && reactMinifiedRegexp.test(ex.message)) {
+    return 1
+  }
+
+  return 0
+}
+
+function errorPropertiesFromError(error: Error, metadata?: ErrorMetadata): ErrorProperties {
+  const frames = parseStackFrames(error)
+
+  const handled = metadata?.handled ?? true
+  const synthetic = metadata?.synthetic ?? false
+
+  const exceptionType = metadata?.overrideExceptionType ? metadata.overrideExceptionType : error.name
+  const exceptionMessage = metadata?.overrideExceptionMessage
+    ? metadata.overrideExceptionMessage
+    : extractMessage(error)
+
+  return {
+    $exception_list: [
+      {
+        type: exceptionType,
+        value: exceptionMessage,
+        stacktrace: {
+          frames,
+          type: 'raw',
+        },
+        mechanism: {
+          handled,
+          synthetic,
+        },
+      },
+    ],
+    $exception_level: 'error',
+  }
+}
+
+/**
+ * There are cases where stacktrace.message is an Event object
+ * https://github.com/getsentry/sentry-javascript/issues/1949
+ * In this specific case we try to extract stacktrace.message.error.message
+ */
+function extractMessage(err: Error & { message: { error?: Error } }): string {
+  const message = err.message
+
+  if (message.error && typeof message.error.message === 'string') {
+    return message.error.message
+  }
+
+  return message
+}
+
+function errorPropertiesFromString(candidate: string, metadata?: ErrorMetadata): ErrorProperties {
+  // Defaults for metadata are based on what the error candidate is.
+  const handled = metadata?.handled ?? true
+  const synthetic = metadata?.synthetic ?? true
+
+  const exceptionType = metadata?.overrideExceptionType
+    ? metadata.overrideExceptionType
+    : metadata?.defaultExceptionType ?? 'Error'
+  const exceptionMessage = metadata?.overrideExceptionMessage
+    ? metadata.overrideExceptionMessage
+    : candidate
+    ? candidate
+    : metadata?.defaultExceptionMessage
+
+  const exception: Exception = {
+    type: exceptionType,
+    value: exceptionMessage,
+    mechanism: {
+      handled,
+      synthetic,
+    },
+  }
+
+  if (metadata?.syntheticException) {
+    // Kludge: strip the last frame from a synthetically created error
+    // so that it does not appear in a users stack trace
+    const frames = parseStackFrames(metadata.syntheticException, 1)
+    if (frames.length) {
+      exception.stacktrace = { frames, type: 'raw' }
+    }
+  }
+
+  return {
+    $exception_list: [exception],
+    $exception_level: 'error',
+  }
+}
+
+/**
+ * Given any captured exception, extract its keys and create a sorted
+ * and truncated list that will be used inside the event message.
+ * eg. `Non-error exception captured with keys: foo, bar, baz`
+ */
+function extractExceptionKeysForMessage(exception: Record<string, unknown>, maxLength = 40): string {
+  const keys = Object.keys(exception)
+  keys.sort()
+
+  if (!keys.length) {
+    return '[object has no keys]'
+  }
+
+  for (let i = keys.length; i > 0; i--) {
+    const serialized = keys.slice(0, i).join(', ')
+    if (serialized.length > maxLength) {
+      continue
+    }
+    if (i === keys.length) {
+      return serialized
+    }
+    return serialized.length <= maxLength ? serialized : `${serialized.slice(0, maxLength)}...`
+  }
+
+  return ''
+}
+
+function isSeverityLevel(x: unknown): x is SeverityLevel {
+  return isString(x) && !isEmptyString(x) && severityLevels.indexOf(x as SeverityLevel) >= 0
+}
+
+function errorPropertiesFromObject(candidate: Record<string, unknown>, metadata?: ErrorMetadata): ErrorProperties {
+  // Defaults for metadata are based on what the error candidate is.
+  const handled = metadata?.handled ?? true
+  const synthetic = metadata?.synthetic ?? true
+
+  const exceptionType = metadata?.overrideExceptionType
+    ? metadata.overrideExceptionType
+    : isEvent(candidate)
+    ? candidate.constructor.name
+    : 'Error'
+  const exceptionMessage = metadata?.overrideExceptionMessage
+    ? metadata.overrideExceptionMessage
+    : `Non-Error ${'exception'} captured with keys: ${extractExceptionKeysForMessage(candidate)}`
+
+  const exception: Exception = {
+    type: exceptionType,
+    value: exceptionMessage,
+    mechanism: {
+      handled,
+      synthetic,
+    },
+  }
+
+  if (metadata?.syntheticException) {
+    // Kludge: strip the last frame from a synthetically created error
+    // so that it does not appear in a users stack trace
+    const frames = parseStackFrames(metadata?.syntheticException, 1)
+    if (frames.length) {
+      exception.stacktrace = { frames, type: 'raw' }
+    }
+  }
+
+  return {
+    $exception_list: [exception],
+    $exception_level: isSeverityLevel(candidate.level) ? candidate.level : 'error',
+  }
+}
+
+export function errorToProperties(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  [event, _, __, ___, error]: ErrorEventArgs,
+  metadata?: ErrorMetadata
+): ErrorProperties {
+  const candidate = error || event
+
+  if (isErrorEvent(candidate as ErrorEvent) && (candidate as ErrorEvent).error) {
+    return errorPropertiesFromError((candidate as ErrorEvent).error as Error, metadata)
+  } else if (isError(candidate)) {
+    return errorPropertiesFromError(candidate, metadata)
+  } else if (isPlainObject(candidate) || isEvent(candidate)) {
+    // group these by using the keys available on the object
+    const objectException = candidate as Record<string, unknown>
+    return errorPropertiesFromObject(objectException, metadata)
+  } else if (isUndefined(error) && isString(event)) {
+    let name = 'Error'
+    let message = event
+    const groups = event.match(ERROR_TYPES_PATTERN)
+    if (groups) {
+      name = groups[1]
+      message = groups[2]
+    }
+
+    return errorPropertiesFromString(message, {
+      ...metadata,
+      overrideExceptionType: name,
+      defaultExceptionMessage: message,
+    })
+  } else {
+    return errorPropertiesFromString(candidate as string, metadata)
+  }
+}

--- a/extensions/error-tracking/stack-trace.ts
+++ b/extensions/error-tracking/stack-trace.ts
@@ -1,0 +1,277 @@
+// copied and adapted from https://github.com/getsentry/sentry-javascript/blob/41fef4b10f3a644179b77985f00f8696c908539f/packages/browser/src/stack-parsers.ts
+// 💖open source
+
+import { StackFrame, StackLineParser, StackLineParserFn, StackParser } from './types'
+
+// This was originally forked from https://github.com/csnover/TraceKit, and was largely
+// re-written as part of raven - js.
+//
+// This code was later copied to the JavaScript mono - repo and further modified and
+// refactored over the years.
+
+// Copyright (c) 2013 Onur Can Cakmak onur.cakmak@gmail.com and all TraceKit contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files(the 'Software'), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and / or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+// OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+const WEBPACK_ERROR_REGEXP = /\(error: (.*)\)/
+const STACKTRACE_FRAME_LIMIT = 50
+
+const UNKNOWN_FUNCTION = '?'
+
+const OPERA10_PRIORITY = 10
+const OPERA11_PRIORITY = 20
+const CHROME_PRIORITY = 30
+const WINJS_PRIORITY = 40
+const GECKO_PRIORITY = 50
+
+function createFrame(filename: string, func: string, lineno?: number, colno?: number): StackFrame {
+  const frame: StackFrame = {
+    platform: 'web:javascript',
+    filename,
+    function: func === '<anonymous>' ? UNKNOWN_FUNCTION : func,
+    in_app: true, // All browser frames are considered in_app
+  }
+
+  if (!lineno === undefined) {
+    frame.lineno = lineno
+  }
+
+  if (!colno === undefined) {
+    frame.colno = colno
+  }
+
+  return frame
+}
+
+// This regex matches frames that have no function name (ie. are at the top level of a module).
+// For example "at http://localhost:5000//script.js:1:126"
+// Frames _with_ function names usually look as follows: "at commitLayoutEffects (react-dom.development.js:23426:1)"
+const chromeRegexNoFnName = /^\s*at (\S+?)(?::(\d+))(?::(\d+))\s*$/i
+
+// This regex matches all the frames that have a function name.
+const chromeRegex =
+  /^\s*at (?:(.+?\)(?: \[.+\])?|.*?) ?\((?:address at )?)?(?:async )?((?:<anonymous>|[-a-z]+:|.*bundle|\/)?.*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i
+
+const chromeEvalRegex = /\((\S*)(?::(\d+))(?::(\d+))\)/
+
+// Chromium based browsers: Chrome, Brave, new Opera, new Edge
+// We cannot call this variable `chrome` because it can conflict with global `chrome` variable in certain environments
+// See: https://github.com/getsentry/sentry-javascript/issues/6880
+const chromeStackParserFn: StackLineParserFn = (line) => {
+  // If the stack line has no function name, we need to parse it differently
+  const noFnParts = chromeRegexNoFnName.exec(line) as null | [string, string, string, string]
+
+  if (noFnParts) {
+    const [, filename, line, col] = noFnParts
+    return createFrame(filename, UNKNOWN_FUNCTION, +line, +col)
+  }
+
+  const parts = chromeRegex.exec(line) as null | [string, string, string, string, string]
+
+  if (parts) {
+    const isEval = parts[2] && parts[2].indexOf('eval') === 0 // start of line
+
+    if (isEval) {
+      const subMatch = chromeEvalRegex.exec(parts[2]) as null | [string, string, string, string]
+
+      if (subMatch) {
+        // throw out eval line/column and use top-most line/column number
+        parts[2] = subMatch[1] // url
+        parts[3] = subMatch[2] // line
+        parts[4] = subMatch[3] // column
+      }
+    }
+
+    // Kamil: One more hack won't hurt us right? Understanding and adding more rules on top of these regexps right now
+    // would be way too time consuming. (TODO: Rewrite whole RegExp to be more readable)
+    const [func, filename] = extractSafariExtensionDetails(parts[1] || UNKNOWN_FUNCTION, parts[2])
+
+    return createFrame(filename, func, parts[3] ? +parts[3] : undefined, parts[4] ? +parts[4] : undefined)
+  }
+
+  return
+}
+
+export const chromeStackLineParser: StackLineParser = [CHROME_PRIORITY, chromeStackParserFn]
+
+// gecko regex: `(?:bundle|\d+\.js)`: `bundle` is for react native, `\d+\.js` also but specifically for ram bundles because it
+// generates filenames without a prefix like `file://` the filenames in the stacktrace are just 42.js
+// We need this specific case for now because we want no other regex to match.
+const geckoREgex =
+  /^\s*(.*?)(?:\((.*?)\))?(?:^|@)?((?:[-a-z]+)?:\/.*?|\[native code\]|[^@]*(?:bundle|\d+\.js)|\/[\w\-. /=]+)(?::(\d+))?(?::(\d+))?\s*$/i
+const geckoEvalRegex = /(\S+) line (\d+)(?: > eval line \d+)* > eval/i
+
+const gecko: StackLineParserFn = (line) => {
+  const parts = geckoREgex.exec(line) as null | [string, string, string, string, string, string]
+
+  if (parts) {
+    const isEval = parts[3] && parts[3].indexOf(' > eval') > -1
+    if (isEval) {
+      const subMatch = geckoEvalRegex.exec(parts[3]) as null | [string, string, string]
+
+      if (subMatch) {
+        // throw out eval line/column and use top-most line number
+        parts[1] = parts[1] || 'eval'
+        parts[3] = subMatch[1]
+        parts[4] = subMatch[2]
+        parts[5] = '' // no column when eval
+      }
+    }
+
+    let filename = parts[3]
+    let func = parts[1] || UNKNOWN_FUNCTION
+    ;[func, filename] = extractSafariExtensionDetails(func, filename)
+
+    return createFrame(filename, func, parts[4] ? +parts[4] : undefined, parts[5] ? +parts[5] : undefined)
+  }
+
+  return
+}
+
+export const geckoStackLineParser: StackLineParser = [GECKO_PRIORITY, gecko]
+
+const winjsRegex = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:[-a-z]+):.*?):(\d+)(?::(\d+))?\)?\s*$/i
+
+const winjs: StackLineParserFn = (line) => {
+  const parts = winjsRegex.exec(line) as null | [string, string, string, string, string]
+
+  return parts
+    ? createFrame(parts[2], parts[1] || UNKNOWN_FUNCTION, +parts[3], parts[4] ? +parts[4] : undefined)
+    : undefined
+}
+
+export const winjsStackLineParser: StackLineParser = [WINJS_PRIORITY, winjs]
+
+const opera10Regex = / line (\d+).*script (?:in )?(\S+)(?:: in function (\S+))?$/i
+
+const opera10: StackLineParserFn = (line) => {
+  const parts = opera10Regex.exec(line) as null | [string, string, string, string]
+  return parts ? createFrame(parts[2], parts[3] || UNKNOWN_FUNCTION, +parts[1]) : undefined
+}
+
+export const opera10StackLineParser: StackLineParser = [OPERA10_PRIORITY, opera10]
+
+const opera11Regex = / line (\d+), column (\d+)\s*(?:in (?:<anonymous function: ([^>]+)>|([^)]+))\(.*\))? in (.*):\s*$/i
+
+const opera11: StackLineParserFn = (line) => {
+  const parts = opera11Regex.exec(line) as null | [string, string, string, string, string, string]
+  return parts ? createFrame(parts[5], parts[3] || parts[4] || UNKNOWN_FUNCTION, +parts[1], +parts[2]) : undefined
+}
+
+export const opera11StackLineParser: StackLineParser = [OPERA11_PRIORITY, opera11]
+
+export const defaultStackLineParsers = [chromeStackLineParser, geckoStackLineParser]
+
+export const defaultStackParser = createStackParser(...defaultStackLineParsers)
+
+export function reverseAndStripFrames(stack: ReadonlyArray<StackFrame>): StackFrame[] {
+  if (!stack.length) {
+    return []
+  }
+
+  const localStack = Array.from(stack)
+
+  localStack.reverse()
+
+  return localStack.slice(0, STACKTRACE_FRAME_LIMIT).map((frame) => ({
+    ...frame,
+    filename: frame.filename || getLastStackFrame(localStack).filename,
+    function: frame.function || UNKNOWN_FUNCTION,
+  }))
+}
+
+function getLastStackFrame(arr: StackFrame[]): StackFrame {
+  return arr[arr.length - 1] || {}
+}
+
+export function createStackParser(...parsers: StackLineParser[]): StackParser {
+  const sortedParsers = parsers.sort((a, b) => a[0] - b[0]).map((p) => p[1])
+
+  return (stack: string, skipFirstLines: number = 0): StackFrame[] => {
+    const frames: StackFrame[] = []
+    const lines = stack.split('\n')
+
+    for (let i = skipFirstLines; i < lines.length; i++) {
+      const line = lines[i] as string
+      // Ignore lines over 1kb as they are unlikely to be stack frames.
+      // Many of the regular expressions use backtracking which results in run time that increases exponentially with
+      // input size. Huge strings can result in hangs/Denial of Service:
+      // https://github.com/getsentry/sentry-javascript/issues/2286
+      if (line.length > 1024) {
+        continue
+      }
+
+      // https://github.com/getsentry/sentry-javascript/issues/5459
+      // Remove webpack (error: *) wrappers
+      const cleanedLine = WEBPACK_ERROR_REGEXP.test(line) ? line.replace(WEBPACK_ERROR_REGEXP, '$1') : line
+
+      // https://github.com/getsentry/sentry-javascript/issues/7813
+      // Skip Error: lines
+      if (cleanedLine.match(/\S*Error: /)) {
+        continue
+      }
+
+      for (const parser of sortedParsers) {
+        const frame = parser(cleanedLine)
+
+        if (frame) {
+          frames.push(frame)
+          break
+        }
+      }
+
+      if (frames.length >= STACKTRACE_FRAME_LIMIT) {
+        break
+      }
+    }
+
+    return reverseAndStripFrames(frames)
+  }
+}
+
+/**
+ * Safari web extensions, starting version unknown, can produce "frames-only" stacktraces.
+ * What it means, is that instead of format like:
+ *
+ * Error: wat
+ *   at function@url:row:col
+ *   at function@url:row:col
+ *   at function@url:row:col
+ *
+ * it produces something like:
+ *
+ *   function@url:row:col
+ *   function@url:row:col
+ *   function@url:row:col
+ *
+ * Because of that, it won't be captured by `chrome` RegExp and will fall into `Gecko` branch.
+ * This function is extracted so that we can use it in both places without duplicating the logic.
+ * Unfortunately "just" changing RegExp is too complicated now and making it pass all tests
+ * and fix this case seems like an impossible, or at least way too time-consuming task.
+ */
+const extractSafariExtensionDetails = (func: string, filename: string): [string, string] => {
+  const isSafariExtension = func.indexOf('safari-extension') !== -1
+  const isSafariWebExtension = func.indexOf('safari-web-extension') !== -1
+
+  return isSafariExtension || isSafariWebExtension
+    ? [
+        func.indexOf('@') !== -1 ? (func.split('@')[0] as string) : UNKNOWN_FUNCTION,
+        isSafariExtension ? `safari-extension:${filename}` : `safari-web-extension:${filename}`,
+      ]
+    : [func, filename]
+}

--- a/extensions/error-tracking/type-checking.ts
+++ b/extensions/error-tracking/type-checking.ts
@@ -1,0 +1,35 @@
+import { ErrorEvent } from './types'
+
+export function isEvent(candidate: unknown): candidate is Event {
+  return Event != undefined && isInstanceOf(candidate, Event)
+}
+
+export function isPlainObject(candidate: unknown): candidate is Record<string, unknown> {
+  return isBuiltin(candidate, 'Object')
+}
+
+export function isInstanceOf(candidate: unknown, base: any): boolean {
+  try {
+    return candidate instanceof base
+  } catch {
+    return false
+  }
+}
+
+export function isError(candidate: unknown): candidate is Error {
+  switch (Object.prototype.toString.call(candidate)) {
+    case '[object Error]':
+    case '[object Exception]':
+      return true
+    default:
+      return isInstanceOf(candidate, Error)
+  }
+}
+
+export function isErrorEvent(event: string | Error | Event): event is ErrorEvent {
+  return isBuiltin(event, 'ErrorEvent')
+}
+
+export function isBuiltin(candidate: unknown, className: string): boolean {
+  return Object.prototype.toString.call(candidate) === `[object ${className}]`
+}

--- a/extensions/error-tracking/types.ts
+++ b/extensions/error-tracking/types.ts
@@ -1,0 +1,90 @@
+// levels originally copied from Sentry to work with the sentry integration
+// and to avoid relying on a frequently changing @sentry/types dependency
+// but provided as an array of literal types, so we can constrain the level below
+export const severityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug'] as const
+export declare type SeverityLevel = (typeof severityLevels)[number]
+
+export interface ErrorEvent extends Event {
+  readonly colno: number
+  readonly error: any
+  readonly filename: string
+  readonly lineno: number
+  readonly message: string
+}
+
+export type ErrorEventArgs = [
+  event: string | Event,
+  source?: string | undefined,
+  lineno?: number | undefined,
+  colno?: number | undefined,
+  error?: Error | undefined
+]
+
+export type ErrorMetadata = {
+  handled?: boolean
+  synthetic?: boolean
+  syntheticException?: Error
+  overrideExceptionType?: string
+  overrideExceptionMessage?: string
+  defaultExceptionType?: string
+  defaultExceptionMessage?: string
+}
+
+export interface ErrorProperties {
+  $exception_list: Exception[]
+  $exception_level?: SeverityLevel
+  $exception_DOMException_code?: string
+  $exception_personURL?: string
+}
+
+export interface Exception {
+  type?: string
+  value?: string
+  mechanism?: {
+    /**
+     * In theory, whether or not the exception has been handled by the user. In practice, whether or not we see it before
+     * it hits the global error/rejection handlers, whether through explicit handling by the user or auto instrumentation.
+     */
+    handled?: boolean
+    type?: string
+    source?: string
+    /**
+     * True when `captureException` is called with anything other than an instance of `Error` (or, in the case of browser,
+     * an instance of `ErrorEvent`, `DOMError`, or `DOMException`). causing us to create a synthetic error in an attempt
+     * to recreate the stacktrace.
+     */
+    synthetic?: boolean
+  }
+  module?: string
+  thread_id?: number
+  stacktrace?: {
+    frames?: StackFrame[]
+    type: 'raw'
+  }
+}
+
+export type StackParser = (stack: string, skipFirstLines?: number) => StackFrame[]
+export type StackLineParserFn = (line: string) => StackFrame | undefined
+export type StackLineParser = [number, StackLineParserFn]
+
+export interface StackFrame {
+  platform: string
+  filename?: string
+  function?: string
+  module?: string
+  lineno?: number
+  colno?: number
+  abs_path?: string
+  context_line?: string
+  pre_context?: string[]
+  post_context?: string[]
+  in_app?: boolean
+  instruction_addr?: string
+  addr_mode?: string
+  vars?: { [key: string]: any }
+  debug_id?: string
+}
+
+export interface ErrorConversions {
+  errorToProperties: (args: ErrorEventArgs) => ErrorProperties
+}

--- a/extensions/error-tracking/utils.ts
+++ b/extensions/error-tracking/utils.ts
@@ -1,0 +1,60 @@
+const nativeIsArray = Array.isArray
+const ObjProto = Object.prototype
+export const hasOwnProperty = ObjProto.hasOwnProperty
+const toString = ObjProto.toString
+
+export const isArray =
+  nativeIsArray ||
+  function (obj: any): obj is any[] {
+    return toString.call(obj) === '[object Array]'
+  }
+
+// from a comment on http://dbj.org/dbj/?p=286
+// fails on only one very rare and deliberate custom object:
+// let bomb = { toString : undefined, valueOf: function(o) { return "function BOMBA!"; }};
+export const isFunction = (x: unknown): x is (...args: any[]) => any => {
+  return typeof x === 'function'
+}
+
+export const isNativeFunction = (x: unknown): x is (...args: any[]) => any =>
+  isFunction(x) && x.toString().indexOf('[native code]') !== -1
+
+// Underscore Addons
+export const isObject = (x: unknown): x is Record<string, any> => {
+  return x === Object(x) && !isArray(x)
+}
+export const isEmptyObject = (x: unknown): boolean => {
+  if (isObject(x)) {
+    for (const key in x) {
+      if (hasOwnProperty.call(x, key)) {
+        return false
+      }
+    }
+    return true
+  }
+  return false
+}
+export const isUndefined = (x: unknown): x is undefined => x === void 0
+
+export const isString = (x: unknown): x is string => {
+  return toString.call(x) == '[object String]'
+}
+
+export const isEmptyString = (x: unknown): boolean => isString(x) && x.trim().length === 0
+
+export const isNull = (x: unknown): x is null => {
+  return x === null
+}
+
+/*
+    sometimes you want to check if something is null or undefined
+    that's what this is for
+ */
+export const isNullish = (x: unknown): x is null | undefined => isUndefined(x) || isNull(x)
+
+export const isNumber = (x: unknown): x is number => {
+  return toString.call(x) == '[object Number]'
+}
+export const isBoolean = (x: unknown): x is boolean => {
+  return toString.call(x) === '[object Boolean]'
+}

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -1395,7 +1395,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
    *** ERROR TRACKING
    ***/
   captureException(error: Error, additionalProperties?: { [key: string]: any }): void {
-    const properties = {
+    const properties: { [key: string]: any } = {
       $exception_level: 'error',
       $exception_list: [
         {
@@ -1409,6 +1409,11 @@ export abstract class PostHogCore extends PostHogCoreStateless {
       ],
       ...additionalProperties,
     }
+
+    properties.$exception_personURL = new URL(
+      `/project/${this.apiKey}/person/${this.getDistinctId()}`,
+      this.host
+    ).toString()
 
     this.capture('$exception', properties)
   }

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -1394,7 +1394,22 @@ export abstract class PostHogCore extends PostHogCoreStateless {
   /***
    *** ERROR TRACKING
    ***/
-  captureException(properties?: { [key: string]: any }): void {
+  captureException(error: Error, additionalProperties?: { [key: string]: any }): void {
+    const properties = {
+      $exception_level: 'error',
+      $exception_list: [
+        {
+          type: error.name,
+          value: error.message,
+          mechanism: {
+            handled: true,
+            synthetic: false,
+          },
+        },
+      ],
+      ...additionalProperties,
+    }
+
     this.capture('$exception', properties)
   }
 }

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -1390,6 +1390,13 @@ export abstract class PostHogCore extends PostHogCoreStateless {
       return this.setPersistedProperty(PostHogPersistedProperty.OverrideFeatureFlags, flags)
     })
   }
+
+  /***
+   *** ERROR TRACKING
+   ***/
+  captureException(properties?: { [key: string]: any }): void {
+    this.capture('$exception', properties)
+  }
 }
 
 export * from './types'

--- a/posthog-node/src/error-tracking.ts
+++ b/posthog-node/src/error-tracking.ts
@@ -1,0 +1,39 @@
+import { addUncaughtExceptionListener, addUnhandledRejectionListener } from './extensions/exception-autocapture'
+import { PostHog, PostHogOptions } from './posthog-node'
+import { uuidv7 } from 'posthog-core/src/vendor/uuidv7'
+
+const SHUTDOWN_TIMEOUT = 2000
+
+export default class ExceptionObserver {
+  private client: PostHog
+  private _exceptionAutocaptureEnabled: boolean
+
+  constructor(client: PostHog, options: PostHogOptions) {
+    this.client = client
+    this._exceptionAutocaptureEnabled = options.enableExceptionAutocapture || false
+
+    this.startIfEnabled()
+  }
+
+  isEnabled(): boolean {
+    return !this.client.isDisabled && this._exceptionAutocaptureEnabled
+  }
+
+  private startIfEnabled(): void {
+    if (this.isEnabled()) {
+      addUncaughtExceptionListener(this.captureException.bind(this), this.onFatalError.bind(this))
+      addUnhandledRejectionListener(this.captureException.bind(this))
+    }
+  }
+
+  private captureException(exception: Error): void {
+    // Given stateless nature of Node SDK we capture exceptions using personless processing
+    // when no user can be determined e.g. in the case of exception autocapture
+    this.client.captureException(exception, uuidv7(), { $process_person_profile: false })
+  }
+
+  private async onFatalError(): Promise<void> {
+    await this.client.shutdown(SHUTDOWN_TIMEOUT)
+    global.process.exit(1)
+  }
+}

--- a/posthog-node/src/extensions/exception-autocapture.ts
+++ b/posthog-node/src/extensions/exception-autocapture.ts
@@ -1,0 +1,47 @@
+type ErrorHandler = { _errorHandler: boolean } & ((error: Error) => void)
+type TaggedListener = NodeJS.UncaughtExceptionListener & {
+  tag?: string
+}
+
+function makeUncaughtExceptionHandler(captureFn: (exception: Error) => void, onFatalFn: () => void): ErrorHandler {
+  let calledFatalError: boolean = false
+
+  return Object.assign(
+    (error: Error): void => {
+      // Attaching a listener to `uncaughtException` will prevent the node process from exiting. We generally do not
+      // want to alter this behaviour so we check for other listeners that users may have attached themselves and adjust
+      // exit behaviour of the SDK accordingly:
+      // - If other listeners are attached, do not exit.
+      // - If the only listener attached is ours, exit.
+      const userProvidedListenersCount = (global.process.listeners('uncaughtException') as TaggedListener[]).filter(
+        (listener) => {
+          // There are 2 listeners we ignore:
+          return (
+            // as soon as we're using domains this listener is attached by node itself
+            listener.name !== 'domainUncaughtExceptionClear' &&
+            // the handler we register in this integration
+            (listener as ErrorHandler)._errorHandler !== true
+          )
+        }
+      ).length
+
+      const processWouldExit = userProvidedListenersCount === 0
+
+      captureFn(error)
+
+      if (!calledFatalError && processWouldExit) {
+        calledFatalError = true
+        onFatalFn()
+      }
+    },
+    { _errorHandler: true }
+  )
+}
+
+export function addUncaughtExceptionListener(captureFn: (exception: Error) => void, onFatalFn: () => void): void {
+  global.process.on('uncaughtException', makeUncaughtExceptionHandler(captureFn, onFatalFn))
+}
+
+export function addUnhandledRejectionListener(captureFn: (exception: Error) => void): void {
+  global.process.on('unhandledRejection', captureFn)
+}

--- a/posthog-node/src/extensions/sentry-integration.ts
+++ b/posthog-node/src/extensions/sentry-integration.ts
@@ -22,10 +22,8 @@
  * @param {SeverityLevel[] | '*'} [severityAllowList] Optional: send events matching the provided levels. Use '*' to send all events (default: ['error'])
  */
 
+import { SeverityLevel } from 'extensions/error-tracking/types'
 import { type PostHog } from '../posthog-node'
-
-export const severityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug'] as const
-export declare type SeverityLevel = (typeof severityLevels)[number]
 
 // NOTE - we can't import from @sentry/types because it changes frequently and causes clashes
 // We only use a small subset of the types, so we can just define the integration overall and use any for the rest

--- a/posthog-web/src/posthog-web.ts
+++ b/posthog-web/src/posthog-web.ts
@@ -84,4 +84,23 @@ export class PostHog extends PostHogCore {
       ...getContext(this.getWindow()),
     }
   }
+
+  captureException(error: Error, additionalProperties?: { [key: string]: any }): void {
+    const properties = {
+      $exception_level: 'error',
+      $exception_list: [
+        {
+          type: error.name,
+          value: error.message,
+          mechanism: {
+            handled: true,
+            synthetic: false,
+          },
+        },
+      ],
+      ...additionalProperties,
+    }
+
+    super.captureException(properties)
+  }
 }

--- a/posthog-web/src/posthog-web.ts
+++ b/posthog-web/src/posthog-web.ts
@@ -84,23 +84,4 @@ export class PostHog extends PostHogCore {
       ...getContext(this.getWindow()),
     }
   }
-
-  captureException(error: Error, additionalProperties?: { [key: string]: any }): void {
-    const properties = {
-      $exception_level: 'error',
-      $exception_list: [
-        {
-          type: error.name,
-          value: error.message,
-          mechanism: {
-            handled: true,
-            synthetic: false,
-          },
-        },
-      ],
-      ...additionalProperties,
-    }
-
-    super.captureException(properties)
-  }
 }


### PR DESCRIPTION
## Problem

We do not support error tracking in our Node SDK

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

- [x] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-react-native

### Changelog notes

- Added support for manual exception capture in web, Node and React Native libraries
- Added support for exception autocapture in Node