### PR TITLE
chore: release Supports gracefully handling quotaLimited responses from the PostHog API for feature flag

### DIFF
--- a/examples/example-expo-latest/App.tsx
+++ b/examples/example-expo-latest/App.tsx
@@ -21,9 +21,9 @@ export const SharedPostHogProvider = (props: any) => {
     <PostHogProvider
       client={posthog}
       autocapture={{
-        captureLifecycleEvents: true,
-        captureScreens: true,
-        captureTouches: true,
+        captureLifecycleEvents: false,
+        captureScreens: false,
+        captureTouches: false,
         customLabelProp: 'ph-my-label',
       }}
       debug
@@ -42,8 +42,24 @@ export default function App() {
   const [buttonText, setButtonText] = useState('Open up App.js to start working on your app!')
 
   const handleClick = () => {
-    posthog.capture('button_clicked', { name: 'example' })
-    setButtonText('button_clicked' + new Date().toISOString())
+    // posthog.capture('button_clicked', { name: 'example' })
+    // setButtonText('button_clicked' + new Date().toISOString())
+    const userId = String(93929292112)
+    const user = {
+      id: userId,
+      invite_token: 'e8d605f6a8e58e64552675331ce98680',
+      location: 'San Francisco, California',
+      state: 'active',
+      stats: {
+        bookmark_count: 61,
+        review_count: 70,
+      },
+      created_at: '2013-06-10T18:35:57+00:00',
+      updated_at: '2025-02-22T03:27:26+00:00',
+      user_type: ['User'],
+    }
+    posthog.alias(userId)
+    posthog.identify(userId, user)
   }
 
   return (

--- a/examples/example-expo-latest/App.tsx
+++ b/examples/example-expo-latest/App.tsx
@@ -21,9 +21,9 @@ export const SharedPostHogProvider = (props: any) => {
     <PostHogProvider
       client={posthog}
       autocapture={{
-        captureLifecycleEvents: false,
-        captureScreens: false,
-        captureTouches: false,
+        captureLifecycleEvents: true,
+        captureScreens: true,
+        captureTouches: true,
         customLabelProp: 'ph-my-label',
       }}
       debug
@@ -42,24 +42,8 @@ export default function App() {
   const [buttonText, setButtonText] = useState('Open up App.js to start working on your app!')
 
   const handleClick = () => {
-    // posthog.capture('button_clicked', { name: 'example' })
-    // setButtonText('button_clicked' + new Date().toISOString())
-    const userId = String(93929292112)
-    const user = {
-      id: userId,
-      invite_token: 'e8d605f6a8e58e64552675331ce98680',
-      location: 'San Francisco, California',
-      state: 'active',
-      stats: {
-        bookmark_count: 61,
-        review_count: 70,
-      },
-      created_at: '2013-06-10T18:35:57+00:00',
-      updated_at: '2025-02-22T03:27:26+00:00',
-      user_type: ['User'],
-    }
-    posthog.alias(userId)
-    posthog.identify(userId, user)
+    posthog.capture('button_clicked', { name: 'example' })
+    setButtonText('button_clicked' + new Date().toISOString())
   }
 
   return (

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # 3.11.2 - 2025-02-27
 
+## Fixed
+
 1. Supports gracefully handling quotaLimited responses from the PostHog API for feature flag
 
 # 3.11.1 - 2025-02-21

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Fixed
 
-1. Supports gracefully handling quotaLimited responses from the PostHog API for feature flag
+1. Supports gracefully handling quotaLimited responses from the PostHog API for feature flags.
 
 # 3.11.1 - 2025-02-21
 

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.11.2 - 2025-02-27
+
+1. Supports gracefully handling quotaLimited responses from the PostHog API for feature flag
+
 # 3.11.1 - 2025-02-21
 
 ## Fixed

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 3.4.2 - 2025-02-27
+
+1. Supports gracefully handling quotaLimited responses from the PostHog API for feature flag
+
 # 3.4.1 - 2025-02-20
 
 ## Fixed

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # 3.4.2 - 2025-02-27
 
+## Fixed
+
 1. Supports gracefully handling quotaLimited responses from the PostHog API for feature flag
 
 # 3.4.1 - 2025-02-20

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Fixed
 
-1. Supports gracefully handling quotaLimited responses from the PostHog API for feature flag
+1. Supports gracefully handling quotaLimited responses from the PostHog API for feature flags.
 
 # 3.4.1 - 2025-02-20
 

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-js-lite",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Problem

Follow up https://github.com/PostHog/posthog-js-lite/pull/403
changes were for web and RN as well

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [X] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
