### PR TITLE
feat: add autocapture pageviews with history api

### DIFF
--- a/posthog-core/src/patch.ts
+++ b/posthog-core/src/patch.ts
@@ -1,0 +1,46 @@
+// import { patch } from 'rrweb/typings/utils'
+// copied from: https://github.com/PostHog/posthog-js/blob/main/src/extensions/replay/rrweb-plugins/patch.ts
+// which was copied from https://github.com/rrweb-io/rrweb/blob/8aea5b00a4dfe5a6f59bd2ae72bb624f45e51e81/packages/rrweb/src/utils.ts#L129
+// which was copied from https://github.com/getsentry/sentry-javascript/blob/b2109071975af8bf0316d3b5b38f519bdaf5dc15/packages/utils/src/object.ts
+import { isFunction } from './utils'
+
+export function patch(
+  source: { [key: string]: any },
+  name: string,
+  replacement: (...args: unknown[]) => unknown
+): () => void {
+  try {
+    if (!(name in source)) {
+      return () => {
+        //
+      }
+    }
+
+    const original = source[name] as () => unknown
+    const wrapped = replacement(original)
+
+    // Make sure it's a function first, as we need to attach an empty prototype for `defineProperties` to work
+    // otherwise it'll throw "TypeError: Object.defineProperties called on non-object"
+    if (isFunction(wrapped)) {
+      wrapped.prototype = wrapped.prototype || {}
+      Object.defineProperties(wrapped, {
+        __posthog_wrapped__: {
+          enumerable: false,
+          value: true,
+        },
+      })
+    }
+
+    source[name] = wrapped
+
+    return () => {
+      source[name] = original
+    }
+  } catch {
+    return () => {
+      //
+    }
+    // This can throw if multiple fill happens on a global object like XMLHttpRequest
+    // Fixes https://github.com/getsentry/sentry-javascript/issues/2043
+  }
+}

