### PR TITLE
chore(flags): emit an error message whenever `/decide` fails to calculate flags

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -522,7 +522,7 @@ export abstract class PostHogCoreStateless {
     }
     const decideResponse = await this.getDecide(distinctId, groups, personProperties, groupProperties, extraPayload)
 
-    // if there's an error on the decideREsponse, log a console error, but don't throw an error
+    // if there's an error on the decideResponse, log a console error, but don't throw an error
     if (decideResponse?.errorsWhileComputingFlags) {
       console.error(
         '[FEATURE FLAGS] Error while computing feature flags, some flags may be missing or incorrect. Learn more at https://posthog.com/docs/feature-flags/best-practices'

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -522,6 +522,13 @@ export abstract class PostHogCoreStateless {
     }
     const decideResponse = await this.getDecide(distinctId, groups, personProperties, groupProperties, extraPayload)
 
+    // if there's an error on the decideREsponse, log a console error, but don't throw an error
+    if (decideResponse?.errorsWhileComputingFlags) {
+      console.error(
+        '[FEATURE FLAGS] Error while computing feature flags, some flags may be missing or incorrect. Learn more at https://posthog.com/docs/feature-flags/best-practices'
+      )
+    }
+
     // Add check for quota limitation on feature flags
     if (decideResponse?.quotaLimited?.includes(QuotaLimitedFeature.FeatureFlags)) {
       console.warn(

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,20 +1,24 @@
 # Next
 
-1. Fix: prevent fetch floods when rate-limited.
+# 4.10.2 - 2025-03-06
 
-# 4.10.1 – 2025-03-06
+1. Add: log error message when feature flags have computation errors.
+
+# 4.10.1 – 2025-03-06
 
 1. Fix: only set `platform` on PostHog exception frame properties
+1. Fix: prevent fetch floods when rate-limited.
 
-# 4.10.0 – 2025-03-06
+
+# 4.10.0 – 2025-03-06
 
 1. Attach requestId to $feature_flag_called if present in /decide response
 
-# 4.9.0 – 2025-03-04
+# 4.9.0 – 2025-03-04
 
 1. Allow feature flags to be evaluated individually when local evaluation is not being used
 
-# 4.8.1 – 2025-02-26
+# 4.8.1 – 2025-02-26
 
 1. Supports gracefully handling quotaLimited responses from the PostHog API for feature flag evaluation
 

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -1319,5 +1319,25 @@ describe('PostHog Node.js', () => {
         })
       )
     })
+
+    it('should log error when decide response has errors', async () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      mockedFetch.mockImplementation(
+        apiImplementation({
+          decideFlags: { 'feature-1': true },
+          decideFlagPayloads: {},
+          errorsWhileComputingFlags: true,
+        })
+      )
+
+      await posthog.getFeatureFlag('feature-1', '123')
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[FEATURE FLAGS] Error while computing feature flags, some flags may be missing or incorrect. Learn more at https://posthog.com/docs/feature-flags/best-practices'
+      )
+
+      errorSpy.mockRestore()
+    })
   })
 })

--- a/posthog-node/test/test-utils.ts
+++ b/posthog-node/test/test-utils.ts
@@ -4,12 +4,14 @@ export const apiImplementation = ({
   decideFlagPayloads,
   decideStatus = 200,
   localFlagsStatus = 200,
+  errorsWhileComputingFlags = false,
 }: {
   localFlags?: any
   decideFlags?: any
   decideFlagPayloads?: any
   decideStatus?: number
   localFlagsStatus?: number
+  errorsWhileComputingFlags?: boolean
 }) => {
   return (url: any): Promise<any> => {
     if ((url as any).includes('/decide/')) {
@@ -25,6 +27,7 @@ export const apiImplementation = ({
               featureFlagPayloads: Object.fromEntries(
                 Object.entries(decideFlagPayloads || {}).map(([k, v]) => [k, JSON.stringify(v)])
               ),
+              errorsWhileComputingFlags,
             })
           }
         },


### PR DESCRIPTION
## Problem

Customer asked for this, seems reasonable to do it: https://posthog.slack.com/archives/C0386ASS3TN/p1742599095502899?thread_ts=1740762972.509389&cid=C0386ASS3TN

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

