### PR TITLE
chore: release web 3.6.0

### DIFF
--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+# 3.6.0 – 2025-06-05
+
 ## Added
 
 1. chore: improve event prop types

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-js-lite",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog-js-lite/issues/517
Already fixed by https://github.com/PostHog/posthog-js-lite/pull/496#discussion_r2077196650 but not released

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [X] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [X] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
