### PR TITLE
fix: Improve flush behaviour

### DIFF
--- a/posthog-ai/src/utils.ts
+++ b/posthog-ai/src/utils.ts
@@ -185,7 +185,9 @@ export const sendEventToPosthog = async ({
   tools,
   captureImmediate = false,
 }: SendEventToPosthogParams): Promise<void> => {
-  if (!client.capture) return Promise.resolve()
+  if (!client.capture) {
+    return Promise.resolve()
+  }
   // sanitize input and output for UTF-8 validity
   const safeInput = sanitizeValues(input)
   const safeOutput = sanitizeValues(output)

--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -1030,7 +1030,7 @@ export abstract class PostHogCoreStateless {
       try {
         await this.fetchWithRetry(url, fetchOptions, retryOptions)
       } catch (err) {
-        if (isPostHogFetchContentTooLargeError(err)) {
+        if (isPostHogFetchContentTooLargeError(err) && batchMessages.length > 1) {
           // if we get a 413 error, we want to reduce the batch size and try again
           this.maxBatchSize = Math.max(1, Math.floor(batchMessages.length / 2))
           this.logMsgIfDebug(() =>

--- a/posthog-core/src/utils.ts
+++ b/posthog-core/src/utils.ts
@@ -107,7 +107,7 @@ export function removeTrailingSlash(url: string): string {
 export interface RetriableOptions {
   retryCount: number
   retryDelay: number
-  retryCheck: (err: any) => boolean
+  retryCheck: (err: unknown) => boolean
 }
 
 export async function retriable<T>(fn: () => Promise<T>, props: RetriableOptions): Promise<T> {

--- a/posthog-core/test/posthog.flush.spec.ts
+++ b/posthog-core/test/posthog.flush.spec.ts
@@ -1,7 +1,6 @@
 import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from './test-utils/PostHogCoreTestClient'
 import { delay, waitForPromises } from './test-utils/test-utils'
 import { PostHogPersistedProperty } from '../src'
-import useRealTimers = jest.useRealTimers
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient
@@ -176,7 +175,7 @@ describe('PostHog Core', () => {
     })
 
     it('should stop at first error', async () => {
-      useRealTimers()
+      jest.useRealTimers()
       ;[posthog, mocks] = createTestClient('TEST_API_KEY', { flushAt: 10, fetchRetryDelay: 1 })
       posthog['maxBatchSize'] = 1 // a bit contrived because usually maxBatchSize >= flushAt
       const successfulMessages: any[] = []

--- a/posthog-core/test/posthog.groups.spec.ts
+++ b/posthog-core/test/posthog.groups.spec.ts
@@ -42,7 +42,9 @@ describe('PostHog Core', () => {
       await waitForPromises()
 
       expect(mocks.fetch).toHaveBeenCalledTimes(2) // 1 for decide, 1 for groupIdentify
-      expect(parseBody(mocks.fetch.mock.calls[0])).toMatchObject({
+      const batchCall = mocks.fetch.mock.calls[1]
+      expect(batchCall[0]).toEqual('https://us.i.posthog.com/batch/')
+      expect(parseBody(batchCall)).toMatchObject({
         batch: [
           {
             event: '$groupidentify',

--- a/posthog-core/test/posthog.identify.spec.ts
+++ b/posthog-core/test/posthog.identify.spec.ts
@@ -19,7 +19,9 @@ describe('PostHog Core', () => {
       posthog.identify('id-1', { foo: 'bar' })
       await waitForPromises()
       expect(mocks.fetch).toHaveBeenCalledTimes(2)
-      expect(parseBody(mocks.fetch.mock.calls[0])).toEqual({
+      const batchCall = mocks.fetch.mock.calls[1]
+      expect(batchCall[0]).toEqual('https://us.i.posthog.com/batch/')
+      expect(parseBody(batchCall)).toMatchObject({
         api_key: 'TEST_API_KEY',
         batch: [
           {
@@ -56,7 +58,9 @@ describe('PostHog Core', () => {
       })
       await waitForPromises()
       expect(mocks.fetch).toHaveBeenCalledTimes(2)
-      expect(parseBody(mocks.fetch.mock.calls[0])).toEqual({
+      const batchCall = mocks.fetch.mock.calls[1]
+      expect(batchCall[0]).toEqual('https://us.i.posthog.com/batch/')
+      expect(parseBody(batchCall)).toMatchObject({
         api_key: 'TEST_API_KEY',
         batch: [
           {
@@ -94,7 +98,9 @@ describe('PostHog Core', () => {
       })
       await waitForPromises()
       expect(mocks.fetch).toHaveBeenCalledTimes(2)
-      expect(parseBody(mocks.fetch.mock.calls[0])).toEqual({
+      const batchCall = mocks.fetch.mock.calls[1]
+      expect(batchCall[0]).toEqual('https://us.i.posthog.com/batch/')
+      expect(parseBody(batchCall)).toMatchObject({
         api_key: 'TEST_API_KEY',
         batch: [
           {
@@ -128,7 +134,9 @@ describe('PostHog Core', () => {
       await waitForPromises()
 
       expect(mocks.fetch).toHaveBeenCalledTimes(2)
-      expect(parseBody(mocks.fetch.mock.calls[0])).toMatchObject({
+      const batchCall = mocks.fetch.mock.calls[1]
+      expect(batchCall[0]).toEqual('https://us.i.posthog.com/batch/')
+      expect(parseBody(batchCall)).toMatchObject({
         batch: [
           {
             distinct_id: posthog.getDistinctId(),
@@ -157,7 +165,9 @@ describe('PostHog Core', () => {
       // One call exists for the queueing, one for persisting distinct id
       expect(mocks.storage.setItem).toHaveBeenCalledWith('distinct_id', 'id-1')
       expect(mocks.fetch).toHaveBeenCalledTimes(2)
-      expect(parseBody(mocks.fetch.mock.calls[0])).toMatchObject({
+      const batchCall = mocks.fetch.mock.calls[1]
+      expect(batchCall[0]).toEqual('https://us.i.posthog.com/batch/')
+      expect(parseBody(batchCall)).toMatchObject({
         batch: [
           {
             distinct_id: 'id-1',

--- a/posthog-core/test/test-utils/PostHogCoreTestClient.ts
+++ b/posthog-core/test/test-utils/PostHogCoreTestClient.ts
@@ -64,10 +64,10 @@ export const createTestClient = (
   storageCache: { [key: string]: string | JsonType } = {}
 ): [PostHogCoreTestClient, PostHogCoreTestClientMocks] => {
   const mocks = {
-    fetch: jest.fn<Promise<PostHogFetchResponse>, [string, PostHogFetchOptions]>(),
+    fetch: jest.fn(),
     storage: {
-      getItem: jest.fn<any | undefined, [string]>((key) => storageCache[key]),
-      setItem: jest.fn<void, [string, any | null]>((key, val) => {
+      getItem: jest.fn((key) => storageCache[key]),
+      setItem: jest.fn((key, val) => {
         storageCache[key] = val == null ? undefined : val
       }),
     },

--- a/posthog-core/test/test-utils/test-utils.ts
+++ b/posthog-core/test/test-utils/test-utils.ts
@@ -17,3 +17,17 @@ export const parseBody = (mockCall: any): any => {
   expect(options.method).toBe('POST')
   return JSON.parse(options.body || '')
 }
+
+export const createImperativePromise = <T>(): [Promise<T>, (value: T) => void] => {
+  let resolve: (value: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return [promise, (val) => resolve?.(val)]
+}
+
+export const delay = (ms: number): Promise<void> => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -381,33 +381,29 @@ describe('PostHog Node.js', () => {
       })
       ph.debug(true)
 
-      // using debug mode to check console.log output
-      // which tells us when the flush is complete
+      ph.capture({ event: 'test-event-1', distinctId: '123' })
 
-      ph.capture({ event: 'test-event', distinctId: '123' })
-      await wait(100)
-      expect(logSpy).toHaveBeenCalledTimes(1)
+      // start flushing, but don't wait for promise to resolve before resuming events
+      void ph.flush()
 
-      ph.capture({ event: 'test-event', distinctId: '123' })
-      ph.capture({ event: 'test-event', distinctId: '123' })
-      await wait(100)
-      expect(logSpy).toHaveBeenCalledTimes(3)
-      await wait(400) // The flush will resolve in this time
-      ph.capture({ event: 'test-event', distinctId: '123' })
-      ph.capture({ event: 'test-event', distinctId: '123' })
-      await wait(100)
-      expect(logSpy).toHaveBeenCalledTimes(6) // 5 captures and 1 flush
-      expect(5).toEqual(logSpy.mock.calls.filter((call) => call[1].includes('capture')).length)
-      expect(1).toEqual(logSpy.mock.calls.filter((call) => call[1].includes('flush')).length)
+      ph.capture({ event: 'test-event-2', distinctId: '123' })
 
-      logSpy.mockClear()
-      expect(logSpy).toHaveBeenCalledTimes(0)
+      // start shutdown, but don't wait for promise to resolve before resuming events
+      const shutdownPromise = ph.shutdown()
 
-      console.warn('YOO!!')
+      ph.capture({ event: 'test-event-3', distinctId: '123' })
 
-      await ph.shutdown()
-      // 1 final flush for the events that were queued during shutdown
-      expect(1).toEqual(logSpy.mock.calls.filter((call) => call[1].includes('flush')).length)
+      // wait for shutdown to finish
+      await shutdownPromise
+
+      expect(3).toEqual(logSpy.mock.calls.filter((call) => call[1].includes('capture')).length)
+      const flushedEvents = logSpy.mock.calls.filter((call) => call[1].includes('flush')).flatMap((flush) => flush[2])
+      expect(flushedEvents).toMatchObject([
+        { event: 'test-event-1' },
+        { event: 'test-event-2' },
+        { event: 'test-event-3' },
+      ])
+
       logSpy.mockRestore()
       warnSpy.mockRestore()
     })

--- a/posthog-node/test/test-utils.ts
+++ b/posthog-node/test/test-utils.ts
@@ -1,4 +1,5 @@
 import { PostHogV4DecideResponse } from 'posthog-core/src/types'
+import util from 'util'
 
 type ErrorResponse = {
   status: number
@@ -104,3 +105,7 @@ export const anyLocalEvalCall = [
   expect.any(Object),
 ]
 export const anyDecideCall = ['http://example.com/flags/?v=2', expect.any(Object)]
+
+export const isPending = (promise: Promise<any>): boolean => {
+  return util.inspect(promise).includes('pending')
+}


### PR DESCRIPTION
## Problem

There's a long internal thread here: https://posthog.slack.com/archives/C087XQ7K9K7/p1745963996974469

We are not respecting the maximum body size restrictions on the capture endpoint, and `flush()` does not correctly flush all events.

## Changes

* Handle 413 errors, which can be returned if the request is too large. Handle this by reducing the batch size by half and retrying. If batch size was already 1, treat it as a regular error.
* Change the behaviour of `flush()`, to send >1 batch if necessary. Previously, it only sent 1 batch
* Ensure that `flush()` does not get stuck infinitely if there are a constant stream of new events. It is only guaranteed to flush events that occurred before `flush()` was called (and *may* include some afterwards, but is not guaranteed to) or until an error occurred.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

- Improved flush() behaviour, to ensure that it is more aware of batch size restrictions, and fix an infinite loop.
