### PR TITLE
Deprecate `is_simple_flag`

### DIFF
--- a/posthog-node/src/types.ts
+++ b/posthog-node/src/types.ts
@@ -58,6 +58,7 @@ export type PostHogFeatureFlag = {
   }
   deleted: boolean
   active: boolean
+  /** @deprecated This field will be removed in a future version. **/
   is_simple_flag: boolean
   rollout_percentage: null | number
   ensure_experience_continuity: boolean

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -31,7 +31,6 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'person-flag',
-          is_simple_flag: true,
           active: true,
           filters: {
             groups: [
@@ -99,7 +98,6 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'person-flag',
-          is_simple_flag: true,
           active: true,
           filters: {
             groups: [
@@ -143,7 +141,6 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'group-flag',
-          is_simple_flag: true,
           active: true,
           filters: {
             aggregation_group_type_index: 0,
@@ -222,7 +219,6 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'group-flag',
-          is_simple_flag: true,
           active: true,
           filters: {
             aggregation_group_type_index: 0,
@@ -271,8 +267,7 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'complex-flag',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [
               {
@@ -547,7 +542,6 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: true,
           active: true,
           filters: {
             groups: [
@@ -586,7 +580,6 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: true,
           active: true,
           filters: {
             groups: [
@@ -629,7 +622,6 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: true,
           active: true,
           ensure_experience_continuity: true,
           filters: {
@@ -665,8 +657,7 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           rollout_percentage: 100,
           filters: {
             groups: [
@@ -681,8 +672,7 @@ describe('local evaluation', () => {
           id: 2,
           name: 'Beta Feature',
           key: 'disabled-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [
               {
@@ -696,8 +686,7 @@ describe('local evaluation', () => {
           id: 3,
           name: 'Beta Feature',
           key: 'beta-feature2',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [
               {
@@ -739,8 +728,7 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           rollout_percentage: 100,
           filters: {
             groups: [
@@ -758,8 +746,7 @@ describe('local evaluation', () => {
           id: 2,
           name: 'Beta Feature',
           key: 'disabled-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [
               {
@@ -776,8 +763,7 @@ describe('local evaluation', () => {
           id: 3,
           name: 'Beta Feature',
           key: 'beta-feature2',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [
               {
@@ -822,8 +808,7 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           rollout_percentage: 100,
           filters: {
             groups: [
@@ -838,8 +823,7 @@ describe('local evaluation', () => {
           id: 2,
           name: 'Beta Feature',
           key: 'disabled-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [
               {
@@ -853,8 +837,7 @@ describe('local evaluation', () => {
           id: 3,
           name: 'Beta Feature',
           key: 'beta-feature2',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [
               {
@@ -894,8 +877,7 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           rollout_percentage: 100,
           filters: {
             groups: [
@@ -913,8 +895,7 @@ describe('local evaluation', () => {
           id: 2,
           name: 'Beta Feature',
           key: 'disabled-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [
               {
@@ -931,8 +912,7 @@ describe('local evaluation', () => {
           id: 3,
           name: 'Beta Feature',
           key: 'beta-feature2',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [
               {
@@ -1027,8 +1007,7 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           rollout_percentage: 100,
           filters: {
             groups: [
@@ -1043,8 +1022,7 @@ describe('local evaluation', () => {
           id: 2,
           name: 'Beta Feature',
           key: 'disabled-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [
               {
@@ -1080,8 +1058,7 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           rollout_percentage: 100,
           filters: {
             groups: [
@@ -1099,8 +1076,7 @@ describe('local evaluation', () => {
           id: 2,
           name: 'Beta Feature',
           key: 'disabled-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [
               {
@@ -1139,8 +1115,7 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           rollout_percentage: 100,
           filters: {
             groups: [
@@ -1155,8 +1130,7 @@ describe('local evaluation', () => {
           id: 2,
           name: 'Beta Feature',
           key: 'disabled-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [
               {
@@ -1191,8 +1165,7 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: false,
-          active: false,
+                    active: false,
           rollout_percentage: 100,
           filters: {
             groups: [
@@ -1207,8 +1180,7 @@ describe('local evaluation', () => {
           id: 2,
           name: 'Beta Feature',
           key: 'disabled-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [
               {
@@ -1236,8 +1208,7 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           rollout_percentage: 100,
           filters: {
             groups: [
@@ -1318,8 +1289,7 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           rollout_percentage: 100,
           filters: {
             groups: [
@@ -1409,7 +1379,6 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: true,
           active: true,
           filters: {
             groups: [
@@ -1478,7 +1447,6 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: true,
           active: true,
           filters: {
             groups: [
@@ -1563,7 +1531,6 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: true,
           active: true,
           filters: {
             groups: [
@@ -1632,7 +1599,6 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: true,
           active: true,
           filters: {
             groups: [
@@ -1706,7 +1672,6 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'person-flag',
-          is_simple_flag: true,
           active: true,
           filters: {
             groups: [
@@ -1765,7 +1730,6 @@ describe('local evaluation', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'beta-feature',
-          is_simple_flag: true,
           active: true,
           filters: {
             groups: [
@@ -2357,8 +2321,7 @@ describe('consistency tests', () => {
           name: '',
           key: 'simple-flag',
           active: true,
-          is_simple_flag: false,
-          filters: {
+                    filters: {
             groups: [{ properties: [], rollout_percentage: 45 }],
           },
         },
@@ -3390,8 +3353,7 @@ describe('consistency tests', () => {
           id: 1,
           name: 'Beta Feature',
           key: 'multivariate-flag',
-          is_simple_flag: false,
-          active: true,
+                    active: true,
           filters: {
             groups: [{ properties: [], rollout_percentage: 55 }],
             multivariate: {

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -506,8 +506,7 @@ describe('PostHog Node.js', () => {
         id: 1,
         name: 'Beta Feature',
         key: 'beta-feature-local',
-        is_simple_flag: false,
-        active: true,
+                active: true,
         rollout_percentage: 100,
         filters: {
           groups: [
@@ -533,7 +532,6 @@ describe('PostHog Node.js', () => {
         id: 1,
         name: 'Beta Feature',
         key: 'person-flag',
-        is_simple_flag: true,
         active: true,
         filters: {
           groups: [
@@ -556,7 +554,6 @@ describe('PostHog Node.js', () => {
         id: 1,
         name: 'Beta Feature',
         key: 'false-flag',
-        is_simple_flag: true,
         active: true,
         filters: {
           groups: [


### PR DESCRIPTION
And remove it from tests.

This is a follow-up to https://github.com/PostHog/posthog-python/pull/186. See that issue for more context.