### PR TITLE
fix(session-replay): improve session replay linked flag type handling

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -27,7 +27,7 @@
 # 3.4.0 - 2024-11-26
 
 1. feat: automatically mask out user photos and sandboxed views like photo picker (iOS Only)
-1. To disable masking set `maskAllSandboxedViews` and `maskPhotoLibraryImages` to false
+   1. To disable masking set `maskAllSandboxedViews` and `maskPhotoLibraryImages` to false
 
 ```js
 export const posthog = new PostHog(

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.6.4 - 2025-02-03
+
+1. fix: improve session replay linked flag type handling
+
 # 3.6.3 - 2025-01-16
 
 1. fix: session replay respect linked feature flags
@@ -23,7 +27,7 @@
 # 3.4.0 - 2024-11-26
 
 1. feat: automatically mask out user photos and sandboxed views like photo picker (iOS Only)
-  1. To disable masking set `maskAllSandboxedViews` and `maskPhotoLibraryImages` to false
+1. To disable masking set `maskAllSandboxedViews` and `maskPhotoLibraryImages` to false
 
 ```js
 export const posthog = new PostHog(
@@ -99,16 +103,13 @@ export const posthog = new PostHog(
 ## Changed
 
 1. chore: session id will be rotate on app restart.
-    1. To keep the session id across restarts, set the `enablePersistSessionIdAcrossRestart` option to `true` when initializing the PostHog client.
+   1. To keep the session id across restarts, set the `enablePersistSessionIdAcrossRestart` option to `true` when initializing the PostHog client.
 
 ```js
-export const posthog = new PostHog(
-  'apiKey...',
-  {
-    // ...
-    enablePersistSessionIdAcrossRestart: true,
-  },
-);
+export const posthog = new PostHog('apiKey...', {
+  // ...
+  enablePersistSessionIdAcrossRestart: true,
+})
 ```
 
 # 3.2.1 - 2024-09-24
@@ -122,7 +123,7 @@ export const posthog = new PostHog(
 ## Changed
 
 1. chore: default `captureMode` changed to `json`.
-    1. To keep using the `form` mode, just set the `captureMode` option to `form` when initializing the PostHog client.
+   1. To keep using the `form` mode, just set the `captureMode` option to `form` when initializing the PostHog client.
 2. chore: Session Replay for React-Native - Experimental support
 
 Install Session Replay for React-Native:
@@ -136,13 +137,10 @@ npm i -s posthog-react-native-session-replay
 Enable Session Replay for React-Native:
 
 ```js
-export const posthog = new PostHog(
-  'apiKey...',
-  {
-    // ...
-    enableSessionReplay: true,
-  },
-);
+export const posthog = new PostHog('apiKey...', {
+  // ...
+  enableSessionReplay: true,
+})
 ```
 
 Or using the `PostHogProvider`

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -336,7 +336,7 @@ export class PostHog extends PostHogCore {
     )
 
     let recordingActive = true
-    const linkedFlag = decideReplayConfig['linkedFlag'] as string | { [key: string]: JsonType } | undefined
+    const linkedFlag = decideReplayConfig['linkedFlag'] as string | { [key: string]: JsonType } | null | undefined
     if (typeof linkedFlag === 'string') {
       const value = decideFeatureFlags[linkedFlag]
       if (typeof value === 'boolean') {
@@ -344,7 +344,7 @@ export class PostHog extends PostHogCore {
       }
 
       this.logMsgIfDebug(() => console.log('PostHog Debug', `Session replay ${linkedFlag} linked flag value: ${value}`))
-    } else if (typeof linkedFlag === 'object') {
+    } else if (linkedFlag && typeof linkedFlag === 'object') {
       const flag = linkedFlag['flag'] as string | undefined
       const variant = linkedFlag['variant'] as string | undefined
       if (flag && variant) {


### PR DESCRIPTION
## Problem

Noticed errors in the production version of a React Native app, complaining of the line with a typecast. When the config is null, it goes through the `typeof ... === 'object'` condition, as `typeof` for null returns `object`.

## Changes

Fix the line to check for null values.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [x] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- fix: improve session replay linked flag type handling
