### PR TITLE
feat(flags): Attach requestId to $feature_flag_called if present in /decide response

### DIFF
--- a/posthog-core/src/types.ts
+++ b/posthog-core/src/types.ts
@@ -126,6 +126,7 @@ export type PostHogDecideResponse = {
     | {
         [key: string]: JsonType
       }
+  requestId?: string
 }
 
 export type PostHogFlagsAndPayloadsResponse = {

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 4.10.0 – 2025-03-06
+
+1. Attach requestId to $feature_flag_called if present in /decide response
+
 # 4.9.0 – 2025-03-04
 
 1. Allow feature flags to be evaluated individually when local evaluation is not being used

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -130,12 +130,12 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
       super.captureStateless(distinctId, event, props, { timestamp, disableGeoip, uuid })
     }
 
-    const _getFlags = (
+    const _getFlags = async (
       distinctId: EventMessage['distinctId'],
       groups: EventMessage['groups'],
       disableGeoip: EventMessage['disableGeoip']
     ): Promise<PostHogDecideResponse['featureFlags'] | undefined> => {
-      return super.getFeatureFlagsStateless(distinctId, groups, undefined, undefined, disableGeoip)
+      return (await super.getFeatureFlagsStateless(distinctId, groups, undefined, undefined, disableGeoip)).flags
     }
 
     // :TRICKY: If we flush, or need to shut down, to not lose events we want this promise to resolve before we flush
@@ -260,9 +260,9 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
     )
 
     const flagWasLocallyEvaluated = response !== undefined
-
+    let requestId = undefined
     if (!flagWasLocallyEvaluated && !onlyEvaluateLocally) {
-      response = await super.getFeatureFlagStateless(
+      const remoteResponse = await super.getFeatureFlagStateless(
         key,
         distinctId,
         groups,
@@ -270,6 +270,8 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
         groupProperties,
         disableGeoip
       )
+      response = remoteResponse.response
+      requestId = remoteResponse.requestId
     }
 
     const featureFlagReportedKey = `${key}_${response}`
@@ -295,6 +297,7 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
           $feature_flag_response: response,
           locally_evaluated: flagWasLocallyEvaluated,
           [`$feature/${key}`]: response,
+          $request_id: requestId,
         },
         groups,
         disableGeoip,

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -297,7 +297,7 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
           $feature_flag_response: response,
           locally_evaluated: flagWasLocallyEvaluated,
           [`$feature/${key}`]: response,
-          $request_id: requestId,
+          $feature_flag_request_id: requestId,
         },
         groups,
         disableGeoip,


### PR DESCRIPTION
## Problem

To help correlate Node SDK (remotely loaded) $feature_flag_called events to `/decide` requests, we'll attach  a new `$feature_flag_request_id` property to the event

Combined with https://github.com/PostHog/posthog/pull/29563, we'll have clear signal as to how a specific flag evaluation was determined at a point in the past, including any SDK property overrides that could have affected it.

## Changes

- Refactor stateless flag code to return both a flag value and a requestId, if one is found
- Add the `$feature_flag_request_id` property to $feature_flag_called event

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

Request ID being passed through with https://github.com/PostHog/posthog/pull/29563 changes:
![image](https://github.com/user-attachments/assets/7cbfb569-14b3-4a16-94e1-05972d9368f4)

SDK just omits `$feature_flag_request_id` if none present in API response:
![image](https://github.com/user-attachments/assets/e886c9de-f3d0-4167-8855-d02afc7a3f50)

