### PR TITLE
fix(nextjs): do not delete server sourcemaps

### DIFF
--- a/posthog-nextjs/src/webpack-plugin.ts
+++ b/posthog-nextjs/src/webpack-plugin.ts
@@ -60,7 +60,7 @@ export class SourcemapWebpackPlugin {
     if (this.posthogOptions.sourcemaps.version) {
       cliOptions.push('--version', this.posthogOptions.sourcemaps.version)
     }
-    if (this.posthogOptions.sourcemaps.deleteAfterUpload) {
+    if (this.posthogOptions.sourcemaps.deleteAfterUpload && !this.isServer) {
       cliOptions.push('--delete-after')
     }
     // Add env variables


### PR DESCRIPTION
## Problem

- During deployment vercel is expecting server sourcemaps but we delete them by default. There is no need to do that as they are not served in any case.

## Changes

- Only delete client sourcemaps. Tested using `vercel build`

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native
- [x] posthog-nextjs

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Fix vercel deployment