--- a/posthog-core/src/utils.ts
+++ b/posthog-core/src/utils.ts
@@ -75,3 +75,8 @@ export const isError = (x: unknown): x is Error => {
 export function getFetch(): FetchLike | undefined {
   return typeof fetch !== 'undefined' ? fetch : typeof global.fetch !== 'undefined' ? global.fetch : undefined
 }
+
+// copied from: https://github.com/PostHog/posthog-js/blob/main/react/src/utils/type-utils.ts#L4
+export const isFunction = function (f: any): f is (...args: any[]) => any {
+  return typeof f === 'function'
+}

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+## Added
+
+1. Added `trackHistoryEvents` option to automatically capture navigation events in single-page applications using the History API.
+
 ## Fixed
 
 1. apiKey cannot be empty.

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Added
 
-1. Added `trackHistoryEvents` option to automatically capture navigation events in single-page applications using the History API.
+1. Added `captureHistoryEvents` option to automatically capture navigation events in single-page applications using the History API.
 
 ## Fixed
 

--- a/posthog-web/README.md
+++ b/posthog-web/README.md
@@ -22,7 +22,6 @@ import PostHog from 'posthog-js-lite'
 const posthog = new PostHog('my-api-key', {
   /* options, e.g. for self-hosted users */
   // host: "https://my-posthog.app.com"
-  // trackHistoryEvents: true // Enable tracking of History API navigation events as pageviews
 })
 
 // Capture generic events
@@ -78,11 +77,11 @@ posthog.optIn() // Will start tracking
 
 Single-page applications (SPAs) typically use the History API (`pushState`, `replaceState`) for navigation instead of full page loads. By default, PostHog only tracks the initial page load.
 
-To automatically track navigation events in SPAs, enable the `trackHistoryEvents` option:
+To automatically track navigation events in SPAs, enable the `captureHistoryEvents` option:
 
 ```ts
 const posthog = new PostHog('my-api-key', {
-  trackHistoryEvents: true
+  captureHistoryEvents: true
 })
 ```
 

--- a/posthog-web/README.md
+++ b/posthog-web/README.md
@@ -22,6 +22,7 @@ import PostHog from 'posthog-js-lite'
 const posthog = new PostHog('my-api-key', {
   /* options, e.g. for self-hosted users */
   // host: "https://my-posthog.app.com"
+  // trackHistoryEvents: true // Enable tracking of History API navigation events as pageviews
 })
 
 // Capture generic events
@@ -72,4 +73,23 @@ posthog.onFeatureFlag('my-feature-flag', (value) => {
 // Opt users in or out, persisting across sessions (default is they are opted in)
 posthog.optOut() // Will stop tracking
 posthog.optIn() // Will start tracking
+
+## History API Navigation Tracking
+
+Single-page applications (SPAs) typically use the History API (`pushState`, `replaceState`) for navigation instead of full page loads. By default, PostHog only tracks the initial page load.
+
+To automatically track navigation events in SPAs, enable the `trackHistoryEvents` option:
+
+```ts
+const posthog = new PostHog('my-api-key', {
+  trackHistoryEvents: true
+})
 ```
+
+When enabled, PostHog will:
+- Track calls to `history.pushState()` and `history.replaceState()`
+- Track `popstate` events (browser back/forward navigation)
+- Send these as `$pageview` events with the current URL and pathname
+- Include the navigation type (`pushState`, `replaceState`, or `popstate`) as a property
+
+This ensures accurate page tracking in modern web applications without requiring manual pageview capture calls.

--- a/posthog-web/src/posthog-web.ts
+++ b/posthog-web/src/posthog-web.ts
@@ -28,7 +28,7 @@ export class PostHog extends PostHogCore {
       this.reloadFeatureFlags()
     }
 
-    if (options?.trackHistoryEvents && typeof window !== 'undefined') {
+    if (options?.captureHistoryEvents && typeof window !== 'undefined') {
       this.setupHistoryEventTracking()
     }
   }

--- a/posthog-web/src/posthog-web.ts
+++ b/posthog-web/src/posthog-web.ts
@@ -103,15 +103,15 @@ export class PostHog extends PostHogCore {
 
     // Use patch with proper History method types
     patch(window.history, 'pushState', (originalPushState) => {
-      return function patchedPushState(history: History, state: any, title: string, url?: string | URL | null): void {
-        (originalPushState as History['pushState']).call(history, state, title, url)
+      return function patchedPushState(this: History, state: any, title: string, url?: string | URL | null): void {
+        (originalPushState as History['pushState']).call(this, state, title, url)
         self.captureNavigationEvent('pushState')
       }
     })
 
     patch(window.history, 'replaceState', (originalReplaceState) => {
-      return function patchedReplaceState(history: History, state: any, title: string, url?: string | URL | null): void {
-        (originalReplaceState as History['replaceState']).call(history, state, title, url)
+      return function patchedReplaceState(this: History, state: any, title: string, url?: string | URL | null): void {
+        (originalReplaceState as History['replaceState']).call(this, state, title, url)
         self.captureNavigationEvent('replaceState')
       }
     })

--- a/posthog-web/src/posthog-web.ts
+++ b/posthog-web/src/posthog-web.ts
@@ -90,28 +90,26 @@ export class PostHog extends PostHogCore {
     }
   }
 
-  // Setup tracking for the three SPA navigation types: pushState, replaceState, and popstate
   private setupHistoryEventTracking(): void {
     const window = this.getWindow()
     if (!window) {
       return
     }
 
-    // Old fashioned, we could also use arrow functions but I think relying on the closure for a patch is more reliable
+    // Old fashioned, we could also use arrow functions but I think the closure for a patch is more reliable
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this
 
-    // Use patch with proper History method types
     patch(window.history, 'pushState', (originalPushState) => {
       return function patchedPushState(this: History, state: any, title: string, url?: string | URL | null): void {
-        (originalPushState as History['pushState']).call(this, state, title, url)
+        ;(originalPushState as History['pushState']).call(this, state, title, url)
         self.captureNavigationEvent('pushState')
       }
     })
 
     patch(window.history, 'replaceState', (originalReplaceState) => {
       return function patchedReplaceState(this: History, state: any, title: string, url?: string | URL | null): void {
-        (originalReplaceState as History['replaceState']).call(this, state, title, url)
+        ;(originalReplaceState as History['replaceState']).call(this, state, title, url)
         self.captureNavigationEvent('replaceState')
       }
     })
@@ -122,8 +120,6 @@ export class PostHog extends PostHogCore {
     })
   }
 
-  // Capture navigation as pageview with only navigation_type
-  // URL and pathname come from getCommonEventProperties()
   private captureNavigationEvent(navigationType: 'pushState' | 'replaceState' | 'popstate'): void {
     const window = this.getWindow()
     if (!window) {

--- a/posthog-web/src/posthog-web.ts
+++ b/posthog-web/src/posthog-web.ts
@@ -103,15 +103,15 @@ export class PostHog extends PostHogCore {
 
     // Use patch with proper History method types
     patch(window.history, 'pushState', (originalPushState) => {
-      return function patchedPushState(this: History, state: any, title: string, url?: string | URL | null): void {
-        ;(originalPushState as History['pushState']).call(this, state, title, url)
+      return function patchedPushState(history: History, state: any, title: string, url?: string | URL | null): void {
+        (originalPushState as History['pushState']).call(history, state, title, url)
         self.captureNavigationEvent('pushState')
       }
     })
 
     patch(window.history, 'replaceState', (originalReplaceState) => {
-      return function patchedReplaceState(this: History, state: any, title: string, url?: string | URL | null): void {
-        ;(originalReplaceState as History['replaceState']).call(this, state, title, url)
+      return function patchedReplaceState(history: History, state: any, title: string, url?: string | URL | null): void {
+        (originalReplaceState as History['replaceState']).call(history, state, title, url)
         self.captureNavigationEvent('replaceState')
       }
     })

--- a/posthog-web/src/posthog-web.ts
+++ b/posthog-web/src/posthog-web.ts
@@ -15,6 +15,7 @@ export class PostHog extends PostHogCore {
   private _storage: PostHogStorage
   private _storageCache: any
   private _storageKey: string
+  private _lastPathname: string = ''
 
   constructor(apiKey: string, options?: PostHogOptions) {
     super(apiKey, options)
@@ -30,6 +31,7 @@ export class PostHog extends PostHogCore {
     }
 
     if (options?.captureHistoryEvents && typeof window !== 'undefined') {
+      this._lastPathname = window?.location?.pathname || ''
       this.setupHistoryEventTracking()
     }
   }
@@ -126,6 +128,12 @@ export class PostHog extends PostHogCore {
       return
     }
 
-    this.capture('$pageview', { navigation_type: navigationType })
+    const currentPathname = window.location.pathname
+
+    // Only capture pageview if the pathname has changed
+    if (currentPathname !== this._lastPathname) {
+      this.capture('$pageview', { navigation_type: navigationType })
+      this._lastPathname = currentPathname
+    }
   }
 }

--- a/posthog-web/src/types.ts
+++ b/posthog-web/src/types.ts
@@ -4,4 +4,5 @@ export type PostHogOptions = {
   autocapture?: boolean
   persistence?: 'localStorage' | 'sessionStorage' | 'cookie' | 'memory'
   persistence_name?: string
+  trackHistoryEvents?: boolean
 } & PostHogCoreOptions

--- a/posthog-web/src/types.ts
+++ b/posthog-web/src/types.ts
@@ -4,5 +4,5 @@ export type PostHogOptions = {
   autocapture?: boolean
   persistence?: 'localStorage' | 'sessionStorage' | 'cookie' | 'memory'
   persistence_name?: string
-  trackHistoryEvents?: boolean
+  captureHistoryEvents?: boolean
 } & PostHogCoreOptions

--- a/posthog-web/test/posthog-web.spec.ts
+++ b/posthog-web/test/posthog-web.spec.ts
@@ -110,20 +110,20 @@ describe('PostHogWeb', () => {
       window.removeEventListener('popstate', popstateHandler)
     })
 
-    it('should not patch history methods when trackHistoryEvents is disabled', () => {
+    it('should not patch history methods when captureHistoryEvents is disabled', () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const posthog = new PostHog('TEST_API_KEY', {
-        trackHistoryEvents: false,
+        captureHistoryEvents: false,
       })
 
       expect(window.history.pushState).toBe(originalPushState)
       expect(window.history.replaceState).toBe(originalReplaceState)
     })
 
-    it('should patch history methods when trackHistoryEvents is enabled', () => {
+    it('should patch history methods when captureHistoryEvents is enabled', () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const posthog = new PostHog('TEST_API_KEY', {
-        trackHistoryEvents: true,
+        captureHistoryEvents: true,
       })
 
       expect(window.history.pushState).not.toBe(originalPushState)
@@ -132,7 +132,7 @@ describe('PostHogWeb', () => {
 
     it('should capture pageview events on pushState', async () => {
       const posthog = new PostHog('TEST_API_KEY', {
-        trackHistoryEvents: true,
+        captureHistoryEvents: true,
         flushAt: 1,
       })
 
@@ -150,7 +150,7 @@ describe('PostHogWeb', () => {
 
     it('should capture pageview events on replaceState', async () => {
       const posthog = new PostHog('TEST_API_KEY', {
-        trackHistoryEvents: true,
+        captureHistoryEvents: true,
         flushAt: 1,
       })
 
@@ -168,7 +168,7 @@ describe('PostHogWeb', () => {
 
     it('should capture pageview events on popstate', async () => {
       const posthog = new PostHog('TEST_API_KEY', {
-        trackHistoryEvents: true,
+        captureHistoryEvents: true,
         flushAt: 1,
       })
 
@@ -186,7 +186,7 @@ describe('PostHogWeb', () => {
 
     it('should include navigation properties in capture call and rely on getCommonEventProperties', async () => {
       const posthog = new PostHog('TEST_API_KEY', {
-        trackHistoryEvents: true,
+        captureHistoryEvents: true,
         flushAt: 1,
       })
 

--- a/posthog-web/test/posthog-web.spec.ts
+++ b/posthog-web/test/posthog-web.spec.ts
@@ -95,4 +95,124 @@ describe('PostHogWeb', () => {
       })
     })
   })
+
+  describe('History API tracking', () => {
+    const originalPushState = window.history.pushState
+    const originalReplaceState = window.history.replaceState
+
+    // Reset history methods after each test
+    afterEach(() => {
+      window.history.pushState = originalPushState
+      window.history.replaceState = originalReplaceState
+
+      window.removeEventListener('popstate', () => {})
+    })
+
+    it('should not patch history methods when trackHistoryEvents is disabled', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const posthog = new PostHog('TEST_API_KEY', {
+        trackHistoryEvents: false,
+      })
+
+      expect(window.history.pushState).toBe(originalPushState)
+      expect(window.history.replaceState).toBe(originalReplaceState)
+    })
+
+    it('should patch history methods when trackHistoryEvents is enabled', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const posthog = new PostHog('TEST_API_KEY', {
+        trackHistoryEvents: true,
+      })
+
+      expect(window.history.pushState).not.toBe(originalPushState)
+      expect(window.history.replaceState).not.toBe(originalReplaceState)
+    })
+
+    it('should capture pageview events on pushState', async () => {
+      const posthog = new PostHog('TEST_API_KEY', {
+        trackHistoryEvents: true,
+        flushAt: 1,
+      })
+
+      const captureSpy = jest.spyOn(posthog, 'capture')
+
+      window.history.pushState({}, '', '/test-page')
+
+      expect(captureSpy).toHaveBeenCalledWith(
+        '$pageview',
+        expect.objectContaining({
+          navigation_type: 'pushState',
+        })
+      )
+    })
+
+    it('should capture pageview events on replaceState', async () => {
+      const posthog = new PostHog('TEST_API_KEY', {
+        trackHistoryEvents: true,
+        flushAt: 1,
+      })
+
+      const captureSpy = jest.spyOn(posthog, 'capture')
+
+      window.history.replaceState({}, '', '/replaced-page')
+
+      expect(captureSpy).toHaveBeenCalledWith(
+        '$pageview',
+        expect.objectContaining({
+          navigation_type: 'replaceState',
+        })
+      )
+    })
+
+    it('should capture pageview events on popstate', async () => {
+      const posthog = new PostHog('TEST_API_KEY', {
+        trackHistoryEvents: true,
+        flushAt: 1,
+      })
+
+      const captureSpy = jest.spyOn(posthog, 'capture')
+
+      window.dispatchEvent(new Event('popstate'))
+
+      expect(captureSpy).toHaveBeenCalledWith(
+        '$pageview',
+        expect.objectContaining({
+          navigation_type: 'popstate',
+        })
+      )
+    })
+
+    it('should include navigation properties in capture call and rely on getCommonEventProperties', async () => {
+      const posthog = new PostHog('TEST_API_KEY', {
+        trackHistoryEvents: true,
+        flushAt: 1,
+      })
+
+      const commonEventProps = { $lib: 'posthog-js-lite', $lib_version: '1.0.0' }
+      const getCommonEventPropertiesSpy = jest
+        .spyOn(posthog, 'getCommonEventProperties')
+        .mockImplementation(() => commonEventProps)
+
+      const coreCaptureMethod = jest.spyOn(PostHog.prototype, 'capture')
+
+      window.history.pushState({}, '', '/captured-page')
+
+      // Will use a mock here for now and rely on the implementation since the tests setup is very simple at the moment
+      expect(getCommonEventPropertiesSpy).toHaveBeenCalled()
+
+      const captureCall = coreCaptureMethod.mock.calls.find(
+        (call) => call[0] === '$pageview' && call[1] && call[1].navigation_type === 'pushState'
+      )
+
+      expect(captureCall).toBeDefined()
+
+      const navigationProperties = {
+        navigation_type: 'pushState',
+      }
+
+      if (captureCall) {
+        expect(captureCall[1]).toMatchObject(navigationProperties)
+      }
+    })
+  })
 })

--- a/posthog-web/test/posthog-web.spec.ts
+++ b/posthog-web/test/posthog-web.spec.ts
@@ -105,7 +105,9 @@ describe('PostHogWeb', () => {
       window.history.pushState = originalPushState
       window.history.replaceState = originalReplaceState
 
-      window.removeEventListener('popstate', () => {})
+      const popstateHandler = () => {}
+      window.addEventListener('popstate', popstateHandler)
+      window.removeEventListener('popstate', popstateHandler)
     })
 
     it('should not patch history methods when trackHistoryEvents is disabled', () => {

--- a/posthog-web/test/posthog-web.spec.ts
+++ b/posthog-web/test/posthog-web.spec.ts
@@ -105,7 +105,7 @@ describe('PostHogWeb', () => {
       window.history.pushState = originalPushState
       window.history.replaceState = originalReplaceState
 
-      const popstateHandler = () => {}
+      const popstateHandler = (): void => {}
       window.addEventListener('popstate', popstateHandler)
       window.removeEventListener('popstate', popstateHandler)
     })


### PR DESCRIPTION
## Problem

This Bluesky thread gave us the idea: https://bsky.app/profile/danabra.mov/post/3lmflnn62ys2y to have a tiny sdk option for simple navigation event capture.

This internal Slack thread also has some comments, it is my first SDK PR: https://posthog.slack.com/archives/C03P7NL6RMW/p1744225093576939

I've bundled a simple repo to test this out: https://lricoy.github.io/test-posthog-history/

## Changes

Added an option to attach listeners to the browser's history api and autocapture pageviews.


## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

- Added `trackHistoryEvents` option to automatically capture navigation events in single-page applications using the History API.
