### PR TITLE
fix: Add a guard around calling shutdown multiple times

### DIFF
--- a/examples/example-cloudflare/src/index.ts
+++ b/examples/example-cloudflare/src/index.ts
@@ -25,7 +25,7 @@ export default {
 
 		posthog.capture({ distinctId: `user-${Date.now()}`, event: 'test event', properties: { test: 'test' } });
 
-		await posthog.shutdown();
+		await posthog.flush();
 
 		return new Response('Success!');
 	},

--- a/examples/example-gcp-functions/index.js
+++ b/examples/example-gcp-functions/index.js
@@ -1,37 +1,34 @@
-const functions = require('@google-cloud/functions-framework');
-const { PostHog } = require('posthog-node');
+const functions = require('@google-cloud/functions-framework')
+const { PostHog } = require('posthog-node')
 
 const posthog = new PostHog('phc_pQ70jJhZKHRvDIL5ruOErnPy6xiAiWCqlL4ayELj4X8', {
-    // works as well if you uncomment the following lines
-    // flushAt: 1,
-    // flushInterval: 0
-  })
+  // works as well if you uncomment the following lines
+  // flushAt: 1,
+  // flushInterval: 0
+})
 posthog.debug(true)
 
 async function sendEvent(id) {
-    // works as well if you uncomment the following line, and comment the global posthog declaration
-    // const posthog = new PostHog('phc_pQ70jJhZKHRvDIL5ruOErnPy6xiAiWCqlL4ayELj4X8')
-    // posthog.debug(true)
+  // works as well if you uncomment the following line, and comment the global posthog declaration
+  // const posthog = new PostHog('phc_pQ70jJhZKHRvDIL5ruOErnPy6xiAiWCqlL4ayELj4X8')
+  // posthog.debug(true)
 
-    posthog.capture({
-        distinctId: 'test',
-        event: 'test' + id,
-    })
+  posthog.capture({
+    distinctId: 'test',
+    event: 'test' + id,
+  })
 
-    // works as well if you uncomment the following line, and comment the line after
-    // await posthog.flush()
-    await posthog.shutdown()
+  await posthog.flush()
 }
 
-
 functions.http('helloWorld', async (req, res) => {
-   console.info("PostHog before hello");
+  console.info('PostHog before hello')
 
-  res.send('Hello, World');
+  res.send('Hello, World')
 
-  console.info("PostHog before send event");
+  console.info('PostHog before send event')
 
-  await sendEvent(req.executionId);
+  await sendEvent(req.executionId)
 
-  console.info("PostHog end");
-});
+  console.info('PostHog end')
+})

--- a/examples/example-gcp-functions/index.js
+++ b/examples/example-gcp-functions/index.js
@@ -1,7 +1,7 @@
 const functions = require('@google-cloud/functions-framework')
 const { PostHog } = require('posthog-node')
 
