### PR TITLE
fix: react native navigation missing navigationRef

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Next
 
+# 3.13.2 - 2025-04-16
+
+## Fixed
+
+1. react native navigation missing navigationRef
+
 # 3.13.1 - 2025-04-15
 
 ## Fixed

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-react-native/src/PostHogProvider.tsx
+++ b/posthog-react-native/src/PostHogProvider.tsx
@@ -24,7 +24,7 @@ function PostHogNavigationHook({
   options?: PostHogAutocaptureOptions
   client?: PostHog
 }): JSX.Element | null {
-  useNavigationTracker(options?.navigation, client)
+  useNavigationTracker(options?.navigation, options?.navigationRef, client)
   return null
 }
 

--- a/posthog-react-native/src/hooks/useNavigationTracker.ts
+++ b/posthog-react-native/src/hooks/useNavigationTracker.ts
@@ -8,7 +8,11 @@ function _useNavigationTrackerDisabled(): void {
   return
 }
 
-function _useNavigationTracker(options?: PostHogAutocaptureNavigationTrackerOptions, navigationRef?: any, client?: PostHog): void {
+function _useNavigationTracker(
+  options?: PostHogAutocaptureNavigationTrackerOptions,
+  navigationRef?: any,
+  client?: PostHog
+): void {
   const contextClient = usePostHog()
   const posthog = client || contextClient
 
@@ -26,7 +30,6 @@ function _useNavigationTracker(options?: PostHogAutocaptureNavigationTrackerOpti
     }
 
     let currentRoute = undefined
-
 
     // NOTE: This method is not typed correctly but is available and takes care of parsing the router state correctly
     try {

--- a/posthog-react-native/src/hooks/useNavigationTracker.ts
+++ b/posthog-react-native/src/hooks/useNavigationTracker.ts
@@ -3,6 +3,7 @@ import { OptionalReactNativeNavigation } from '../optional/OptionalReactNativeNa
 import type { PostHog } from '../posthog-rn'
 import { PostHogAutocaptureNavigationTrackerOptions } from '../types'
 import { usePostHog } from './usePostHog'
+import { PostHogNavigationRef } from '../types'
 
 function _useNavigationTrackerDisabled(): void {
   return
@@ -10,7 +11,7 @@ function _useNavigationTrackerDisabled(): void {
 
 function _useNavigationTracker(
   options?: PostHogAutocaptureNavigationTrackerOptions,
-  navigationRef?: any,
+  navigationRef?: PostHogNavigationRef,
   client?: PostHog
 ): void {
   const contextClient = usePostHog()
@@ -48,6 +49,10 @@ function _useNavigationTracker(
 
       currentRoute = (navigation as any).getCurrentRoute()
     } catch (error) {
+      return
+    }
+
+    if (!currentRoute) {
       return
     }
 

--- a/posthog-react-native/src/hooks/useNavigationTracker.ts
+++ b/posthog-react-native/src/hooks/useNavigationTracker.ts
@@ -8,7 +8,7 @@ function _useNavigationTrackerDisabled(): void {
   return
 }
 
-function _useNavigationTracker(options?: PostHogAutocaptureNavigationTrackerOptions, client?: PostHog): void {
+function _useNavigationTracker(options?: PostHogAutocaptureNavigationTrackerOptions, navigationRef?: any, client?: PostHog): void {
   const contextClient = usePostHog()
   const posthog = client || contextClient
 
@@ -18,12 +18,32 @@ function _useNavigationTracker(options?: PostHogAutocaptureNavigationTrackerOpti
   }
 
   const routes = OptionalReactNativeNavigation.useNavigationState((state) => state?.routes)
-  const navigation = OptionalReactNativeNavigation.useNavigation()
+  const navigation = navigationRef || OptionalReactNativeNavigation.useNavigation()
 
   const trackRoute = useCallback((): void => {
+    if (!navigation) {
+      return
+    }
+
+    let currentRoute = undefined
+
+
     // NOTE: This method is not typed correctly but is available and takes care of parsing the router state correctly
-    const currentRoute = (navigation as any).getCurrentRoute()
-    if (!currentRoute) {
+    try {
+      let isReady = false
+      try {
+        isReady = (navigation as any).isReady()
+      } catch (error) {
+        // keep compatibility with older versions of react-navigation
+        isReady = true
+      }
+
+      if (!isReady) {
+        return
+      }
+
+      currentRoute = (navigation as any).getCurrentRoute()
+    } catch (error) {
       return
     }
 

--- a/posthog-react-native/src/hooks/useNavigationTracker.ts
+++ b/posthog-react-native/src/hooks/useNavigationTracker.ts
@@ -22,6 +22,7 @@ function _useNavigationTracker(
   }
 
   const routes = OptionalReactNativeNavigation.useNavigationState((state) => state?.routes)
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const navigation = navigationRef || OptionalReactNativeNavigation.useNavigation()
 
   const trackRoute = useCallback((): void => {

--- a/posthog-react-native/src/types.ts
+++ b/posthog-react-native/src/types.ts
@@ -15,6 +15,7 @@ export type PostHogAutocaptureOptions = {
   // Navigation
   captureScreens?: boolean
   navigation?: PostHogAutocaptureNavigationTrackerOptions
+  navigationRef?: any
 
   /** Captures app lifecycle events such as Application Installed, Application Updated, Application Opened, Application Became Active and Application Backgrounded.
    * By default is true.

--- a/posthog-react-native/src/types.ts
+++ b/posthog-react-native/src/types.ts
@@ -3,6 +3,11 @@ export type PostHogAutocaptureNavigationTrackerOptions = {
   routeToProperties?: (name: string, params: any) => Record<string, any>
 }
 
+export type PostHogNavigationRef = {
+  getCurrentRoute(): any | undefined
+  isReady: () => boolean
+}
+
 export type PostHogAutocaptureOptions = {
   // Touches
   captureTouches?: boolean
@@ -15,7 +20,7 @@ export type PostHogAutocaptureOptions = {
   // Navigation
   captureScreens?: boolean
   navigation?: PostHogAutocaptureNavigationTrackerOptions
-  navigationRef?: any
+  navigationRef?: PostHogNavigationRef
 
   /** Captures app lifecycle events such as Application Installed, Application Updated, Application Opened, Application Became Active and Application Backgrounded.
    * By default is true.


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog-js-lite/issues/450

```
import { createNavigationContainerRef } from '@react-navigation/native'

export const navigationRef = createNavigationContainerRef()
```

Check the new autocapture prop `navigationRef`

```
export default function RootLayout() {
  const colorScheme = useColorScheme()
  const [loaded] = useFonts({
    SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
  })

  useEffect(() => {
    if (loaded) {
      SplashScreen.hideAsync()
    }
  }, [loaded])

  if (!loaded) {
    return null
  }

  return (
    <PostHogProvider
      client={posthog}
      autocapture={{
        captureScreens: true,
        captureLifecycleEvents: true,
        captureTouches: true,
        navigationRef: navigationRef,
      }}
    >
      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
        <Stack ref={navigationRef}>
          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
          <Stack.Screen name="+not-found" />
        </Stack>
        <StatusBar style="auto" />
      </ThemeProvider>
    </PostHogProvider>
  )
}

```

The reason is that the useNavigation() gives you the screen-level nav object — it does not have .getCurrentRoute()
Only navigationRef created via createNavigationContainerRef() has .getCurrentRoute()
Use navigationRef to track global route state

Fallback to `useNavigation()` if root `navigationRef` isn't provided since it works for other libraries, the goal here is to support this fix of react native navigation and expo router.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
