### PR TITLE
feat(flags): Add method for fetching decrypted remote config flag payload

### DIFF
--- a/examples/example-node/example.ts
+++ b/examples/example-node/example.ts
@@ -68,7 +68,7 @@ async function testFeatureFlags() {
     })
   )
 
-  console.log(await posthog.getDecryptedFeatureFlagPayload('my_secret_flag_value'))
+  console.log(await posthog.getRemoteConfigPayload('my_secret_flag_value'))
 }
 
 testFeatureFlags().then(async () => {

--- a/examples/example-node/example.ts
+++ b/examples/example-node/example.ts
@@ -68,7 +68,7 @@ async function testFeatureFlags() {
     })
   )
 
-  console.log(await posthog.getDecryptedFeatureFlagPayload(257))
+  console.log(await posthog.getDecryptedFeatureFlagPayload('my_secret_flag_value'))
 }
 
 testFeatureFlags().then(async () => {

--- a/examples/example-node/example.ts
+++ b/examples/example-node/example.ts
@@ -67,6 +67,8 @@ async function testFeatureFlags() {
       onlyEvaluateLocally: true,
     })
   )
+
+  console.log(await posthog.getDecryptedFeatureFlagPayload(257))
 }
 
 testFeatureFlags().then(async () => {

--- a/examples/example-node/tsconfig.json
+++ b/examples/example-node/tsconfig.json
@@ -5,7 +5,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "allowJs": true
+    "allowJs": true,
+    "resolveJsonModule": true
   },
   "exclude": ["node_modules"]
 }

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Next
 
+# 4.6.0 - 2025-02-12
+
+## Added
+
+1. Adds ability to fetch decrypted remote config flag payloads via `getDecryptedFeatureFlagPayload`
+
 # 4.5.0 - 2025-02-06
 
 ## Added

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Added
 
-1. Adds ability to fetch decrypted remote config flag payloads via `getDecryptedFeatureFlagPayload`
+1. Adds ability to fetch decrypted remote config flag payloads via `getRemoteConfigPayload`
 
 # 4.5.2 - 2025-02-12
 

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -452,8 +452,8 @@ class FeatureFlagsPoller {
     clearTimeout(this.poller)
   }
 
