### PR TITLE
chore(deps):bump axios to 1.8.2

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.11.2 - 2025-04-07
+
+1. chore: bump axios to 1.8.2 (fixes [CVE-2025-27152](https://github.com/advisories/GHSA-jr5f-v2jv-69x6))
+
+
 # 4.11.1 - 2025-03-28
 
 ## Fixed

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.11.1",
+  "version": "4.11.2",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",
@@ -23,7 +23,7 @@
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",
   "dependencies": {
-    "axios": "^1.7.4"
+    "axios": "^1.8.2"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3286,10 +3286,10 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.7.4:
-  version "1.7.7"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
-  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
+axios@^1.8.2:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
+  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
## Problem

Closes #425 

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- bump axios to 1.8.2
