### PR TITLE
fix: ensure feature flags are reloaded after reset() to prevent undefined values

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -1195,7 +1195,6 @@ export abstract class PostHogCore extends PostHogCoreStateless {
               newFeatureFlags = { ...currentFlags, ...res.featureFlags }
               newFeatureFlagPayloads = { ...currentFlagPayloads, ...res.featureFlagPayloads }
             }
-
             this.setKnownFeatureFlags(newFeatureFlags)
             this.setKnownFeatureFlagPayloads(
               Object.fromEntries(

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -1178,7 +1178,6 @@ export abstract class PostHogCore extends PostHogCoreStateless {
             }
 
             let newFeatureFlags = res.featureFlags
-
             let newFeatureFlagPayloads = res.featureFlagPayloads
             if (res.errorsWhileComputingFlags) {
               // if not all flags were computed, we upsert flags instead of replacing them
@@ -1193,7 +1192,6 @@ export abstract class PostHogCore extends PostHogCoreStateless {
               const currentFlagPayloads = this.getPersistedProperty<PostHogDecideResponse['featureFlagPayloads']>(
                 PostHogPersistedProperty.FeatureFlagPayloads
               )
-
               newFeatureFlags = { ...currentFlags, ...res.featureFlags }
               newFeatureFlagPayloads = { ...currentFlagPayloads, ...res.featureFlagPayloads }
             }

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -1150,7 +1150,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
   private async decideAsync(sendAnonDistinctId: boolean = true): Promise<PostHogDecideResponse | undefined> {
     await this._initPromise
     if (this._decideResponsePromise) {
-      await this._decideResponsePromise
+      return this._decideResponsePromise
     }
     return this._decideAsync(sendAnonDistinctId)
   }

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 3.9.1 - 2025-02-13
 
-1. fix: reset should reload flags and flags should always be loaded if reload method is called
+1. fix: ensure feature flags are reloaded after reset() to prevent undefined values
 
 # 3.9.0 - 2025-02-07
 

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.9.1 - 2025-02-13
+
+1. fix: reset should reload flags and flags should always be loaded if reload method is called
+
 # 3.9.0 - 2025-02-07
 
 1. chore: Session Replay - GA

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog-js-lite/issues/391

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
