### PR TITLE
fix: no throw in sendImmedate

### DIFF
--- a/posthog-core/src/index.ts
+++ b/posthog-core/src/index.ts
@@ -894,7 +894,6 @@ export abstract class PostHogCoreStateless {
       await this.fetchWithRetry(url, fetchOptions)
     } catch (err) {
       this._events.emit('error', err)
-      throw err
     }
   }
 


### PR DESCRIPTION
We have callbacks to notify user code of failure, crashing user apps is a non-starter