### PR TITLE
feat(err): support for error causes

### DIFF
--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -26,7 +26,7 @@
     "axios": "^1.8.2"
   },
   "devDependencies": {
-    "@types/node": "^18.0.0",
+    "@types/node": "^22.0.0",
     "commander": "^9.3.0",
     "mitata": "^1.0.21"
   },

--- a/posthog-node/src/extensions/error-tracking/error-conversion.ts
+++ b/posthog-node/src/extensions/error-tracking/error-conversion.ts
@@ -16,16 +16,29 @@ export async function propertiesFromUnknownInput(
     type: 'generic',
   }
 
-  const error = getError(mechanism, input, hint)
-  const exception = await exceptionFromError(stackParser, error)
+  const errorList = getErrorList(mechanism, input, hint)
+  const exceptionList = await Promise.all(
+    errorList.map(async (error) => {
+      const exception = await exceptionFromError(stackParser, error)
+      exception.value = exception.value || ''
+      exception.type = exception.type || 'Error'
+      exception.mechanism = mechanism
+      return exception
+    })
+  )
 
-  exception.value = exception.value || ''
-  exception.type = exception.type || 'Error'
-  exception.mechanism = mechanism
-
-  const properties = { $exception_list: [exception] }
-
+  const properties = { $exception_list: exceptionList }
   return properties
+}
+
+// Flatten error causes into a list of errors
+// See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+function getErrorList(mechanism: Mechanism, input: unknown, hint?: EventHint): Error[] {
+  const error = getError(mechanism, input, hint)
+  if (error.cause) {
+    return [error, ...getErrorList(mechanism, error.cause, hint)]
+  }
+  return [error]
 }
 
 function getError(mechanism: Mechanism, exception: unknown, hint?: EventHint): Error {
@@ -61,7 +74,7 @@ function getErrorPropertyFromObject(obj: Record<string, unknown>): Error | undef
   for (const prop in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, prop)) {
       const value = obj[prop]
-      if (value instanceof Error) {
+      if (isError(value)) {
         return value
       }
     }

--- a/posthog-node/test/extensions/error-conversion.spec.ts
+++ b/posthog-node/test/extensions/error-conversion.spec.ts
@@ -1,0 +1,44 @@
+import { propertiesFromUnknownInput } from '../../src/extensions/error-tracking/error-conversion'
+import { defaultStackParser } from '../../src/extensions/error-tracking/stack-trace'
+import { ErrorProperties } from '../../src/extensions/error-tracking/types'
+
+describe('error conversion', () => {
+  async function getExceptionList(error: unknown): Promise<ErrorProperties['$exception_list']> {
+    const syntheticException = new Error('PostHog syntheticException')
+    const exceptionProperties = await propertiesFromUnknownInput(defaultStackParser, error, {
+      syntheticException,
+    })
+    return exceptionProperties.$exception_list
+  }
+
+  it('should create an exception list from a string', async () => {
+    const exceptionList = await getExceptionList('My string error')
+    expect(exceptionList.length).toEqual(1)
+    expect(exceptionList[0].value).toEqual('My string error')
+  })
+
+  it('should use the error key in object', async () => {
+    const errorObject = { error: new Error('My special error') }
+    const exceptionList = await getExceptionList(errorObject)
+    expect(exceptionList.length).toEqual(1)
+    expect(exceptionList[0].value).toEqual('My special error')
+  })
+
+  it('should create an exception list from an error cause', async () => {
+    const originalError = new Error('original error')
+    const error = new Error('test error', { cause: originalError })
+    const exceptionList = await getExceptionList(error)
+    expect(exceptionList.length).toEqual(2)
+    expect(exceptionList[0].value).toEqual('test error')
+    expect(exceptionList[1].value).toEqual('original error')
+  })
+
+  it('should create an exception list from a non error cause', async () => {
+    const originalError = { error_code: 'XASKJASK' }
+    const error = new Error('test error', { cause: originalError })
+    const exceptionList = await getExceptionList(error)
+    expect(exceptionList.length).toEqual(2)
+    expect(exceptionList[0].value).toEqual('test error')
+    expect(exceptionList[1].value).toEqual('Object captured as exception with keys: error_code')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2707,6 +2707,13 @@
   dependencies:
     undici-types "~5.26.4"
 
+"@types/node@^22.0.0":
+  version "22.14.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.14.1.tgz#53b54585cec81c21eee3697521e31312d6ca1e6f"
+  integrity sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==
+  dependencies:
+    undici-types "~6.21.0"
+
 "@types/parse5@^6.0.3":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-6.0.3.tgz#705bb349e789efa06f43f128cef51240753424cb"
@@ -10800,6 +10807,11 @@ undici-types@~6.19.2:
   version "6.19.8"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## Problem

- The error cause is not use used when building a stacktrace
See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause

## Changes

- Add support for it

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

- Added support for error cause