-  _requestDecryptedFeatureFlagPayload(flagId: number): Promise<PostHogFetchResponse> {
-    const url = `${this.host}/api/projects/@current/feature_flags/${flagId}/remote_config/`
+  _requestDecryptedFeatureFlagPayload(flagKey: string): Promise<PostHogFetchResponse> {
+    const url = `${this.host}/api/projects/@current/feature_flags/${flagKey}/remote_config/`
 
     const options: PostHogFetchOptions = {
       method: 'GET',

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -456,7 +456,7 @@ class FeatureFlagsPoller {
     clearTimeout(this.poller)
   }
 
-  _requestDecryptedFeatureFlagPayload(flagKey: string): Promise<PostHogFetchResponse> {
+  _requestRemoteConfigPayload(flagKey: string): Promise<PostHogFetchResponse> {
     const url = `${this.host}/api/projects/@current/feature_flags/${flagKey}/remote_config/`
 
     const options = this.getPersonalApiKeyRequestOptions()

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -461,7 +461,19 @@ class FeatureFlagsPoller {
 
     const options = this.getPersonalApiKeyRequestOptions()
 
-    return this.fetch(url, options)
+    let abortTimeout = null
+    if (this.timeout && typeof this.timeout === 'number') {
+      const controller = new AbortController()
+      abortTimeout = safeSetTimeout(() => {
+        controller.abort()
+      }, this.timeout)
+      options.signal = controller.signal
+    }
+    try {
+      return this.fetch(url, options)
+    } finally {
+      clearTimeout(abortTimeout)
+    }
   }
 }
 

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -412,7 +412,7 @@ class FeatureFlagsPoller {
       this.loadedSuccessfullyOnce = true
     } catch (err) {
       // if an error that is not an instance of ClientError is thrown
-      // we silently ignore the error when reloading feature flaorization: `Bearer ${this.persongs
+      // we silently ignore the error when reloading feature flags
       if (err instanceof ClientError) {
         this.onError?.(err)
       }

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -412,24 +412,28 @@ class FeatureFlagsPoller {
       this.loadedSuccessfullyOnce = true
     } catch (err) {
       // if an error that is not an instance of ClientError is thrown
-      // we silently ignore the error when reloading feature flags
+      // we silently ignore the error when reloading feature flaorization: `Bearer ${this.persongs
       if (err instanceof ClientError) {
         this.onError?.(err)
       }
     }
   }
 
-  async _requestFeatureFlagDefinitions(): Promise<PostHogFetchResponse> {
-    const url = `${this.host}/api/feature_flag/local_evaluation?token=${this.projectApiKey}&send_cohorts`
-
-    const options: PostHogFetchOptions = {
-      method: 'GET',
+  private getPersonalApiKeyRequestOptions(method: 'GET' | 'POST' | 'PUT' | 'PATCH' = 'GET'): PostHogFetchOptions {
+    return {
+      method,
       headers: {
         ...this.customHeaders,
         'Content-Type': 'application/json',
         Authorization: `Bearer ${this.personalApiKey}`,
       },
     }
+  }
+
+  async _requestFeatureFlagDefinitions(): Promise<PostHogFetchResponse> {
+    const url = `${this.host}/api/feature_flag/local_evaluation?token=${this.projectApiKey}&send_cohorts`
+
+    const options = this.getPersonalApiKeyRequestOptions()
 
     let abortTimeout = null
 
@@ -455,14 +459,7 @@ class FeatureFlagsPoller {
   _requestDecryptedFeatureFlagPayload(flagKey: string): Promise<PostHogFetchResponse> {
     const url = `${this.host}/api/projects/@current/feature_flags/${flagKey}/remote_config/`
 
-    const options: PostHogFetchOptions = {
-      method: 'GET',
-      headers: {
-        ...this.customHeaders,
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.personalApiKey}`,
-      },
-    }
+    const options = this.getPersonalApiKeyRequestOptions()
 
     return this.fetch(url, options)
   }

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -451,6 +451,21 @@ class FeatureFlagsPoller {
   stopPoller(): void {
     clearTimeout(this.poller)
   }
+
+  _requestDecryptedFeatureFlagPayload(flagId: number): Promise<PostHogFetchResponse> {
+    const url = `${this.host}/api/projects/@current/feature_flags/${flagId}/remote_config/`
+
+    const options: PostHogFetchOptions = {
+      method: 'GET',
+      headers: {
+        ...this.customHeaders,
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.personalApiKey}`,
+      },
+    }
+
+    return this.fetch(url, options)
+  }
 }
 
 // # This function takes a distinct_id and a feature flag key and returns a float between 0 and 1.

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -354,6 +354,10 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
     return response
   }
 
+  async getDecryptedFeatureFlagPayload(flagId: number): Promise<JsonType | undefined> {
+    return (await this.featureFlagsPoller?._requestDecryptedFeatureFlagPayload(flagId))?.json()
+  }
+
   async isFeatureEnabled(
     key: string,
     distinctId: string,

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -354,8 +354,8 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
     return response
   }
 
-  async getDecryptedFeatureFlagPayload(flagId: number): Promise<JsonType | undefined> {
-    return (await this.featureFlagsPoller?._requestDecryptedFeatureFlagPayload(flagId))?.json()
+  async getDecryptedFeatureFlagPayload(flagKey: string): Promise<JsonType | undefined> {
+    return (await this.featureFlagsPoller?._requestDecryptedFeatureFlagPayload(flagKey))?.json()
   }
 
   async isFeatureEnabled(

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -359,8 +359,8 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
     return response
   }
 
-  async getDecryptedFeatureFlagPayload(flagKey: string): Promise<JsonType | undefined> {
-    return (await this.featureFlagsPoller?._requestDecryptedFeatureFlagPayload(flagKey))?.json()
+  async getRemoteConfigPayload(flagKey: string): Promise<JsonType | undefined> {
+    return (await this.featureFlagsPoller?._requestRemoteConfigPayload(flagKey))?.json()
   }
 
   async isFeatureEnabled(


### PR DESCRIPTION
## Problem

Context: [PostHog/posthog#27414 (files)](https://github.com/PostHog/posthog/pull/27414/files)

<img width="577" alt="Screenshot 2025-02-11 at 5 07 21 PM" src="https://github.com/user-attachments/assets/ddc211ee-edac-480b-89fb-89e96b2db7f8" />


## Changes

Adds new `getDecryptedFeatureFlagPayload` method to Node SDK

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

