### PR TITLE
rotate session id if expired when the app is back from background

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Next
 
+# 3.16.1 – 2025-05-28
+
+## Fixed
+
+1. rotate session id if expired when the app is back from background
+
+# 3.16.0 – 2025-05-27
+
 ## Fixed
 
 1. rotate session id if expired after 24 hours

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"


### PR DESCRIPTION
## Problem

Helps with https://github.com/PostHog/posthog-js-lite/issues/510
iOS will stop capturing network logs and console logs in the background, so the React Native sessions should not be extended because of this after those changes.
Android does not capture network logs for React native yet.
afaict console logs on Android aren't captured when the app is in the background.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [X] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
