### PR TITLE
Use 'node' for tsconfig module resolution

### DIFF
--- a/posthog-react-native/tsconfig.json
+++ b/posthog-react-native/tsconfig.json
@@ -6,7 +6,7 @@
     "jsx": "react-native",
     "lib": ["ESNext"],
     "module": "ESNext",
-    "moduleResolution": "node16",
+    "moduleResolution": "node",
     "noEmitOnError": true,
     "outDir": "./lib",
     "skipLibCheck": true,


### PR DESCRIPTION
## Problem

TypeScript linter complains about imports in React Native projects because they are extensionless. That's because the current moduleResolution is `node16`.

React Native's Metro bundler does not fully support Node.js's ESM resolution rules used in "node16". The "node" setting is more compatible with the way Metro resolves modules, avoids issues with missing file extensions, and aligns with community standards in React Native tooling (e.g., [React Native CLI tsconfig](https://github.com/react-native-community/cli/blob/main/tsconfig.json#L20)).

## Changes

Changed `moduleResolution` to `node` in tsconfig.json.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

This only affects development, so no need to cut a new NPM release.

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [x] posthog-react-native

### Changelog notes

No notes.