### PR TITLE
chore: Use `posthog-node` v5.0.0

### DIFF
--- a/posthog-ai/CHANGELOG.md
+++ b/posthog-ai/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+# 5.0.1
+
+- Bump posthog-node to v5.0.0
+
 # 5.0.0
 
 - Major bump for breaking change:

--- a/posthog-ai/package.json
+++ b/posthog-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@posthog/ai",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "PostHog Node.js AI integrations",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "posthog-node": "^4.17.1"
+    "posthog-node": "^5.0.0"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
## Changes

This has just been released, let's use it as our dependency to foster adoption

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [x] posthog-ai
- [ ] posthog-react-native