### PR TITLE
fix: ensure we don't send multiple flag requests in parallel

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 1. Fix: prevent fetch floods when rate-limited.
+2. Fix: never send multiple feature flag fetch requests in parallel.
 
 # 4.10.1 – 2025-03-06
 


### PR DESCRIPTION
## Problem

currently if we call e.g. `getFeatureFlags()` 100 times straight away after initialisation we will send 100 fetch requests before the first one returns

this is even worse if e.g. we are erroring so never setting `loadedSuccessfullyOnce`

## Changes

add logic to check if we have an inflight request already and block on the existing one instead of starting a new one

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Fix: don't send multiple feature flag fetch requests in parallel.
