### PR TITLE
Warn the user if they're following the web client API

### DIFF
--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -99,16 +99,14 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
     this.featureFlagsPoller?.debug(enabled)
   }
 
-  capture({
-    distinctId,
-    event,
-    properties,
-    groups,
-    sendFeatureFlags,
-    timestamp,
-    disableGeoip,
-    uuid,
-  }: EventMessage): void {
+  capture(props: EventMessage): void {
+    if (typeof props === 'string') {
+      this.logMsgIfDebug(() =>
+        console.warn('Called capture() with a string as the first argument when an object was expected.')
+      )
+    }
+    const { distinctId, event, properties, groups, sendFeatureFlags, timestamp, disableGeoip, uuid }: EventMessage =
+      props
     const _capture = (props: EventMessage['properties']): void => {
       super.captureStateless(distinctId, event, props, { timestamp, disableGeoip, uuid })
     }

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -328,6 +328,17 @@ describe('PostHog Node.js', () => {
 
       await client.shutdown()
     })
+
+    it('should warn if capture is called with a string', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      posthog.debug(true)
+      // @ts-expect-error - Testing the warning when passing a string instead of an object
+      posthog.capture('test-event')
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Called capture() with a string as the first argument when an object was expected.'
+      )
+      warnSpy.mockRestore()
+    })
   })
 
   describe('shutdown', () => {


### PR DESCRIPTION
It's not obvious that the `capture()` function signature varies between web and node until you learn the hard way.