### PR TITLE
fix: correct file export names

### DIFF
--- a/posthog-ai/CHANGELOG.md
+++ b/posthog-ai/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.3.2
+
+- Fix exported file extensions to work with older Node versions
+
 # 4.3.1
 
 - Remove fullDebug mode

--- a/posthog-ai/package.json
+++ b/posthog-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@posthog/ai",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "PostHog Node.js AI integrations",
   "repository": {
     "type": "git",

--- a/posthog-ai/package.json
+++ b/posthog-ai/package.json
@@ -7,8 +7,8 @@
     "url": "git+https://github.com/PostHog/posthog-js-lite.git",
     "directory": "posthog-ai"
   },
-  "main": "lib/index.cjs.js",
-  "module": "lib/index.esm.js",
+  "main": "lib/index.cjs",
+  "module": "lib/index.mjs",
   "types": "lib/index.d.ts",
   "license": "MIT",
   "devDependencies": {
@@ -40,28 +40,28 @@
   },
   "exports": {
     ".": {
-      "require": "./lib/index.cjs.js",
-      "import": "./lib/index.esm.js",
+      "require": "./lib/index.cjs",
+      "import": "./lib/index.mjs",
       "types": "./lib/index.d.ts"
     },
     "./anthropic": {
-      "require": "./lib/anthropic/index.cjs.js",
-      "import": "./lib/anthropic/index.esm.js",
+      "require": "./lib/anthropic/index.cjs",
+      "import": "./lib/anthropic/index.mjs",
       "types": "./lib/anthropic/index.d.ts"
     },
     "./openai": {
-      "require": "./lib/openai/index.cjs.js",
-      "import": "./lib/openai/index.esm.js",
+      "require": "./lib/openai/index.cjs",
+      "import": "./lib/openai/index.mjs",
       "types": "./lib/openai/index.d.ts"
     },
     "./vercel": {
-      "require": "./lib/vercel/index.cjs.js",
-      "import": "./lib/vercel/index.esm.js",
+      "require": "./lib/vercel/index.cjs",
+      "import": "./lib/vercel/index.mjs",
       "types": "./lib/vercel/index.d.ts"
     },
     "./langchain": {
-      "require": "./lib/langchain/index.cjs.js",
-      "import": "./lib/langchain/index.esm.js",
+      "require": "./lib/langchain/index.cjs",
+      "import": "./lib/langchain/index.mjs",
       "types": "./lib/langchain/index.d.ts"
     }
   },

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Next
 
+# 3.5.1 – 2025-05-06
+
+## Fixed
+
+1. Fix exported file extensions to work with older Node versions
+
 # 3.5.0 – 2025-04-17
 
 ## Added

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-js-lite",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "types": "lib/index.d.ts",

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -1,8 +1,8 @@
 {
   "name": "posthog-js-lite",
   "version": "3.5.0",
-  "main": "lib/index.cjs.js",
-  "module": "lib/index.esm.js",
+  "main": "lib/index.cjs",
+  "module": "lib/index.mjs",
   "types": "lib/index.d.ts",
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -127,13 +127,13 @@ providers.forEach((provider) => {
     input: `./posthog-ai/src/${provider}/index.ts`,
     output: [
       {
-        file: `./posthog-ai/lib/${provider}/index.cjs.js`,
+        file: `./posthog-ai/lib/${provider}/index.cjs`,
         sourcemap: true,
         exports: 'named',
         format: 'cjs',
       },
       {
-        file: `./posthog-ai/lib/${provider}/index.esm.js`,
+        file: `./posthog-ai/lib/${provider}/index.mjs`,
         sourcemap: true,
         format: 'es',
       },


### PR DESCRIPTION
## Problem

Reported in https://github.com/PostHog/posthog-js-lite/issues/491#issuecomment-2853781601

## Changes

Apply same fixes to the web / ai repos that were added to Node in https://github.com/PostHog/posthog-js-lite/pull/492

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

- [ ] All of them
- [x] posthog-web
- [ ] posthog-node
- [x] posthog-ai
- [ ] posthog-react-native

### Changelog notes

- Fix exported file extensions to work with older Node versions