### PR TITLE
fix(flags): Return undefined when a feature flag does not exist

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.11.1 - 2025-03-28
+
+## Fixed
+
+1. `getFeatureFlag`, `isFeatureEnabled`, and `getAllFlagsAndPayloads` now return `undefined` if the flag is not found.
+
 # 4.11.0 - 2025-03-28
 
 ## Added

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -279,7 +279,7 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
       }
 
       flagDetail = remoteResponse.response
-      response = getFeatureFlagValue(flagDetail) ?? false
+      response = getFeatureFlagValue(flagDetail)
       requestId = remoteResponse?.requestId
     }
 

--- a/posthog-node/test/feature-flags.decide.spec.ts
+++ b/posthog-node/test/feature-flags.decide.spec.ts
@@ -15,7 +15,7 @@ const posthogImmediateResolveOptions: PostHogOptions = {
 
 describe('decide v4', () => {
   describe('getFeatureFlag v4', () => {
-    it('returns false if the flag is not found', async () => {
+    it('returns undefined if the flag is not found', async () => {
       const decideResponse: PostHogV4DecideResponse = {
         flags: {},
         errorsWhileComputingFlags: false,
@@ -34,7 +34,7 @@ describe('decide v4', () => {
 
       const result = await posthog.getFeatureFlag('non-existent-flag', 'some-distinct-id')
 
-      expect(result).toBe(false)
+      expect(result).toBe(undefined)
       expect(mockedFetch).toHaveBeenCalledWith('http://example.com/decide/?v=4', expect.any(Object))
 
       await waitForPromises()
@@ -44,9 +44,9 @@ describe('decide v4', () => {
         library: posthog.getLibraryId(),
         library_version: posthog.getLibraryVersion(),
         properties: {
-          '$feature/non-existent-flag': false,
+          '$feature/non-existent-flag': undefined,
           $feature_flag: 'non-existent-flag',
-          $feature_flag_response: false,
+          $feature_flag_response: undefined,
           $feature_flag_request_id: '0152a345-295f-4fba-adac-2e6ea9c91082',
           $groups: undefined,
           $lib: posthog.getLibraryId(),
@@ -220,97 +220,97 @@ describe('decide v4', () => {
     })
   })
 
-    describe('error handling', () => {
-      let posthog: PostHog
-      describe.each([
-        { 
-          case: 'JSON error response',
-          mock: apiImplementationV4({
-            status: 400,
-            json: () => Promise.resolve({ error: 'error response' })
-          })
-        },
-        { 
-          case: 'undefined response',
-          mock: apiImplementationV4({
-            status: 400,
-            json: () => Promise.resolve(undefined)
-          })
-        },
-        { 
-          case: 'null response',
-          mock: apiImplementationV4({
-            status: 400,
-            json: () => Promise.resolve(null)
-          })
-        },
-        { 
-          case: 'empty response',
-          mock: apiImplementationV4({
-            status: 400,
-            json: () => Promise.resolve({})
-          })
-        },
-        { 
-          case: 'network error',
-          mock: () => Promise.reject(new Error('Network error'))
-        },
-        { 
-          case: 'invalid JSON',
-          mock: apiImplementationV4({
-            status: 500,
-            json: () => Promise.reject(new Error('Invalid JSON'))
-          })
-        }
-      ])('when $case', ({ mock }) => {
-        beforeEach(() => {
-          posthog = new PostHog('TEST_API_KEY', {
-            host: 'http://example.com',
-            ...posthogImmediateResolveOptions,
-          })
-          mockedFetch.mockImplementation(mock)
+  describe('error handling', () => {
+    let posthog: PostHog
+    describe.each([
+      {
+        case: 'JSON error response',
+        mock: apiImplementationV4({
+          status: 400,
+          json: () => Promise.resolve({ error: 'error response' }),
+        }),
+      },
+      {
+        case: 'undefined response',
+        mock: apiImplementationV4({
+          status: 400,
+          json: () => Promise.resolve(undefined),
+        }),
+      },
+      {
+        case: 'null response',
+        mock: apiImplementationV4({
+          status: 400,
+          json: () => Promise.resolve(null),
+        }),
+      },
+      {
+        case: 'empty response',
+        mock: apiImplementationV4({
+          status: 400,
+          json: () => Promise.resolve({}),
+        }),
+      },
+      {
+        case: 'network error',
+        mock: () => Promise.reject(new Error('Network error')),
+      },
+      {
+        case: 'invalid JSON',
+        mock: apiImplementationV4({
+          status: 500,
+          json: () => Promise.reject(new Error('Invalid JSON')),
+        }),
+      },
+    ])('when $case', ({ mock }) => {
+      beforeEach(() => {
+        posthog = new PostHog('TEST_API_KEY', {
+          host: 'http://example.com',
+          ...posthogImmediateResolveOptions,
         })
+        mockedFetch.mockImplementation(mock)
+      })
 
-        it('getFeatureFlag returns undefined', async () => {
-          expect(await posthog.getFeatureFlag('error-flag', 'some-distinct-id')).toBe(undefined)
-        })
+      it('getFeatureFlag returns undefined', async () => {
+        expect(await posthog.getFeatureFlag('error-flag', 'some-distinct-id')).toBe(undefined)
+      })
 
-        it('isFeatureEnabled returns undefined', async () => {
-          expect(await posthog.isFeatureEnabled('error-flag', 'some-distinct-id')).toBe(undefined)
-        })
+      it('isFeatureEnabled returns undefined', async () => {
+        expect(await posthog.isFeatureEnabled('error-flag', 'some-distinct-id')).toBe(undefined)
+      })
 
-        it('getFeatureFlagPayload returns undefined', async () => {
-          expect(await posthog.getFeatureFlagPayload('error-flag', 'some-distinct-id')).toBe(undefined)
-        })
+      it('getFeatureFlagPayload returns undefined', async () => {
+        expect(await posthog.getFeatureFlagPayload('error-flag', 'some-distinct-id')).toBe(undefined)
+      })
 
-        it('getAllFlags returns empty object', async () => {
-          expect(await posthog.getAllFlags('some-distinct-id')).toEqual({})
-        })
+      it('getAllFlags returns empty object', async () => {
+        expect(await posthog.getAllFlags('some-distinct-id')).toEqual({})
+      })
 
-        it('getAllFlagsAndPayloads returns object with empty flags and payloads', async () => {
-          expect(await posthog.getAllFlagsAndPayloads('some-distinct-id')).toEqual({
-            featureFlags: {},
-            featureFlagPayloads: {},
-          })
-        })
-
-        it('captures no events', async () => {
-          let capturedMessage: any
-          posthog.on('capture', (message) => {
-            capturedMessage = message
-          })
-
-          await posthog.getFeatureFlag('error-flag', 'some-distinct-id')
-          await waitForPromises()
-          expect(capturedMessage).toBeUndefined()
+      it('getAllFlagsAndPayloads returns object with empty flags and payloads', async () => {
+        expect(await posthog.getAllFlagsAndPayloads('some-distinct-id')).toEqual({
+          featureFlags: {},
+          featureFlagPayloads: {},
         })
       })
+
+      it('captures no events', async () => {
+        let capturedMessage: any
+        posthog.on('capture', (message) => {
+          capturedMessage = message
+        })
+
+        await posthog.getFeatureFlag('error-flag', 'some-distinct-id')
+        await waitForPromises()
+        expect(capturedMessage).toBeUndefined()
+      })
     })
+  })
 })
 
 describe('decide v3', () => {
   describe('getFeatureFlag v3', () => {
-    it('returns false if the flag is not found', async () => {
+    it('returns undefined if the flag is not found', async () => {
       mockedFetch.mockImplementation(apiImplementation({ decideFlags: {} }))
 
       const posthog = new PostHog('TEST_API_KEY', {
@@ -324,7 +324,7 @@ describe('decide v3', () => {
 
       const result = await posthog.getFeatureFlag('non-existent-flag', 'some-distinct-id')
 
-      expect(result).toBe(false)
+      expect(result).toBe(undefined)
       expect(mockedFetch).toHaveBeenCalledWith('http://example.com/decide/?v=4', expect.any(Object))
 
       await waitForPromises()
@@ -334,9 +334,9 @@ describe('decide v3', () => {
         library: posthog.getLibraryId(),
         library_version: posthog.getLibraryVersion(),
         properties: {
-          '$feature/non-existent-flag': false,
+          '$feature/non-existent-flag': undefined,
           $feature_flag: 'non-existent-flag',
-          $feature_flag_response: false,
+          $feature_flag_response: undefined,
           $groups: undefined,
           $lib: posthog.getLibraryId(),
           $lib_version: posthog.getLibraryVersion(),

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -576,48 +576,6 @@ describe('local evaluation', () => {
     expect(mockedFetch).toHaveBeenCalledWith(...anyDecideCall)
   })
 
-  it('returns undefined when decide errors out', async () => {
-    const flags = {
-      flags: [
-        {
-          id: 1,
-          name: 'Beta Feature',
-          key: 'beta-feature',
-          active: true,
-          filters: {
-            groups: [
-              {
-                properties: [],
-                rollout_percentage: 0,
-              },
-            ],
-          },
-        },
-      ],
-    }
-    mockedFetch.mockImplementation(
-      apiImplementation({ localFlags: flags, decideFlags: { error: 'went wrong' }, decideStatus: 400 })
-    )
-
-    posthog = new PostHog('TEST_API_KEY', {
-      host: 'http://example.com',
-      personalApiKey: 'TEST_PERSONAL_API_KEY',
-      ...posthogImmediateResolveOptions,
-    })
-
-    let err: any = null
-    posthog.on('error', (e) => {
-      err = e
-    })
-
-    // # beta-feature2 falls back to decide, which on error returns undefined
-    expect(await posthog.getFeatureFlag('beta-feature2', 'some-distinct-id')).toEqual(undefined)
-    expect(await posthog.isFeatureEnabled('beta-feature2', 'some-distinct-id')).toEqual(undefined)
-    expect(mockedFetch).toHaveBeenCalledWith(...anyDecideCall)
-    await posthog.shutdown()
-    expect(err).toHaveProperty('name', 'PostHogFetchHttpError')
-  })
-
   it('experience continuity flags are not evaluated locally', async () => {
     const flags = {
       flags: [

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -571,8 +571,8 @@ describe('local evaluation', () => {
     expect(mockedFetch).not.toHaveBeenCalledWith(...anyDecideCall)
 
     // # beta-feature2 falls back to decide, and whatever decide returns is the value
-    expect(await posthog.getFeatureFlag('beta-feature2', 'some-distinct-id')).toEqual(false)
-    expect(await posthog.isFeatureEnabled('beta-feature2', 'some-distinct-id')).toEqual(false)
+    expect(await posthog.getFeatureFlag('beta-feature2', 'some-distinct-id')).toEqual(undefined)
+    expect(await posthog.isFeatureEnabled('beta-feature2', 'some-distinct-id')).toEqual(undefined)
     expect(mockedFetch).toHaveBeenCalledWith(...anyDecideCall)
   })
 
@@ -1320,7 +1320,7 @@ describe('local evaluation', () => {
       await posthog.getFeatureFlag('beta-feature', 'some-distinct-id', {
         personProperties: { region: 'USA', other: 'thing' },
       })
-    ).toEqual(false)
+    ).toEqual(undefined)
     expect(mockedFetch).toHaveBeenCalledWith(...anyDecideCall)
 
     mockedFetch.mockClear()

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -622,7 +622,7 @@ describe('PostHog Node.js', () => {
     it('should do isFeatureEnabled', async () => {
       expect(mockedFetch).toHaveBeenCalledTimes(0)
       await expect(posthog.isFeatureEnabled('feature-1', '123', { groups: { org: '123' } })).resolves.toEqual(true)
-      await expect(posthog.isFeatureEnabled('feature-4', '123', { groups: { org: '123' } })).resolves.toEqual(false)
+      await expect(posthog.isFeatureEnabled('feature-4', '123', { groups: { org: '123' } })).resolves.toEqual(undefined)
       expect(mockedFetch).toHaveBeenCalledTimes(2)
     })
 

--- a/posthog-node/test/test-utils.ts
+++ b/posthog-node/test/test-utils.ts
@@ -1,7 +1,7 @@
 import { PostHogV4DecideResponse } from 'posthog-core/src/types'
 
 type ErrorResponse = {
-  status: number,
+  status: number
   json: () => Promise<any>
 }
 

--- a/posthog-node/test/test-utils.ts
+++ b/posthog-node/test/test-utils.ts
@@ -1,13 +1,25 @@
 import { PostHogV4DecideResponse } from 'posthog-core/src/types'
 
-export const apiImplementationV4 = (decideResponse?: PostHogV4DecideResponse) => {
+type ErrorResponse = {
+  status: number,
+  json: () => Promise<any>
+}
+
+export const apiImplementationV4 = (decideResponse: PostHogV4DecideResponse | ErrorResponse) => {
   return (url: any): Promise<any> => {
     if ((url as any).includes('/decide/?v=4')) {
-      return Promise.resolve({
-        status: 200,
-        text: () => Promise.resolve('ok'),
-        json: () => Promise.resolve(decideResponse),
-      }) as any
+      // Check if the response is a decide response or an error response
+      return 'flags' in decideResponse
+        ? Promise.resolve({
+            status: 200,
+            text: () => Promise.resolve('ok'),
+            json: () => Promise.resolve(decideResponse),
+          })
+        : Promise.resolve({
+            status: decideResponse.status,
+            text: () => Promise.resolve('not-ok'),
+            json: decideResponse.json,
+          })
     }
 
     return Promise.resolve({


### PR DESCRIPTION
A feature flag might not exist in a `/decide` response for three reasons.

1. It never existed.
2. It was deleted.
3. It had an error during evaluation

## Problem

In the third case, returning `true` when there was an error was confusing. In all cases, the value of the flag is indeterminate so it makes sense to return `undefined`.

## Changes

No longer coerces `undefined` flag value to `false`.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [x] posthog-react-native

### Changelog notes

- `getFeatureFlag` and `isFeatureEnabled` now return `undefined` when the flag is not in the response.
