### PR TITLE
fix: cache replay config for remote config

### DIFF
--- a/examples/example-expo-latest/App.tsx
+++ b/examples/example-expo-latest/App.tsx
@@ -7,7 +7,7 @@ import PostHog, { PostHogProvider, PostHogSurveyProvider } from 'posthog-react-n
 export const posthog = new PostHog('phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D', {
   host: 'https://us.i.posthog.com',
   flushAt: 1,
-  enableSessionReplay: false,
+  enableSessionReplay: true,
   // if using WebView, you have to disable masking for text inputs and images
   // sessionReplayConfig: {
   //   maskAllTextInputs: false,

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -1196,7 +1196,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
 
   resetPersonPropertiesForFlags(): void {
     this.wrap(() => {
-      this.setPersistedProperty<PostHogEventProperties>(PostHogPersistedProperty.PersonProperties, {})
+      this.setPersistedProperty<PostHogEventProperties>(PostHogPersistedProperty.PersonProperties, null)
     })
   }
 
@@ -1231,7 +1231,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
 
   resetGroupPropertiesForFlags(): void {
     this.wrap(() => {
-      this.setPersistedProperty<PostHogEventProperties>(PostHogPersistedProperty.GroupProperties, {})
+      this.setPersistedProperty<PostHogEventProperties>(PostHogPersistedProperty.GroupProperties, null)
     })
   }
 
@@ -1310,7 +1310,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
                 surveys as Survey[]
               )
             } else {
-              this.setPersistedProperty<SurveyResponse['surveys']>(PostHogPersistedProperty.Surveys, [])
+              this.setPersistedProperty<SurveyResponse['surveys']>(PostHogPersistedProperty.Surveys, null)
             }
 
             // we cache the surveys in its own storage key

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -1308,6 +1308,17 @@ export abstract class PostHogCore extends PostHogCoreStateless {
               remoteConfigWithoutSurveys
             )
 
+            const sessionReplay = response?.sessionRecording
+            if (sessionReplay) {
+              this.setPersistedProperty(PostHogPersistedProperty.SessionReplay, sessionReplay)
+              this.logMsgIfDebug(() =>
+                console.log('PostHog Debug', 'Session replay config: ', JSON.stringify(sessionReplay))
+              )
+            } else {
+              this.logMsgIfDebug(() => console.info('PostHog Debug', 'Session replay config disabled.'))
+              this.setPersistedProperty(PostHogPersistedProperty.SessionReplay, null)
+            }
+
             // we only dont load flags if the remote config has no feature flags
             if (response.hasFeatureFlags === false) {
               // resetting flags to empty object

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -302,7 +302,7 @@ export class PostHog extends PostHogCore {
   public async getSurveys(): Promise<SurveyResponse['surveys']> {
     if (this._disableSurveys === true) {
       this.logMsgIfDebug(() => console.log('Loading surveys is disabled.'))
-      this.setPersistedProperty<SurveyResponse['surveys']>(PostHogPersistedProperty.Surveys, [])
+      this.setPersistedProperty<SurveyResponse['surveys']>(PostHogPersistedProperty.Surveys, null)
       return []
     }
 


### PR DESCRIPTION
## Problem

we're doing it for decide API but not for remote config

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
