### PR TITLE
add missing `license` field to package.json files

### DIFF
--- a/posthog-core/package.json
+++ b/posthog-core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "posthog-core",
   "version": "2.2.0",
+  "license": "MIT",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,7 @@
 {
   "name": "posthog-react-native",
   "version": "4.1.0",
+  "license": "MIT",
   "main": "lib/posthog-react-native/index.js",
   "files": [
     "lib/"

--- a/posthog-web/package.json
+++ b/posthog-web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "posthog-js-lite",
   "version": "4.1.0",
+  "license": "MIT",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

People who are creating a bill of materials (BOM) for their project often analyse the package.json files of their dependencies to see what the licenses of the libraries they're depending on, so it's useful to them to have `license` fields in `package.json` files of distributed packages.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

I've added `"license": "MIT"` to `package.json` files that didn't have it. This matches the license of the repository and the `license` field in some of the other `package.json` files.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-core
- [x] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [x] posthog-react-native

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for package.json `license` field.
