### PR TITLE
feat: Add method to wait for feature flag definitions for local evaluation to be loaded.

### DIFF
--- a/examples/example-node/server.ts
+++ b/examples/example-node/server.ts
@@ -23,6 +23,12 @@ const posthog = new PostHog(PH_API_KEY, {
   },
 })
 
+console.log('LOCAL EVALUATION READY RIGHT AFTER CREATION: ', posthog.isLocalEvaluationReady())
+
+posthog.on('localEvaluationFlagsLoaded', (count) => {
+  console.log('LOCAL EVALUATION READY (localEvaluationFlagsLoaded) EVENT EMITTED: flags count: ', count)
+})
+
 posthog.debug()
 
 Sentry.init({
@@ -53,6 +59,12 @@ app.get('/error', (req, res) => {
   })
   posthog.captureException(error, 'EXAMPLE_APP_GLOBAL')
   res.send({ status: 'error!!' })
+})
+
+app.get('/wait-for-local-evaluation-ready', async (req, res) => {
+  const FIVE_SECONDS = 5000
+  const ready = await posthog.waitForLocalEvaluationReady(FIVE_SECONDS)
+  res.send({ ready })
 })
 
 app.get('/user/:userId/action', (req, res) => {

--- a/posthog-node/src/feature-flags.ts
+++ b/posthog-node/src/feature-flags.ts
@@ -39,6 +39,7 @@ type FeatureFlagsPollerOptions = {
   timeout?: number
   fetch?: (url: string, options: PostHogFetchOptions) => Promise<PostHogFetchResponse>
   onError?: (error: Error) => void
+  onLoad?: (count: number) => void
   customHeaders?: { [key: string]: string }
 }
 
@@ -60,6 +61,7 @@ class FeatureFlagsPoller {
   customHeaders?: { [key: string]: string }
   shouldBeginExponentialBackoff: boolean = false
   backOffCount: number = 0
+  onLoad?: (count: number) => void
 
   constructor({
     pollingInterval,
@@ -84,7 +86,7 @@ class FeatureFlagsPoller {
     this.fetch = options.fetch || fetch
     this.onError = options.onError
     this.customHeaders = customHeaders
-
+    this.onLoad = options.onLoad
     void this.loadFeatureFlags()
   }
 
@@ -380,6 +382,14 @@ class FeatureFlagsPoller {
   }
 
   /**
+   * Returns true if the feature flags poller has loaded successfully at least once and has more than 0 feature flags.
+   * This is useful to check if local evaluation is ready before calling getFeatureFlag.
+   */
+  isLocalEvaluationReady(): boolean {
+    return (this.loadedSuccessfullyOnce ?? false) && (this.featureFlags?.length ?? 0) > 0
+  }
+
+  /**
    * If a client is misconfigured with an invalid or improper API key, the polling interval is doubled each time
    * until a successful request is made, up to a maximum of 60 seconds.
    *
@@ -475,6 +485,7 @@ class FeatureFlagsPoller {
           this.loadedSuccessfullyOnce = true
           this.shouldBeginExponentialBackoff = false
           this.backOffCount = 0
+          this.onLoad?.(this.featureFlags.length)
           break
         }
 

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -223,22 +223,10 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
     super.aliasStateless(data.alias, data.distinctId, undefined, { disableGeoip: data.disableGeoip })
   }
 
-  /**
-   * Returns true if the feature flags poller has loaded successfully at least once and has more than 0 feature flags.
-   * This is useful to check if local evaluation is ready before calling getFeatureFlag.
-   *
-   * @returns true if the feature flags poller has loaded successfully at least once and has more than 0 feature flags.
-   */
   isLocalEvaluationReady(): boolean {
     return this.featureFlagsPoller?.isLocalEvaluationReady() ?? false
   }
 
-  /**
-   * Waits for local evaluation to be ready, with an optional timeout.
-   * @param timeoutMs - Maximum time to wait in milliseconds. Defaults to 30 seconds.
-   * @returns A promise that resolves to true if local evaluation is ready (aka, flag
-   * definitions are loaded and there's more than 0 flags), false if the timeout was reached or if local evaluation is not enabled or if there are no flags.
-   */
   async waitForLocalEvaluationReady(timeoutMs: number = THIRTY_SECONDS): Promise<boolean> {
     if (this.isLocalEvaluationReady()) {
       return true

--- a/posthog-node/src/types.ts
+++ b/posthog-node/src/types.ts
@@ -215,4 +215,17 @@ export type PostHogNodeV1 = {
    * @param shutdownTimeoutMs The shutdown timeout, in milliseconds. Defaults to 30000 (30s).
    */
   shutdown(shutdownTimeoutMs?: number): void
+
+  /**
+   * @description Waits for local evaluation to be ready, with an optional timeout.
+   * @param timeoutMs - Maximum time to wait in milliseconds. Defaults to 30 seconds.
+   * @returns A promise that resolves to true if local evaluation is ready, false if the timeout was reached.
+   */
+  waitForLocalEvaluationReady(timeoutMs?: number): Promise<boolean>
+
+  /**
+   * @description Returns true if local evaluation is ready, false if it's not.
+   * @returns true if local evaluation is ready, false if it's not.
+   */
+  isLocalEvaluationReady(): boolean
 }

--- a/posthog-node/test/feature-flags.spec.ts
+++ b/posthog-node/test/feature-flags.spec.ts
@@ -1816,6 +1816,54 @@ describe('local evaluation', () => {
     })
   })
 
+  describe('waitForLocalEvaluationReady', () => {
+    it('returns true when local evaluation is ready', async () => {
+      const flags = {
+        flags: [
+          {
+            id: 1,
+            name: 'Beta Feature',
+            key: 'beta-feature',
+            active: true,
+            filters: {
+              groups: [{ properties: [], rollout_percentage: 100 }],
+            },
+          },
+        ],
+      }
+      mockedFetch.mockImplementation(apiImplementation({ localFlags: flags }))
+      posthog = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        personalApiKey: 'TEST_PERSONAL_API_KEY',
+        ...posthogImmediateResolveOptions,
+      })
+
+      expect(await posthog.waitForLocalEvaluationReady()).toBe(true)
+    })
+
+    it('returns false when local evaluation endpoint returns empty flags', async () => {
+      const flags = { flags: [] }
+      mockedFetch.mockImplementation(apiImplementation({ localFlags: flags }))
+      posthog = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        personalApiKey: 'TEST_PERSONAL_API_KEY',
+        ...posthogImmediateResolveOptions,
+      })
+      expect(await posthog.waitForLocalEvaluationReady()).toBe(false)
+    })
+
+    it('returns false when local evaluation is not enabled', async () => {
+      const flags = { flags: [] }
+      mockedFetch.mockImplementation(apiImplementation({ localFlags: flags }))
+      posthog = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        personalApiKey: undefined,
+        ...posthogImmediateResolveOptions,
+      })
+      expect(await posthog.waitForLocalEvaluationReady()).toBe(false)
+    })
+  })
+
   it('emits localEvaluationFlagsLoaded event when flags are loaded', async () => {
     const flags = {
       flags: [


### PR DESCRIPTION
This PR provides a way for users to determine if feature flag definitions for local evaluation are loaded.

## Problem

Fixes #445

## Changes

This adds a new `waitForLocalEvaluationReady` method that waits up to 30 seconds (configurable) for local evaluation feature flags to be loaded.

* It returns `true` immediately if flags are already loaded.
* It returns `false` immediately if local evaluation is not enabled.

This new method waits for the new `localEvaluationFlagsLoaded` event which is emitted when we retrieve feature flag definitions from the local evaluation endpoint.

This PR also adds a synchronous `isLocalEvaluationReady()` method that checks the feature flag poller to see if any flags are loaded.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added new `waitForLocalEvaluationReady()` method used to wait for local evaluation flags to be loaded.
- Added new `localEvaluationFlagsLoaded` event which is emitted every time local evaluation flags are loaded.
- Added new `isLocalEvaluationReady()` method to quickly check if feature flags are loaded.