### PR TITLE
feat: responses api + parse

### DIFF
--- a/posthog-ai/CHANGELOG.md
+++ b/posthog-ai/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 5.1.0
+
+- Add repsonses + parse
+
 # 5.0.1
 
 - Bump posthog-node to v5.0.0

--- a/posthog-ai/package.json
+++ b/posthog-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@posthog/ai",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "PostHog Node.js AI integrations",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "@langchain/core": "^0.3.37",
     "ai": "^4.1.0",
     "langchain": "^0.3.15",
-    "openai": "^4.0.0",
+    "openai": "^5.0.0",
     "uuid": "^11.0.5",
     "zod": "^3.24.1"
   },

--- a/posthog-ai/src/openai/azure.ts
+++ b/posthog-ai/src/openai/azure.ts
@@ -2,20 +2,26 @@ import OpenAIOrignal, { AzureOpenAI } from 'openai'
 import { PostHog } from 'posthog-node'
 import { v4 as uuidv4 } from 'uuid'
 import { formatResponseOpenAI, MonitoringParams, sendEventToPosthog } from '../utils'
+import type { APIPromise } from 'openai'
+import type { Stream } from 'openai/streaming'
+import type { ParsedResponse } from 'openai/resources/responses/responses'
 
 type ChatCompletion = OpenAIOrignal.ChatCompletion
 type ChatCompletionChunk = OpenAIOrignal.ChatCompletionChunk
 type ChatCompletionCreateParamsBase = OpenAIOrignal.Chat.Completions.ChatCompletionCreateParams
 type ChatCompletionCreateParamsNonStreaming = OpenAIOrignal.Chat.Completions.ChatCompletionCreateParamsNonStreaming
 type ChatCompletionCreateParamsStreaming = OpenAIOrignal.Chat.Completions.ChatCompletionCreateParamsStreaming
-import type { APIPromise, RequestOptions } from 'openai/core'
-import type { Stream } from 'openai/streaming'
+type ResponsesCreateParamsBase = OpenAIOrignal.Responses.ResponseCreateParams
+type ResponsesCreateParamsNonStreaming = OpenAIOrignal.Responses.ResponseCreateParamsNonStreaming
+type ResponsesCreateParamsStreaming = OpenAIOrignal.Responses.ResponseCreateParamsStreaming
 
 interface MonitoringOpenAIConfig {
   apiKey: string
   posthog: PostHog
   baseURL?: string
 }
