### PR TITLE
Do not enrich the $feature_flag_called event with more feature flag data

### DIFF
--- a/posthog-core/test/posthog.featureflags.spec.ts
+++ b/posthog-core/test/posthog.featureflags.spec.ts
@@ -463,6 +463,32 @@ describe('PostHog Core', () => {
         })
       })
 
+      it('should capture $feature_flag_called when called, but not add all cached flags', async () => {
+        expect(posthog.getFeatureFlag('feature-1')).toEqual(true)
+        await waitForPromises()
+        expect(mocks.fetch).toHaveBeenCalledTimes(2)
+
+        expect(parseBody(mocks.fetch.mock.calls[1])).toMatchObject({
+          batch: [
+            {
+              event: '$feature_flag_called',
+              distinct_id: posthog.getDistinctId(),
+              properties: {
+                $feature_flag: 'feature-1',
+                $feature_flag_response: true,
+                '$feature/feature-1': true,
+                $used_bootstrap_value: false,
+              },
+              type: 'capture',
+            },
+          ],
+        })
+
+        // Only tracked once
+        expect(posthog.getFeatureFlag('feature-1')).toEqual(true)
+        expect(mocks.fetch).toHaveBeenCalledTimes(2)
+      })
+
       it('should persist feature flags', () => {
         expect(posthog.getPersistedProperty(PostHogPersistedProperty.FeatureFlags)).toEqual(createMockFeatureFlags())
       })

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Next
 
-# 4.5.1 - 2025-02-11
+# 4.5.1 - 2025-02-12
 
 1. fix: Fixed edge case where `$feature_flag_called` events were enriched with additional feature flag data when they shouldn't be.
 

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 4.5.1 - 2025-02-11
+
+1. fix: Fixed edge case where `$feature_flag_called` events were enriched with additional feature flag data when they shouldn't be.
+
 # 4.5.0 - 2025-02-06
 
 ## Added

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -135,8 +135,13 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
           return await _getFlags(distinctId, groups, disableGeoip)
         }
 
+        if (event === '$feature_flag_called') {
+          // If we're capturing a $feature_flag_called event, we don't want to enrich the event with cached flags that may be out of date.
+          return {}
+        }
+
         if ((this.featureFlagsPoller?.featureFlags?.length || 0) > 0) {
-          // Otherwise we may as well check for the flags locally and include them if there
+          // Otherwise we may as well check for the flags locally and include them if they are already loaded
           const groupsWithStringValues: Record<string, string> = {}
           for (const [key, value] of Object.entries(groups || {})) {
             groupsWithStringValues[key] = String(value)

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -1810,7 +1810,7 @@ describe('getFeatureFlag', () => {
             groups: [
               {
                 variant: null,
-                properties: [{ key: 'region', type: 'person', value: 'USA', operator: 'exact'}],
+                properties: [{ key: 'region', type: 'person', value: 'USA', operator: 'exact' }],
                 rollout_percentage: 100,
               },
             ],
@@ -1852,23 +1852,23 @@ describe('getFeatureFlag', () => {
       })
     ).toEqual(true)
 
-    await waitForPromises();
+    await waitForPromises()
 
     expect(capturedMessage).toMatchObject({
-      "distinct_id": "some-distinct-id",
-      "event": "$feature_flag_called",
-      "library": posthog.getLibraryId(),
-      "library_version": posthog.getLibraryVersion(),
-      "properties": {
-        "$feature/complex-flag": true,
-        "$feature_flag": "complex-flag",
-        "$feature_flag_response": true,
-        "$groups": undefined,
-        "$lib": posthog.getLibraryId(),
-        "$lib_version": posthog.getLibraryVersion(),
-        "locally_evaluated": true,
-      }
-    });
+      distinct_id: 'some-distinct-id',
+      event: '$feature_flag_called',
+      library: posthog.getLibraryId(),
+      library_version: posthog.getLibraryVersion(),
+      properties: {
+        '$feature/complex-flag': true,
+        $feature_flag: 'complex-flag',
+        $feature_flag_response: true,
+        $groups: undefined,
+        $lib: posthog.getLibraryId(),
+        $lib_version: posthog.getLibraryVersion(),
+        locally_evaluated: true,
+      },
+    })
 
     expect(capturedMessage.properties).not.toHaveProperty('$active_feature_flags')
     expect(capturedMessage.properties).not.toHaveProperty('$feature/simple-flag')

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -1079,7 +1079,7 @@ describe('PostHog Node.js', () => {
 
       await expect(posthog.getFeatureFlagPayload('false-flag', '123', true)).resolves.toEqual(300)
       // Check no non-batch API calls were made
-      const additionalNonBatchCalls = mockedFetch.mock.calls.filter(call => !call[0].includes('/batch'))
+      const additionalNonBatchCalls = mockedFetch.mock.calls.filter((call) => !call[0].includes('/batch'))
       expect(additionalNonBatchCalls.length).toBe(0)
     })
 

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -1078,7 +1078,9 @@ describe('PostHog Node.js', () => {
       expect(mockedFetch).toHaveBeenCalledTimes(0)
 
       await expect(posthog.getFeatureFlagPayload('false-flag', '123', true)).resolves.toEqual(300)
-      expect(mockedFetch).toHaveBeenCalledTimes(0)
+      // Check no non-batch API calls were made
+      const additionalNonBatchCalls = mockedFetch.mock.calls.filter(call => !call[0].includes('/batch'))
+      expect(additionalNonBatchCalls.length).toBe(0)
     })
 
     it('should not double parse json with getFeatureFlagPayloads and server eval', async () => {


### PR DESCRIPTION
See https://github.com/PostHog/posthog-python/pull/181 for more context. This PR is a port of that fix.

## Problem

The `client.getFeatureFlag()` method will by default call `client.capture` with the event named `$feature_flag_called`. 

Some time ago, the `capture()` method was changed to enrich the event with all locally cached feature flags even if `sendFeatureFlags` is `false`.

What this leads to is `client.getFeatureFlag()` -> `client.capture()` -> `client.getAllFlags()`. But the call to `client.getAllFlags()` isn't passed the original `person_properties` that were passed to `client.getFeatureFlag()`. This leads to inconsistency in the enriched data.

This PR takes the simplest path by not enriching the captured event with all feature flags for the `$feature_flag_called` event.

## Changes

If the captured event is `$feature_flag_called`, we don't enrich it with all flags.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Fixed edge case where `$feature_flag_called` events were enriched with additional feature flag data when they shouldn't be.
