### PR TITLE
fix(flags): Handle double-encoded JSON response

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 5.1.1 - 2025-06-16
+
+1. fix: Handle double-encoded JSON payloads from the remote config endpoint
+
 # 5.1.0 - 2025-06-12
 
 1. chore: use `/flags?v=2&config=true` instead of `/decide?v=4` for the flag evaluation backend

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/src/client.ts
+++ b/posthog-node/src/client.ts
@@ -509,7 +509,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     }
 
     const parsed = await response.json()
-    // The payload from the endpoint is stored as a JSON encoded string. So when we return 
+    // The payload from the endpoint is stored as a JSON encoded string. So when we return
     // it, it's effectively double encoded. As far as we know, we should never get single-encoded
     // JSON, but we'll be defensive here just in case.
     if (typeof parsed === 'string') {

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -1358,7 +1358,7 @@ describe('PostHog Node.js', () => {
     beforeEach(() => {
       // Reset the mock for each test
       mockedFetch.mockClear()
-      
+
       // Initialize posthog with personalApiKey to enable feature flags poller
       posthog = new PostHog('TEST_API_KEY', {
         host: 'http://example.com',
@@ -1392,20 +1392,20 @@ describe('PostHog Node.js', () => {
     })
 
     it('should handle double-encoded JSON payload', async () => {
-      const doubleEncodedPayload = "{ \"foo\":[\"bar\",\"baz\"]}"
+      const doubleEncodedPayload = '{ "foo":["bar","baz"]}'
       requestRemoteConfigPayloadSpy.mockResolvedValue({
         json: () => Promise.resolve(doubleEncodedPayload),
       })
 
       const payload = await posthog.getRemoteConfigPayload('test-flag')
       expect(payload).toEqual({
-        foo: ["bar", "baz"]
+        foo: ['bar', 'baz'],
       })
       expect(requestRemoteConfigPayloadSpy).toHaveBeenCalledWith('test-flag')
     })
 
     it('should handle simple JSON payload', async () => {
-      const simplePayload = { bar: "baz" }
+      const simplePayload = { foo: ['bar', 'baz'] }
       requestRemoteConfigPayloadSpy.mockResolvedValue({
         json: () => Promise.resolve(simplePayload),
       })


### PR DESCRIPTION
## Problem

See https://posthoghelp.zendesk.com/agent/tickets/32276 for the issue.

## Changes

If the response we get from the endpoint is a string, we try parsing as JSON again.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native

### Changelog notes

- fix: Handle double-encoded JSON payloads from the remote config endpoint
