### PR TITLE
fix: update the rate-limiting logic to ensure we don't repeatedly fetch

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Next
 
-1. Fix: prevent fetch floods when quota limited.
+1. Fix: prevent fetch floods when rate-limited.
 
 # 4.10.1 – 2025-03-06
 

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+1. Fix: prevent fetch floods when quota limited.
+
 # 4.10.1 – 2025-03-06
 
 1. Fix: only set `platform` on PostHog exception frame properties

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -418,7 +418,7 @@ class FeatureFlagsPoller {
         )
       }
 
-      if (res && res.status === 402) {
+      if (res && (res.status === 402 || res.status === 429)) {
         // Quota limited - clear all flags
         console.warn(
           '[FEATURE FLAGS] Feature flags quota limit exceeded - unsetting all local flags. Learn more about billing limits at https://posthog.com/docs/billing/limits-alerts'
@@ -427,7 +427,9 @@ class FeatureFlagsPoller {
         this.featureFlagsByKey = {}
         this.groupTypeMapping = {}
         this.cohorts = {}
-        this.loadedSuccessfullyOnce = false
+        // set loadedSuccessfullyOnce on 429s, otherwise every call to getFeatureFlag
+        // will try to fetch again.
+        this.loadedSuccessfullyOnce = true
         return
       }
 

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -419,8 +419,6 @@ class FeatureFlagsPoller {
         this.featureFlagsByKey = {}
         this.groupTypeMapping = {}
         this.cohorts = {}
-        // set loadedSuccessfullyOnce on 429s, otherwise every call to getFeatureFlag
-        // will try to fetch again.
         this.loadedSuccessfullyOnce = true
         return
       }


### PR DESCRIPTION
## Problem

We weren't handling backing off on 429s, so we kept hammering the `fetch` if a request was rate-limited.

## Changes

Added an error handler that wraps 429 errors in exponential backoffs (like we do with 401 and 403 errors)

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Fix: prevent fetch floods when quota limited.
