### PR TITLE
chore: Bump posthog-node to 4.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Information on how to contribute to the project and run tests can be found [here
 
 ## Releasing
 
-Information on how to release the individual libraries can be found [here](RELEASE.md).
+Information on how to release the individual libraries can be found [here](RELEASING.md).
 
 ## License
 

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.13.0 - 2025-04-21
+
+1. feat: Add method to wait for local evaluation feature flag definitions to be loaded
+
 # 4.12.0 – 2025-04-17
 
 1. chore: roll out new feature flag evaluation backend to majority of customers

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.12.0",
+  "version": "4.13.0",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a follow-up to https://github.com/PostHog/posthog-js-lite/pull/447

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
