### PR TITLE
fix:Specify tz with the date

### DIFF
--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -2038,7 +2038,7 @@ describe('match properties', () => {
     ['is_date_after', '1h', '2022-04-30', false],
     // # Try all possible relative dates
     ['is_date_before', '1h', '2022-05-01 00:00:00', false],
-    ['is_date_before', '1h', '2022-04-30 22:00:00', true],
+    ['is_date_before', '1h', '2022-04-30 22:00:00 GMT', true],
     ['is_date_before', '-1d', '2022-04-29 23:59:00 GMT', true],
     ['is_date_before', '-1d', '2022-04-30 00:00:01 GMT', false],
     ['is_date_before', '1w', '2022-04-23 00:00:00 GMT', true],

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -2037,7 +2037,7 @@ describe('match properties', () => {
     ['is_date_after', '1h', new Date('2022-05-30'), true],
     ['is_date_after', '1h', '2022-04-30', false],
     // # Try all possible relative dates
-    ['is_date_before', '1h', '2022-05-01 00:00:00', false],
+    ['is_date_before', '1h', '2022-05-01 00:00:00 GMT', false],
     ['is_date_before', '1h', '2022-04-30 22:00:00 GMT', true],
     ['is_date_before', '-1d', '2022-04-29 23:59:00 GMT', true],
     ['is_date_before', '-1d', '2022-04-30 00:00:01 GMT', false],


### PR DESCRIPTION
This test was failing on my local machine because of TZ differences. Here's the breakdown.

1. System Date: `2022-05-01`. Jest interprets it as `2022-05-01 00:00:00 UTC`
2. 1hr before `2022-04-30 23:00:00 UTC`
3. Override value: `2022-04-30 22:00:00` which JavaScript interprets as PDT (I live on the west coast of the U.S.). Converted to UTC -> `2022-05-01 05:00:00 UTC`. That's definitely not before `2022-05-01 00:00:00 UTC` and the test fails.

Fix: Specify GMT for the override value.

Some of the other tests might break for other TZ. We should probably mock the TZ in the tests to be more explicit. But I just want to make these tests pass my machine for now.