### PR TITLE
Add KeyboardAvoidingView to SurveyModal

### DIFF
--- a/posthog-react-native/src/surveys/PostHogSurveyProvider.tsx
+++ b/posthog-react-native/src/surveys/PostHogSurveyProvider.tsx
@@ -32,7 +32,11 @@ const FeedbackSurveyContext = React.createContext<
 export const useFeedbackSurvey = (selector: string): FeedbackSurveyHook | undefined => {
   const context = React.useContext(FeedbackSurveyContext)
   const survey = context?.surveys.find(
-    (survey: Survey) => survey.type === SurveyType.Widget && survey.appearance?.widgetSelector === selector
+    (survey: Survey) =>
+      survey.type === SurveyType.Widget &&
+      survey.appearance?.widgetSelector === selector &&
+      survey.start_date !== null &&
+      survey.end_date === null
   )
   if (!context || !survey) {
     return undefined

--- a/posthog-react-native/src/surveys/components/SurveyModal.tsx
+++ b/posthog-react-native/src/surveys/components/SurveyModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Modal, Pressable, StyleSheet, TouchableWithoutFeedback, View } from 'react-native'
+import { KeyboardAvoidingView, Modal, Pressable, StyleSheet, TouchableWithoutFeedback, View } from 'react-native'
 
 import { Cancel } from './Cancel'
 import { ConfirmationMessage } from './ConfirmationMessage'
@@ -56,48 +56,45 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
 
   return (
     <Modal animationType="fade" transparent onRequestClose={onClose} statusBarTranslucent={true}>
-      <Pressable
-        style={[styles.modalContainer, { marginBottom: insets.bottom + 20 }]}
-        onPress={onClose}
-        accessible={false}
-      >
-        <TouchableWithoutFeedback accessible={false}>
-          <View
-            style={[
-              styles.modalContent,
-              { borderColor: appearance.borderColor, backgroundColor: appearance.backgroundColor },
-            ]}
-          >
-            {!shouldShowConfirmation ? (
-              <Questions survey={survey} appearance={appearance} onSubmit={() => setIsSurveySent(true)} />
-            ) : (
-              <ConfirmationMessage
-                appearance={appearance}
-                header={appearance.thankYouMessageHeader}
-                description={appearance.thankYouMessageDescription}
-                contentType={
-                  appearance.thankYouMessageDescriptionContentType ?? SurveyQuestionDescriptionContentType.Text
-                }
-                onClose={onClose}
-                isModal={true}
-              />
-            )}
-            <View style={styles.topIconContainer}>
-              <Cancel onPress={onClose} appearance={appearance} />
+      <Pressable style={[styles.modalBackdrop]} onPress={onClose} accessible={false}>
+        <KeyboardAvoidingView behavior={'padding'} style={{ marginBottom: insets.bottom + 10, marginHorizontal: 10 }}>
+          <TouchableWithoutFeedback accessible={false}>
+            <View
+              style={[
+                styles.modalContent,
+                { borderColor: appearance.borderColor, backgroundColor: appearance.backgroundColor },
+              ]}
+            >
+              {!shouldShowConfirmation ? (
+                <Questions survey={survey} appearance={appearance} onSubmit={() => setIsSurveySent(true)} />
+              ) : (
+                <ConfirmationMessage
+                  appearance={appearance}
+                  header={appearance.thankYouMessageHeader}
+                  description={appearance.thankYouMessageDescription}
+                  contentType={
+                    appearance.thankYouMessageDescriptionContentType ?? SurveyQuestionDescriptionContentType.Text
+                  }
+                  onClose={onClose}
+                  isModal={true}
+                />
+              )}
+              <View style={styles.topIconContainer}>
+                <Cancel onPress={onClose} appearance={appearance} />
+              </View>
             </View>
-          </View>
-        </TouchableWithoutFeedback>
+          </TouchableWithoutFeedback>
+        </KeyboardAvoidingView>
       </Pressable>
     </Modal>
   )
 }
 
 const styles = StyleSheet.create({
-  modalContainer: {
+  modalBackdrop: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'flex-end',
-    marginHorizontal: 20,
   },
   modalContent: {
     borderRadius: 10,


### PR DESCRIPTION
Pulling over a couple of bug fixes from my fork:

- When focusing a text field in a popover/modal survey the keyboard would cover the modal so you couldn't see what you were typing
- The `useFeedbackSurvey` hook was returning surveys which were not launched/enabled in PostHog

#110
