### PR TITLE
fix(posthog-node): give explicit file types

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: preactjs/compressed-size-action@v2
         with:
-          pattern: 'posthog-{web,node,react-native,ai}/lib/**/*.js'
+          pattern: 'posthog-{web,node,react-native,ai}/lib/**/*.{cjs,mjs,js}'

--- a/posthog-node/.npmignore
+++ b/posthog-node/.npmignore
@@ -1,0 +1,4 @@
+test
+src
+tsconfig.json
+node_modules

--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.17.1 - 2025-05-02
+
+1. fix: fix imports for old node.js version
+
 # 4.17.0 - 2025-05-02
 
 1. fix: specific exports for edge environments

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -19,8 +19,8 @@
     "email": "hey@posthog.com",
     "url": "https://posthog.com"
   },
-  "main": "lib/node/index.cjs.js",
-  "module": "lib/node/index.esm.js",
+  "main": "lib/node/index.cjs",
+  "module": "lib/node/index.mjs",
   "types": "lib/index.d.ts",
   "dependencies": {
     "axios": "^1.8.2"
@@ -40,27 +40,27 @@
     ".": {
       "types": "./lib/index.d.ts",
       "edge": {
-        "import": "./lib/edge/index.esm.js",
-        "require": "./lib/edge/index.cjs.js",
-        "default": "./lib/edge/index.js"
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs",
+        "default": "./lib/edge/index.mjs"
       },
       "node": {
-        "import": "./lib/node/index.esm.js",
-        "require": "./lib/node/index.cjs.js",
-        "default": "./lib/node/index.js"
+        "import": "./lib/node/index.mjs",
+        "require": "./lib/node/index.cjs",
+        "default": "./lib/node/index.mjs"
       },
       "edge-light": {
-        "import": "./lib/edge/index.esm.js",
-        "require": "./lib/edge/index.cjs.js",
-        "default": "./lib/edge/index.js"
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs",
+        "default": "./lib/edge/index.mjs"
       },
       "workerd": {
-        "import": "./lib/edge/index.esm.js",
-        "require": "./lib/edge/index.cjs.js",
-        "default": "./lib/edge/index.js"
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs",
+        "default": "./lib/edge/index.mjs"
       },
-      "import": "./lib/node/index.esm.js",
-      "require": "./lib/node/index.cjs.js"
+      "import": "./lib/node/index.mjs",
+      "require": "./lib/node/index.cjs"
     }
   }
 }

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -58,13 +58,13 @@ runtimes.forEach((runtime) => {
     input: `./posthog-node/src/entrypoints/index.${runtime}.ts`,
     output: [
       {
-        file: `./posthog-node/lib/${runtime}/index.cjs.js`,
+        file: `./posthog-node/lib/${runtime}/index.cjs`,
         sourcemap: true,
         exports: 'named',
         format: 'cjs',
       },
       {
-        file: `./posthog-node/lib/${runtime}/index.esm.js`,
+        file: `./posthog-node/lib/${runtime}/index.mjs`,
         sourcemap: true,
         format: 'es',
       },


### PR DESCRIPTION
## Problem

Related to : https://github.com/PostHog/posthog-js-lite/issues/491
- Module types are not detected correcly

## Changes

- Give filenames explicit types

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

- Fix tsup bundling
