### PR TITLE
feat(err): add chunk id to posthog-node frames

### DIFF
--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "4.17.2",
+  "version": "4.18.0",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/src/extensions/error-tracking/chunk-ids.ts
+++ b/posthog-node/src/extensions/error-tracking/chunk-ids.ts
@@ -1,0 +1,59 @@
+// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+// Licensed under the MIT License
+
+import type { StackParser } from './types'
+
+type StackString = string
+type CachedResult = [string, string]
+
+type ChunkIdMapType = Record<string, string>
+
+let parsedStackResults: Record<StackString, CachedResult> | undefined
+let lastKeysCount: number | undefined
+let cachedFilenameChunkIds: ChunkIdMapType | undefined
+
+export function getFilenameToChunkIdMap(stackParser: StackParser): ChunkIdMapType {
+  const chunkIdMap = (globalThis as any)._posthogChunkIds as ChunkIdMapType | undefined
+  if (!chunkIdMap) {
+    console.error('No chunk id map found')
+    return {}
+  }
+
+  const chunkIdKeys = Object.keys(chunkIdMap)
+
+  if (cachedFilenameChunkIds && chunkIdKeys.length === lastKeysCount) {
+    return cachedFilenameChunkIds
+  }
+
+  lastKeysCount = chunkIdKeys.length
+
+  cachedFilenameChunkIds = chunkIdKeys.reduce<Record<string, string>>((acc, stackKey) => {
+    if (!parsedStackResults) {
+      parsedStackResults = {}
+    }
+
+    const result = parsedStackResults[stackKey]
+
+    if (result) {
+      acc[result[0]] = result[1]
+    } else {
+      const parsedStack = stackParser(stackKey)
+
+      for (let i = parsedStack.length - 1; i >= 0; i--) {
+        const stackFrame = parsedStack[i]
+        const filename = stackFrame?.filename
+        const chunkId = chunkIdMap[stackKey]
+
+        if (filename && chunkId) {
+          acc[filename] = chunkId
+          parsedStackResults[stackKey] = [filename, chunkId]
+          break
+        }
+      }
+    }
+
+    return acc
+  }, {})
+
+  return cachedFilenameChunkIds
+}

--- a/posthog-node/src/extensions/error-tracking/error-conversion.ts
+++ b/posthog-node/src/extensions/error-tracking/error-conversion.ts
@@ -1,6 +1,7 @@
 // Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
 // Licensed under the MIT License
 
+import { getFilenameToChunkIdMap } from './chunk-ids'
 import { isError, isErrorEvent, isEvent, isPlainObject } from './type-checking'
 import {
   ErrorProperties,
@@ -275,5 +276,16 @@ async function exceptionFromError(
  * Extracts stack frames from the error.stack string
  */
 function parseStackFrames(stackParser: StackParser, error: Error): StackFrame[] {
-  return stackParser(error.stack || '', 1)
+  return applyChunkIds(stackParser(error.stack || '', 1), stackParser)
+}
+
+export function applyChunkIds(frames: StackFrame[], parser: StackParser): StackFrame[] {
+  const filenameChunkIdMap = getFilenameToChunkIdMap(parser)
+  frames.forEach((frame) => {
+    if (frame.filename) {
+      frame.chunk_id = filenameChunkIdMap[frame.filename]
+    }
+  })
+
+  return frames
 }

--- a/posthog-node/src/extensions/error-tracking/types.ts
+++ b/posthog-node/src/extensions/error-tracking/types.ts
@@ -67,5 +67,5 @@ export interface StackFrame {
   instruction_addr?: string
   addr_mode?: string
   vars?: { [key: string]: JsonType }
-  debug_id?: string
+  chunk_id?: string
 }


### PR DESCRIPTION
## Problem

- When minifying js code for server use, there is no way to get error context. It generally happen when using nextjs SSR, server actions and so on... 

## Changes

- Add chunk id to stack frames

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

- Add support for node minified sources inside error tracking