-const posthog = new PostHog('phc_pQ70jJhZKHRvDIL5ruOErnPy6xiAiWCqlL4ayELj4X8', {
+const posthog = new PostHog(process.env.POSTHOG_API_KEY, {
   // works as well if you uncomment the following lines
   // flushAt: 1,
   // flushInterval: 0

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -971,7 +971,7 @@ export abstract class PostHogCoreStateless {
    */
   async shutdown(shutdownTimeoutMs: number = 30000): Promise<void> {
     if (this.shutdownPromise) {
-      this.logMsgIfDebug(() => console.error('shutdown() called while already shutting down. Did you mean flush()?'))
+      this.logMsgIfDebug(() => console.error('shutdown() called while already shutting down. shutdown() is meant to be called once before process exit - use flush() for per-request cleanup'))
     } else {
       this.shutdownPromise = this._shutdown(shutdownTimeoutMs).finally(() => {
         this.shutdownPromise = null

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -965,7 +965,8 @@ export abstract class PostHogCoreStateless {
   }
 
   /**
-   *  Call shutdown() once before the node process exits, so ensure that e.g. all events have been sent first
+   *  Call shutdown() once before the node process exits, so ensure that all events have been sent and all promises
+   *  have resolved. Do not use this function if you intend to keep using this PostHog instance after calling it.
    * @param shutdownTimeoutMs
    */
   async shutdown(shutdownTimeoutMs: number = 30000): Promise<void> {

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -971,7 +971,11 @@ export abstract class PostHogCoreStateless {
    */
   async shutdown(shutdownTimeoutMs: number = 30000): Promise<void> {
     if (this.shutdownPromise) {
-      this.logMsgIfDebug(() => console.error('shutdown() called while already shutting down. shutdown() is meant to be called once before process exit - use flush() for per-request cleanup'))
+      this.logMsgIfDebug(() =>
+        console.error(
+          'shutdown() called while already shutting down. shutdown() is meant to be called once before process exit - use flush() for per-request cleanup'
+        )
+      )
     } else {
       this.shutdownPromise = this._shutdown(shutdownTimeoutMs).finally(() => {
         this.shutdownPromise = null

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -972,7 +972,7 @@ export abstract class PostHogCoreStateless {
   async shutdown(shutdownTimeoutMs: number = 30000): Promise<void> {
     if (this.shutdownPromise) {
       this.logMsgIfDebug(() =>
-        console.error(
+        console.warn(
           'shutdown() called while already shutting down. shutdown() is meant to be called once before process exit - use flush() for per-request cleanup'
         )
       )

--- a/posthog-core/test/posthog.shutdown.spec.ts
+++ b/posthog-core/test/posthog.shutdown.spec.ts
@@ -45,5 +45,25 @@ describe('PostHog Core', () => {
         })
       expect(mocks.fetch).toHaveBeenCalledTimes(1)
     })
+
+    it('return the same promise if called multiple times', async () => {
+      mocks.fetch.mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        console.log('FETCH RETURNED')
+        return {
+          status: 200,
+          text: () => Promise.resolve('ok'),
+          json: () => Promise.resolve({ status: 'ok' }),
+        }
+      })
+
+      posthog.capture('test-event')
+
+      const p1 = posthog.shutdown(100)
+      const p2 = posthog.shutdown(100)
+      expect(p1).toEqual(p2)
+      await Promise.allSettled([p1, p2])
+      expect(mocks.fetch).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/posthog-core/test/posthog.shutdown.spec.ts
+++ b/posthog-core/test/posthog.shutdown.spec.ts
@@ -49,7 +49,6 @@ describe('PostHog Core', () => {
     it('return the same promise if called multiple times in parallel', async () => {
       mocks.fetch.mockImplementation(async () => {
         await new Promise((resolve) => setTimeout(resolve, 1000))
-        console.log('FETCH RETURNED')
         return {
           status: 200,
           text: () => Promise.resolve('ok'),

--- a/posthog-node/src/posthog-node.ts
+++ b/posthog-node/src/posthog-node.ts
@@ -535,9 +535,9 @@ export class PostHog extends PostHogCoreStateless implements PostHogNodeV1 {
     await this.featureFlagsPoller?.loadFeatureFlags(true)
   }
 
-  async shutdown(shutdownTimeoutMs?: number): Promise<void> {
+  async _shutdown(shutdownTimeoutMs?: number): Promise<void> {
     this.featureFlagsPoller?.stopPoller()
-    return super.shutdown(shutdownTimeoutMs)
+    return super._shutdown(shutdownTimeoutMs)
   }
 
   private addLocalPersonAndGroupProperties(


### PR DESCRIPTION
## Problem

Calling shutdown multiple times can have an unexpected result. Additionally, we tell people to do this in our docs.

## Changes

Guard shutdown with a shared promise, similar to how we handle flush. Doesn't break anything if people are calling shutdown() per-request, but also gives them a debug log (and a comment) telling them not to do this

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added protection against calling shutdown in parallel, and update examples to be clearer on using flush() rather than shutdown() for serverless use-cases.