+
+type RequestOptions = Record<string, any>
 
 export class PostHogAzureOpenAI extends AzureOpenAI {
   private readonly phClient: PostHog
@@ -82,32 +88,30 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
 
     const traceId = posthogTraceId ?? uuidv4()
     const startTime = Date.now()
+
     const parentPromise = super.create(openAIParams, options)
 
     if (openAIParams.stream) {
       return parentPromise.then((value) => {
-        let accumulatedContent = ''
-        let usage: {
-          inputTokens: number
-          outputTokens: number
-          reasoningTokens?: number
-          cacheReadInputTokens?: number
-        } = {
-          inputTokens: 0,
-          outputTokens: 0,
-        }
-        let model = openAIParams.model
         if ('tee' in value) {
           const [stream1, stream2] = value.tee()
           ;(async () => {
             try {
+              let accumulatedContent = ''
+              let usage: {
+                inputTokens?: number
+                outputTokens?: number
+                reasoningTokens?: number
+                cacheReadInputTokens?: number
+              } = {
+                inputTokens: 0,
+                outputTokens: 0,
+              }
+
               for await (const chunk of stream1) {
                 const delta = chunk?.choices?.[0]?.delta?.content ?? ''
                 accumulatedContent += delta
                 if (chunk.usage) {
-                  if (chunk.model != model) {
-                    model = chunk.model
-                  }
                   usage = {
                     inputTokens: chunk.usage.prompt_tokens ?? 0,
                     outputTokens: chunk.usage.completion_tokens ?? 0,
@@ -116,12 +120,13 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                   }
                 }
               }
+
               const latency = (Date.now() - startTime) / 1000
               await sendEventToPosthog({
                 client: this.phClient,
                 distinctId: posthogDistinctId ?? traceId,
                 traceId,
-                model,
+                model: openAIParams.model,
                 provider: 'azure',
                 input: openAIParams.messages,
                 output: [{ content: accumulatedContent, role: 'assistant' }],
@@ -133,23 +138,19 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                 captureImmediate: posthogCaptureImmediate,
               })
             } catch (error: any) {
-              // error handling
               await sendEventToPosthog({
                 client: this.phClient,
                 distinctId: posthogDistinctId ?? traceId,
                 traceId,
-                model,
+                model: openAIParams.model,
                 provider: 'azure',
                 input: openAIParams.messages,
-                output: JSON.stringify(error),
+                output: [],
                 latency: 0,
                 baseURL: (this as any).baseURL ?? '',
                 params: body,
                 httpStatus: error?.status ? error.status : 500,
-                usage: {
-                  inputTokens: 0,
-                  outputTokens: 0,
-                },
+                usage: { inputTokens: 0, outputTokens: 0 },
                 isError: true,
                 error: JSON.stringify(error),
                 captureImmediate: posthogCaptureImmediate,
@@ -167,15 +168,11 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
         async (result) => {
           if ('choices' in result) {
             const latency = (Date.now() - startTime) / 1000
-            let model = openAIParams.model
-            if (result.model != model) {
-              model = result.model
-            }
             await sendEventToPosthog({
               client: this.phClient,
               distinctId: posthogDistinctId ?? traceId,
               traceId,
-              model,
+              model: openAIParams.model,
               provider: 'azure',
               input: openAIParams.messages,
               output: formatResponseOpenAI(result),
@@ -224,4 +221,256 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
   }
 }
 
+export class WrappedResponses extends AzureOpenAI.Responses {
+  private readonly phClient: PostHog
+
+  constructor(client: AzureOpenAI, phClient: PostHog) {
+    super(client)
+    this.phClient = phClient
+  }
+
+  // --- Overload #1: Non-streaming
+  public create(
+    body: ResponsesCreateParamsNonStreaming & MonitoringParams,
+    options?: RequestOptions
+  ): APIPromise<OpenAIOrignal.Responses.Response>
+
+  // --- Overload #2: Streaming  
+  public create(
+    body: ResponsesCreateParamsStreaming & MonitoringParams,
+    options?: RequestOptions
+  ): APIPromise<Stream<OpenAIOrignal.Responses.ResponseStreamEvent>>
+
+  // --- Overload #3: Generic base
+  public create(
+    body: ResponsesCreateParamsBase & MonitoringParams,
+    options?: RequestOptions
+  ): APIPromise<OpenAIOrignal.Responses.Response | Stream<OpenAIOrignal.Responses.ResponseStreamEvent>>
+
+  // --- Implementation Signature
+  public create(
+    body: ResponsesCreateParamsBase & MonitoringParams,
+    options?: RequestOptions
+  ): APIPromise<OpenAIOrignal.Responses.Response | Stream<OpenAIOrignal.Responses.ResponseStreamEvent>> {
+    const {
+      posthogDistinctId,
+      posthogTraceId,
+      posthogProperties,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      posthogPrivacyMode = false,
+      posthogGroups,
+      posthogCaptureImmediate,
+      ...openAIParams
+    } = body
+
+    const traceId = posthogTraceId ?? uuidv4()
+    const startTime = Date.now()
+
+    const parentPromise = super.create(openAIParams, options)
+
+    if (openAIParams.stream) {
+      return parentPromise.then((value) => {
+        if ('tee' in value && typeof (value as any).tee === 'function') {
+          const [stream1, stream2] = (value as any).tee()
+          ;(async () => {
+            try {
+              let finalContent: any[] = []
+              let usage: {
+                inputTokens?: number
+                outputTokens?: number
+                reasoningTokens?: number
+                cacheReadInputTokens?: number
+              } = {
+                inputTokens: 0,
+                outputTokens: 0,
+              }
+
+              for await (const chunk of stream1) {
+                if (chunk.type === 'response.completed' && 'response' in chunk && chunk.response?.output && chunk.response.output.length > 0) {
+                  finalContent = chunk.response.output
+                }
+                if ('usage' in chunk && chunk.usage) {
+                  usage = {
+                    inputTokens: chunk.usage.input_tokens ?? 0,
+                    outputTokens: chunk.usage.output_tokens ?? 0,
+                    reasoningTokens: chunk.usage.output_tokens_details?.reasoning_tokens ?? 0,
+                    cacheReadInputTokens: chunk.usage.input_tokens_details?.cached_tokens ?? 0,
+                  }
+                }
+              }
+
+              const latency = (Date.now() - startTime) / 1000
+              await sendEventToPosthog({
+                client: this.phClient,
+                distinctId: posthogDistinctId ?? traceId,
+                traceId,
+                model: openAIParams.model,
+                provider: 'azure',
+                input: openAIParams.input,
+                output: finalContent,
+                latency,
+                baseURL: (this as any).baseURL ?? '',
+                params: body,
+                httpStatus: 200,
+                usage,
+                captureImmediate: posthogCaptureImmediate,
+              })
+            } catch (error: any) {
+              await sendEventToPosthog({
+                client: this.phClient,
+                distinctId: posthogDistinctId ?? traceId,
+                traceId,
+                model: openAIParams.model,
+                provider: 'azure',
+                input: openAIParams.input,
+                output: [],
+                latency: 0,
+                baseURL: (this as any).baseURL ?? '',
+                params: body,
+                httpStatus: error?.status ? error.status : 500,
+                usage: { inputTokens: 0, outputTokens: 0 },
+                isError: true,
+                error: JSON.stringify(error),
+                captureImmediate: posthogCaptureImmediate,
+              })
+            }
+          })()
+
+          return stream2
+        }
+        return value
+      }) as APIPromise<Stream<OpenAIOrignal.Responses.ResponseStreamEvent>>
+    } else {
+      const wrappedPromise = parentPromise.then(
+        async (result) => {
+          if ('output' in result) {
+            const latency = (Date.now() - startTime) / 1000
+            await sendEventToPosthog({
+              client: this.phClient,
+              distinctId: posthogDistinctId ?? traceId,
+              traceId,
+              model: openAIParams.model,
+              provider: 'azure',
+              input: openAIParams.input,
+              output: result.output,
+              latency,
+              baseURL: (this as any).baseURL ?? '',
+              params: body,
+              httpStatus: 200,
+              usage: {
+                inputTokens: result.usage?.input_tokens ?? 0,
+                outputTokens: result.usage?.output_tokens ?? 0,
+                reasoningTokens: result.usage?.output_tokens_details?.reasoning_tokens ?? 0,
+                cacheReadInputTokens: result.usage?.input_tokens_details?.cached_tokens ?? 0,
+              },
+              captureImmediate: posthogCaptureImmediate,
+            })
+          }
+          return result
+        },
+        async (error: any) => {
+          await sendEventToPosthog({
+            client: this.phClient,
+            distinctId: posthogDistinctId ?? traceId,
+            traceId,
+            model: openAIParams.model,
+            provider: 'azure',
+            input: openAIParams.input,
+            output: [],
+            latency: 0,
+            baseURL: (this as any).baseURL ?? '',
+            params: body,
+            httpStatus: error?.status ? error.status : 500,
+            usage: {
+              inputTokens: 0,
+              outputTokens: 0,
+            },
+            isError: true,
+            error: JSON.stringify(error),
+            captureImmediate: posthogCaptureImmediate,
+          })
+          throw error
+        }
+      ) as APIPromise<OpenAIOrignal.Responses.Response>
+
+      return wrappedPromise
+    }
+  }
+
+  public parse<Params extends OpenAIOrignal.Responses.ResponseCreateParams, ParsedT = any>(
+    body: Params & MonitoringParams,
+    options?: RequestOptions
+  ): APIPromise<ParsedResponse<ParsedT>> {
+    const {
+      posthogDistinctId,
+      posthogTraceId,
+      posthogProperties,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      posthogPrivacyMode = false,
+      posthogGroups,
+      posthogCaptureImmediate,
+      ...openAIParams
+    } = body
+
+    const traceId = posthogTraceId ?? uuidv4()
+    const startTime = Date.now()
+
+    const parentPromise = super.parse(openAIParams, options)
+
+    const wrappedPromise = parentPromise.then(
+      async (result) => {
+        const latency = (Date.now() - startTime) / 1000
+        await sendEventToPosthog({
+          client: this.phClient,
+          distinctId: posthogDistinctId ?? traceId,
+          traceId,
+          model: openAIParams.model,
+          provider: 'azure',
+          input: openAIParams.input,
+          output: result.output,
+          latency,
+          baseURL: (this as any).baseURL ?? '',
+          params: body,
+          httpStatus: 200,
+          usage: {
+            inputTokens: result.usage?.input_tokens ?? 0,
+            outputTokens: result.usage?.output_tokens ?? 0,
+            reasoningTokens: result.usage?.output_tokens_details?.reasoning_tokens ?? 0,
+            cacheReadInputTokens: result.usage?.input_tokens_details?.cached_tokens ?? 0,
+          },
+          captureImmediate: posthogCaptureImmediate,
+        })
+        return result
+      },
+      async (error: any) => {
+        await sendEventToPosthog({
+          client: this.phClient,
+          distinctId: posthogDistinctId ?? traceId,
+          traceId,
+          model: openAIParams.model,
+          provider: 'azure',
+          input: openAIParams.input,
+          output: [],
+          latency: 0,
+          baseURL: (this as any).baseURL ?? '',
+          params: body,
+          httpStatus: error?.status ? error.status : 500,
+          usage: {
+            inputTokens: 0,
+            outputTokens: 0,
+          },
+          isError: true,
+          error: JSON.stringify(error),
+          captureImmediate: posthogCaptureImmediate,
+        })
+        throw error
+      }
+    )
+
+    return wrappedPromise as APIPromise<ParsedResponse<ParsedT>>
+  }
+}
+
 export default PostHogAzureOpenAI
+
+export { PostHogAzureOpenAI as OpenAI }

--- a/posthog-ai/src/openai/index.ts
+++ b/posthog-ai/src/openai/index.ts
@@ -2,14 +2,18 @@ import OpenAIOrignal, { ClientOptions } from 'openai'
 import { PostHog } from 'posthog-node'
 import { v4 as uuidv4 } from 'uuid'
 import { formatResponseOpenAI, MonitoringParams, sendEventToPosthog } from '../utils'
+import type { APIPromise } from 'openai'
+import type { Stream } from 'openai/streaming'
+import type { ParsedResponse } from 'openai/resources/responses/responses'
 
 type ChatCompletion = OpenAIOrignal.ChatCompletion
 type ChatCompletionChunk = OpenAIOrignal.ChatCompletionChunk
 type ChatCompletionCreateParamsBase = OpenAIOrignal.Chat.Completions.ChatCompletionCreateParams
 type ChatCompletionCreateParamsNonStreaming = OpenAIOrignal.Chat.Completions.ChatCompletionCreateParamsNonStreaming
 type ChatCompletionCreateParamsStreaming = OpenAIOrignal.Chat.Completions.ChatCompletionCreateParamsStreaming
-import type { APIPromise, RequestOptions } from 'openai/core'
-import type { Stream } from 'openai/streaming'
+type ResponsesCreateParamsBase = OpenAIOrignal.Responses.ResponseCreateParams
+type ResponsesCreateParamsNonStreaming = OpenAIOrignal.Responses.ResponseCreateParamsNonStreaming
+type ResponsesCreateParamsStreaming = OpenAIOrignal.Responses.ResponseCreateParamsStreaming
 
 interface MonitoringOpenAIConfig extends ClientOptions {
   apiKey: string
@@ -17,15 +21,19 @@ interface MonitoringOpenAIConfig extends ClientOptions {
   baseURL?: string
 }
 
+type RequestOptions = Record<string, any>
+
 export class PostHogOpenAI extends OpenAIOrignal {
   private readonly phClient: PostHog
   public chat: WrappedChat
+  public responses: WrappedResponses
 
   constructor(config: MonitoringOpenAIConfig) {
     const { posthog, ...openAIConfig } = config
     super(openAIConfig)
     this.phClient = posthog
     this.chat = new WrappedChat(this, this.phClient)
+    this.responses = new WrappedResponses(this, this.phClient)
   }
 }
 
@@ -211,6 +219,267 @@ export class WrappedCompletions extends OpenAIOrignal.Chat.Completions {
       ) as APIPromise<ChatCompletion>
 
       return wrappedPromise
+    }
+  }
+}
+
+export class WrappedResponses extends OpenAIOrignal.Responses {
+  private readonly phClient: PostHog
+
+  constructor(client: OpenAIOrignal, phClient: PostHog) {
+    super(client)
+    this.phClient = phClient
+  }
+
+  // --- Overload #1: Non-streaming
+  public create(
+    body: ResponsesCreateParamsNonStreaming & MonitoringParams,
+    options?: RequestOptions
+  ): APIPromise<OpenAIOrignal.Responses.Response>
+
+  // --- Overload #2: Streaming  
+  public create(
+    body: ResponsesCreateParamsStreaming & MonitoringParams,
+    options?: RequestOptions
+  ): APIPromise<Stream<OpenAIOrignal.Responses.ResponseStreamEvent>>
+
+  // --- Overload #3: Generic base
+  public create(
+    body: ResponsesCreateParamsBase & MonitoringParams,
+    options?: RequestOptions
+  ): APIPromise<OpenAIOrignal.Responses.Response | Stream<OpenAIOrignal.Responses.ResponseStreamEvent>>
+
+  // --- Implementation Signature
+  public create(
+    body: ResponsesCreateParamsBase & MonitoringParams,
+    options?: RequestOptions
+  ): APIPromise<OpenAIOrignal.Responses.Response | Stream<OpenAIOrignal.Responses.ResponseStreamEvent>> {
+    const {
+      posthogDistinctId,
+      posthogTraceId,
+      posthogProperties,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      posthogPrivacyMode = false,
+      posthogGroups,
+      posthogCaptureImmediate,
+      ...openAIParams
+    } = body
+
+    const traceId = posthogTraceId ?? uuidv4()
+    const startTime = Date.now()
+
+    const parentPromise = super.create(openAIParams, options)
+
+    if (openAIParams.stream) {
+      return parentPromise.then((value) => {
+        if ('tee' in value && typeof (value as any).tee === 'function') {
+          const [stream1, stream2] = (value as any).tee()
+          ;(async () => {
+            try {
+              let finalContent: any[] = []
+              let usage: {
+                inputTokens?: number
+                outputTokens?: number
+                reasoningTokens?: number
+                cacheReadInputTokens?: number
+              } = {
+                inputTokens: 0,
+                outputTokens: 0,
+              }
+
+              for await (const chunk of stream1) {
+                if (chunk.type === 'response.completed' && 'response' in chunk && chunk.response?.output && chunk.response.output.length > 0) {
+                  finalContent = chunk.response.output
+                }
+                if ('response' in chunk && chunk.response?.usage) {
+                  usage = {
+                    inputTokens: chunk.response.usage.input_tokens ?? 0,
+                    outputTokens: chunk.response.usage.output_tokens ?? 0,
+                    reasoningTokens: chunk.response.usage.output_tokens_details?.reasoning_tokens ?? 0,
+                    cacheReadInputTokens: chunk.response.usage.input_tokens_details?.cached_tokens ?? 0,
+                  }
+                }
+              }
+
+              const latency = (Date.now() - startTime) / 1000
+              await sendEventToPosthog({
+                client: this.phClient,
+                distinctId: posthogDistinctId ?? traceId,
+                traceId,
+                model: openAIParams.model,
+                provider: 'openai',
+                input: openAIParams.input,
+                output: finalContent,
+                latency,
+                baseURL: (this as any).baseURL ?? '',
+                params: body,
+                httpStatus: 200,
+                usage,
+                captureImmediate: posthogCaptureImmediate,
+              })
+            } catch (error: any) {
+              await sendEventToPosthog({
+                client: this.phClient,
+                distinctId: posthogDistinctId ?? traceId,
+                traceId,
+                model: openAIParams.model,
+                provider: 'openai',
+                input: openAIParams.input,
+                output: [],
+                latency: 0,
+                baseURL: (this as any).baseURL ?? '',
+                params: body,
+                httpStatus: error?.status ? error.status : 500,
+                usage: { inputTokens: 0, outputTokens: 0 },
+                isError: true,
+                error: JSON.stringify(error),
+                captureImmediate: posthogCaptureImmediate,
+              })
+            }
+          })()
+
+          return stream2
+        }
+        return value
+      }) as APIPromise<Stream<OpenAIOrignal.Responses.ResponseStreamEvent>>
+    } else {
+      const wrappedPromise = parentPromise.then(
+        async (result) => {
+          if ('output' in result) {
+            const latency = (Date.now() - startTime) / 1000
+            await sendEventToPosthog({
+              client: this.phClient,
+              distinctId: posthogDistinctId ?? traceId,
+              traceId,
+              model: openAIParams.model,
+              provider: 'openai',
+              input: openAIParams.input,
+              output: result.output,
+              latency,
+              baseURL: (this as any).baseURL ?? '',
+              params: body,
+              httpStatus: 200,
+              usage: {
+                inputTokens: result.usage?.input_tokens ?? 0,
+                outputTokens: result.usage?.output_tokens ?? 0,
+                reasoningTokens: result.usage?.output_tokens_details?.reasoning_tokens ?? 0,
+                cacheReadInputTokens: result.usage?.input_tokens_details?.cached_tokens ?? 0,
+              },
+              captureImmediate: posthogCaptureImmediate,
+            })
+          }
+          return result
+        },
+        async (error: any) => {
+          await sendEventToPosthog({
+            client: this.phClient,
+            distinctId: posthogDistinctId ?? traceId,
+            traceId,
+            model: openAIParams.model,
+            provider: 'openai',
+            input: openAIParams.input,
+            output: [],
+            latency: 0,
+            baseURL: (this as any).baseURL ?? '',
+            params: body,
+            httpStatus: error?.status ? error.status : 500,
+            usage: {
+              inputTokens: 0,
+              outputTokens: 0,
+            },
+            isError: true,
+            error: JSON.stringify(error),
+            captureImmediate: posthogCaptureImmediate,
+          })
+          throw error
+        }
+      ) as APIPromise<OpenAIOrignal.Responses.Response>
+
+      return wrappedPromise
+    }
+  }
+
+  public parse<Params extends ResponsesCreateParamsBase, ParsedT = any>(
+    body: Params & MonitoringParams,
+    options?: RequestOptions
+  ): APIPromise<ParsedResponse<ParsedT>> {
+    const {
+      posthogDistinctId,
+      posthogTraceId,
+      posthogProperties,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      posthogPrivacyMode = false,
+      posthogGroups,
+      posthogCaptureImmediate,
+      ...openAIParams
+    } = body
+
+    const traceId = posthogTraceId ?? uuidv4()
+    const startTime = Date.now()
+
+    // Create a temporary instance that bypasses our wrapped create method
+    const originalCreate = super.create.bind(this)
+    const originalSelf = this as any
+    const tempCreate = originalSelf.create
+    originalSelf.create = originalCreate
+
+    try {
+      const parentPromise = super.parse(openAIParams, options)
+
+      const wrappedPromise = parentPromise.then(
+        async (result) => {
+          const latency = (Date.now() - startTime) / 1000
+          await sendEventToPosthog({
+            client: this.phClient,
+            distinctId: posthogDistinctId ?? traceId,
+            traceId,
+            model: openAIParams.model,
+            provider: 'openai',
+            input: openAIParams.input,
+            output: result.output,
+            latency,
+            baseURL: (this as any).baseURL ?? '',
+            params: body,
+            httpStatus: 200,
+            usage: {
+              inputTokens: result.usage?.input_tokens ?? 0,
+              outputTokens: result.usage?.output_tokens ?? 0,
+              reasoningTokens: result.usage?.output_tokens_details?.reasoning_tokens ?? 0,
+              cacheReadInputTokens: result.usage?.input_tokens_details?.cached_tokens ?? 0,
+            },
+            captureImmediate: posthogCaptureImmediate,
+          })
+          return result
+        },
+        async (error: any) => {
+          await sendEventToPosthog({
+            client: this.phClient,
+            distinctId: posthogDistinctId ?? traceId,
+            traceId,
+            model: openAIParams.model,
+            provider: 'openai',
+            input: openAIParams.input,
+            output: [],
+            latency: 0,
+            baseURL: (this as any).baseURL ?? '',
+            params: body,
+            httpStatus: error?.status ? error.status : 500,
+            usage: {
+              inputTokens: 0,
+              outputTokens: 0,
+            },
+            isError: true,
+            error: JSON.stringify(error),
+            captureImmediate: posthogCaptureImmediate,
+          })
+          throw error
+        }
+      )
+
+      return wrappedPromise as APIPromise<ParsedResponse<ParsedT>>
+    } finally {
+      // Restore our wrapped create method
+      originalSelf.create = tempCreate
     }
   }
 }

--- a/posthog-ai/src/utils.ts
+++ b/posthog-ai/src/utils.ts
@@ -5,6 +5,7 @@ import AnthropicOriginal from '@anthropic-ai/sdk'
 
 type ChatCompletionCreateParamsBase = OpenAIOrignal.Chat.Completions.ChatCompletionCreateParams
 type MessageCreateParams = AnthropicOriginal.Messages.MessageCreateParams
+type ResponseCreateParams = OpenAIOrignal.Responses.ResponseCreateParams
 
 // limit large outputs by truncating to 200kb (approx 200k bytes)
 export const MAX_OUTPUT_SIZE = 200000
@@ -28,7 +29,7 @@ export interface CostOverride {
 }
 
 export const getModelParams = (
-  params: ((ChatCompletionCreateParamsBase | MessageCreateParams) & MonitoringParams) | null
+  params: ((ChatCompletionCreateParamsBase | MessageCreateParams | ResponseCreateParams) & MonitoringParams) | null
 ): Record<string, any> => {
   if (!params) {
     return {}
@@ -178,7 +179,7 @@ export type SendEventToPosthogParams = {
     cacheReadInputTokens?: any
     cacheCreationInputTokens?: any
   }
-  params: (ChatCompletionCreateParamsBase | MessageCreateParams) & MonitoringParams
+  params: (ChatCompletionCreateParamsBase | MessageCreateParams | ResponseCreateParams) & MonitoringParams
   isError?: boolean
   error?: string
   tools?: any

--- a/posthog-ai/tests/openai.test.ts
+++ b/posthog-ai/tests/openai.test.ts
@@ -3,7 +3,7 @@ import PostHogOpenAI from '../src/openai'
 import openaiModule from 'openai'
 
 let mockOpenAiChatResponse: any = {}
-let mockOpenAiEmbeddingResponse: any = {}
+let mockOpenAiParsedResponse: any = {}
 
 jest.mock('posthog-node', () => {
   return {
@@ -11,7 +11,7 @@ jest.mock('posthog-node', () => {
       return {
         capture: jest.fn(),
         captureImmediate: jest.fn(),
-        privacyMode: false,
+        privacy_mode: false,
       }
     }),
   }
@@ -36,10 +36,20 @@ jest.mock('openai', () => {
     static Completions = MockCompletions
   }
 
+  // Mock Responses class
+  class MockResponses {
+    constructor() {}
+    create = jest.fn()
+  }
+  
+  // Add parse to prototype instead of instance
+  ;(MockResponses.prototype as any).parse = jest.fn()
+
   // Mock OpenAI class
   class MockOpenAI {
     chat: any
     embeddings: any
+    responses: any
     constructor() {
       this.chat = {
         completions: {
@@ -49,8 +59,12 @@ jest.mock('openai', () => {
       this.embeddings = {
         create: jest.fn(),
       }
+      this.responses = {
+        create: jest.fn(),
+      }
     }
     static Chat = MockChat
+    static Responses = MockResponses
   }
 
   return {
@@ -58,6 +72,7 @@ jest.mock('openai', () => {
     default: MockOpenAI,
     OpenAI: MockOpenAI,
     Chat: MockChat,
+    Responses: MockResponses,
   }
 })
 
@@ -109,25 +124,39 @@ describe('PostHogOpenAI - Jest test suite', () => {
       },
     }
 
-    // Some default embedding mock
-    mockOpenAiEmbeddingResponse = {
-      data: [
+    // Some default parsed response mock
+    mockOpenAiParsedResponse = {
+      id: 'test-parsed-response-id',
+      model: 'gpt-4o-2024-08-06',
+      object: 'response',
+      created_at: Date.now(),
+      status: 'completed',
+      output: [
         {
-          object: 'embedding',
-          index: 0,
-          embedding: [0.1, 0.2, 0.3],
+          type: 'output_text',
+          text: '{"name": "Science Fair", "date": "Friday", "participants": ["Alice", "Bob"]}',
         },
       ],
-      model: 'text-embedding-3-small',
-      object: 'list',
+      output_parsed: {
+        name: 'Science Fair',
+        date: 'Friday',
+        participants: ['Alice', 'Bob'],
+      },
       usage: {
-        prompt_tokens: 10,
-        total_tokens: 10,
+        input_tokens: 15,
+        output_tokens: 20,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 5 },
+        total_tokens: 35,
       },
     }
 
     const ChatMock: any = openaiModule.Chat
     ;(ChatMock.Completions as any).prototype.create = jest.fn().mockResolvedValue(mockOpenAiChatResponse)
+    
+    // Mock responses.parse using the same pattern as chat completions
+    const ResponsesMock: any = openaiModule.Responses
+    ResponsesMock.prototype.parse.mockResolvedValue(mockOpenAiParsedResponse)
   })
 
   // Wrap each test with conditional skip
@@ -163,38 +192,6 @@ describe('PostHogOpenAI - Jest test suite', () => {
     expect(typeof properties['$ai_latency']).toBe('number')
   })
 
-  conditionalTest('embeddings', async () => {
-    // Since embeddings calls are not implemented in the snippet by default,
-    // we'll demonstrate how you *would* do it if WrappedEmbeddings is used.
-    // Let's override the internal embeddings to return our mock.
-    const mockEmbeddingsCreate = jest.fn().mockResolvedValue(mockOpenAiEmbeddingResponse)
-    ;(client as any).embeddings = {
-      create: mockEmbeddingsCreate,
-    }
-
-    const response = await (client as any).embeddings.create({
-      model: 'text-embedding-3-small',
-      input: 'Hello world',
-      posthog_distinct_id: 'test-id',
-      posthog_properties: { foo: 'bar' },
-    })
-
-    expect(response).toEqual(mockOpenAiEmbeddingResponse)
-    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
-
-    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
-    const { distinctId, event, properties } = captureArgs[0]
-
-    expect(distinctId).toBe('test-id')
-    expect(event).toBe('$ai_embedding')
-    expect(properties['$ai_provider']).toBe('openai')
-    expect(properties['$ai_model']).toBe('text-embedding-3-small')
-    expect(properties['$ai_input']).toBe('Hello world')
-    expect(properties['$ai_input_tokens']).toBe(10)
-    expect(properties['$ai_http_status']).toBe(200)
-    expect(properties['foo']).toBe('bar')
-    expect(typeof properties['$ai_latency']).toBe('number')
-  })
 
   conditionalTest('groups', async () => {
     await client.chat.completions.create({
@@ -269,9 +266,6 @@ describe('PostHogOpenAI - Jest test suite', () => {
       max_completion_tokens: 100,
       stream: false,
     })
-    expect(properties['$ai_temperature']).toBe(0.5)
-    expect(properties['$ai_max_tokens']).toBe(100)
-    expect(properties['$ai_stream']).toBe(false)
     expect(properties['foo']).toBe('bar')
   })
 
@@ -323,5 +317,57 @@ describe('PostHogOpenAI - Jest test suite', () => {
     // captureImmediate should be called once, and capture should not be called
     expect(mockPostHogClient.captureImmediate).toHaveBeenCalledTimes(1)
     expect(mockPostHogClient.capture).toHaveBeenCalledTimes(0)
+  })
+
+  conditionalTest('responses parse', async () => {
+    const response = await client.responses.parse({
+      model: 'gpt-4o-2024-08-06',
+      input: [
+        { role: 'system', content: 'Extract the event information.' },
+        { role: 'user', content: 'Alice and Bob are going to a science fair on Friday.' },
+      ],
+      text: {
+        format: {
+          type: 'json_object',
+          json_schema: {
+            name: 'event',
+            schema: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                date: { type: 'string' },
+                participants: { type: 'array', items: { type: 'string' } },
+              },
+              required: ['name', 'date', 'participants'],
+            },
+          },
+        },
+      },
+      posthogDistinctId: 'test-id',
+      posthogProperties: { foo: 'bar' },
+    })
+
+    expect(response).toEqual(mockOpenAiParsedResponse)
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+
+    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    const { distinctId, event, properties } = captureArgs[0]
+
+    expect(distinctId).toBe('test-id')
+    expect(event).toBe('$ai_generation')
+    expect(properties['$ai_provider']).toBe('openai')
+    expect(properties['$ai_model']).toBe('gpt-4o-2024-08-06')
+    expect(properties['$ai_input']).toEqual([
+      { role: 'system', content: 'Extract the event information.' },
+      { role: 'user', content: 'Alice and Bob are going to a science fair on Friday.' },
+    ])
+    expect(properties['$ai_output_choices']).toEqual(mockOpenAiParsedResponse.output)
+    expect(properties['$ai_input_tokens']).toBe(15)
+    expect(properties['$ai_output_tokens']).toBe(20)
+    expect(properties['$ai_reasoning_tokens']).toBe(5)
+    expect(properties['$ai_cache_read_input_tokens']).toBeUndefined()
+    expect(properties['$ai_http_status']).toBe(200)
+    expect(properties['foo']).toBe('bar')
+    expect(typeof properties['$ai_latency']).toBe('number')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8749,19 +8749,6 @@ open@^8.0.4, open@^8.3.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-openai@^4.0.0:
-  version "4.82.0"
-  resolved "https://registry.yarnpkg.com/openai/-/openai-4.82.0.tgz#9a28ba6552f94639c2de4278255ad669940b6267"
-  integrity sha512-1bTxOVGZuVGsKKUWbh3BEwX1QxIXUftJv+9COhhGGVDTFwiaOd4gWsMynF2ewj1mg6by3/O+U8+EEHpWRdPaJg==
-  dependencies:
-    "@types/node" "^18.11.18"
-    "@types/node-fetch" "^2.6.4"
-    abort-controller "^3.0.0"
-    agentkeepalive "^4.2.1"
-    form-data-encoder "1.7.2"
-    formdata-node "^4.3.2"
-    node-fetch "^2.6.7"
-
 openai@^4.77.0:
   version "4.83.0"
   resolved "https://registry.yarnpkg.com/openai/-/openai-4.83.0.tgz#87edfebecf8a4dc2317269dd704cf0ebd9f11979"
@@ -8774,6 +8761,11 @@ openai@^4.77.0:
     form-data-encoder "1.7.2"
     formdata-node "^4.3.2"
     node-fetch "^2.6.7"
+
+openai@^5.0.0, openai@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-5.3.0.tgz#7d4d48f1f0beb011f66fd0c291749e35465c4b52"
+  integrity sha512-VIKmoF7y4oJCDOwP/oHXGzM69+x0dpGFmN9QmYO+uPbLFOmmnwO+x1GbsgUtI+6oraxomGZ566Y421oYVu191w==
 
 openapi-types@^12.1.3:
   version "12.1.3"


### PR DESCRIPTION
## Problem

We needed to add the openAI reponses api to the typescript AI SDK similar to the python one

## Changes

Added openAI responses API and Parse endpoint

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [X] Minor
- [ ] Patch

### Libraries affected

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [X] posthog-ai
- [ ] posthog-react-native

