### PR TITLE
fix(nextjs): add local bin folder to PATH

### DIFF
--- a/posthog-nextjs/src/config.ts
+++ b/posthog-nextjs/src/config.ts
@@ -36,15 +36,16 @@ export function withPostHogConfig(userNextConfig: UserProvidedConfig, posthogCon
   return async (phase: string, { defaultConfig }: { defaultConfig: NextConfig }) => {
     const { webpack: userWebPackConfig, ...userConfig } = await resolveUserConfig(userNextConfig, phase, defaultConfig)
     const defaultWebpackConfig = userWebPackConfig || ((config: any) => config)
+    const sourceMapEnabled = posthogNextConfigComplete.sourcemaps.enabled
     return {
       ...userConfig,
-      productionBrowserSourceMaps: posthogNextConfigComplete.sourcemaps.enabled,
+      productionBrowserSourceMaps: sourceMapEnabled,
       webpack: (config: any, options: any) => {
         const webpackConfig = defaultWebpackConfig(config, options)
-        if (webpackConfig && options.isServer && posthogNextConfigComplete.sourcemaps.enabled) {
+        if (webpackConfig && options.isServer && sourceMapEnabled) {
           webpackConfig.devtool = 'source-map'
         }
-        if (posthogNextConfigComplete.sourcemaps.enabled) {
+        if (sourceMapEnabled) {
           webpackConfig.plugins = webpackConfig.plugins || []
           webpackConfig.plugins.push(
             new SourcemapWebpackPlugin(posthogNextConfigComplete, options.isServer, options.nextRuntime)

--- a/posthog-nextjs/src/webpack-plugin.ts
+++ b/posthog-nextjs/src/webpack-plugin.ts
@@ -1,5 +1,6 @@
 import { PostHogNextConfigComplete } from './config'
 import { spawn } from 'child_process'
+import path from 'path'
 
 type NextRuntime = 'edge' | 'nodejs' | undefined
 
@@ -73,9 +74,10 @@ export class SourcemapWebpackPlugin {
 }
 
 async function callPosthogCli(args: string[], env: NodeJS.ProcessEnv, verbose: boolean): Promise<void> {
-  const child = spawn('npx', ['@posthog/cli', ...args], {
+  const cwd = path.resolve('.')
+  const child = spawn('posthog-cli', [...args], {
     stdio: verbose ? 'inherit' : 'ignore',
-    env: env,
+    env: addLocalPath(env ?? process.env, cwd),
   })
 
   await new Promise<void>((resolve, reject) => {
@@ -86,8 +88,22 @@ async function callPosthogCli(args: string[], env: NodeJS.ProcessEnv, verbose: b
         reject(new Error(`Command failed with code ${code}`))
       }
     })
+
     child.on('error', (error) => {
       reject(error)
     })
   })
 }
+
+const addLocalPath = ({ Path = '', PATH = Path, ...env }: NodeJS.ProcessEnv, cwd: string) => {
+  const pathParts = PATH.split(path.delimiter)
+  const localPaths = getLocalPaths([], path.resolve(cwd))
+    .map((localPath: string) => path.join(localPath, 'node_modules/.bin'))
+    .filter((localPath: string) => !pathParts.includes(localPath))
+  return { ...env, PATH: [...localPaths, PATH].filter(Boolean).join(path.delimiter) }
+}
+
+const getLocalPaths = (localPaths: string[], localPath: string): string[] =>
+  localPaths.at(-1) === localPath
+    ? localPaths
+    : getLocalPaths([...localPaths, localPath], path.resolve(localPath, '..'))


### PR DESCRIPTION
## Problem

- Depending on installation, `posthog-cli` might not be found

## Changes

- add node_modules/.bin to PATH to search for installed posthog-cli

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native
- [ ] posthog-nextjs

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Improve `posthog-cli` resolution
