### PR TITLE
chore: force session replay to use string values for sessionId, distinctId and anonymousId

### DIFF
--- a/examples/example-expo-latest/package.json
+++ b/examples/example-expo-latest/package.json
@@ -21,7 +21,7 @@
     "expo-localization": "~15.0.3",
     "expo-status-bar": "~1.12.1",
     "posthog-react-native": "file:.yalc/posthog-react-native",
-    "posthog-react-native-session-replay": "^1.1.0",
+    "posthog-react-native-session-replay": "^1.1.1",
     "react": "18.2.0",
     "react-native": "0.74.5",
     "react-native-webview": "^13.12.4",

--- a/examples/example_rn/package.json
+++ b/examples/example_rn/package.json
@@ -25,7 +25,7 @@
     "react-native-device-info": "^10.12.0",
     "react-native-navigation": "^7.37.2",
     "react-native-localize": "^3.0.0",
-    "posthog-react-native-session-replay": "^1.1.0"
+    "posthog-react-native-session-replay": "^1.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Next
 
+# 4.1.2 - 2025-06-24
+
+## Fixed
+
+1. Force session replay to use string values for sessionId, distinctId and anonymousId
+
 # 4.1.1 - 2025-06-23
 
 ## Fixed

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "license": "MIT",
   "main": "lib/posthog-react-native/index.js",
   "files": [
@@ -35,7 +35,7 @@
     "react-native-device-info": "^10.3.0",
     "react-native-navigation": "^6.0.0",
     "react-native-localize": "^3.0.0",
-    "posthog-react-native-session-replay": "^1.1.0",
+    "posthog-react-native-session-replay": "^1.1.1",
     "react-native-safe-area-context": "^4.10.1",
     "react-native-svg": "^15.0.0"
   },
@@ -49,7 +49,7 @@
     "react-native-device-info": ">= 10.0.0",
     "react-native-navigation": ">= 6.0.0",
     "react-native-localize": ">= 3.0.0",
-    "posthog-react-native-session-replay": ">= 1.1.0",
+    "posthog-react-native-session-replay": ">= 1.1.1",
     "react-native-safe-area-context": ">= 4.0.0",
     "react-native-svg": ">= 15.0.0"
   },

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -301,7 +301,10 @@ export class PostHog extends PostHogCore {
         const anonymousId = this.getAnonymousId()
         OptionalReactNativeSessionReplay.identify(String(distinctId), String(anonymousId))
         this.logMsgIfDebug(() =>
-          console.info('PostHog Debug', `Session replay identified with distinctId ${distinctId} and anonymousId ${anonymousId}.`)
+          console.info(
+            'PostHog Debug',
+            `Session replay identified with distinctId ${distinctId} and anonymousId ${anonymousId}.`
+          )
         )
       } catch (e) {
         this.logMsgIfDebug(() => console.error('PostHog Debug', `Session replay failed to identify: ${e}.`))

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -298,9 +298,10 @@ export class PostHog extends PostHogCore {
     if (this._isEnableSessionReplay() && OptionalReactNativeSessionReplay) {
       try {
         distinctId = distinctId || previousDistinctId
-        OptionalReactNativeSessionReplay.identify(distinctId, this.getAnonymousId())
+        const anonymousId = this.getAnonymousId()
+        OptionalReactNativeSessionReplay.identify(String(distinctId), String(anonymousId))
         this.logMsgIfDebug(() =>
-          console.info('PostHog Debug', `Session replay identified with distinctId ${distinctId}.`)
+          console.info('PostHog Debug', `Session replay identified with distinctId ${distinctId} and anonymousId ${anonymousId}.`)
         )
       } catch (e) {
         this.logMsgIfDebug(() => console.error('PostHog Debug', `Session replay failed to identify: ${e}.`))
@@ -462,7 +463,7 @@ export class PostHog extends PostHogCore {
         try {
           if (!(await OptionalReactNativeSessionReplay.isEnabled())) {
             await OptionalReactNativeSessionReplay.start(
-              sessionId,
+              String(sessionId),
               sdkOptions,
               sdkReplayConfig,
               cachedSessionReplayConfig

--- a/posthog-react-native/src/posthog-rn.ts
+++ b/posthog-react-native/src/posthog-rn.ts
@@ -258,7 +258,7 @@ export class PostHog extends PostHogCore {
     if (sessionId.length > 0 && this._currentSessionId && sessionId !== this._currentSessionId) {
       if (OptionalReactNativeSessionReplay) {
         try {
-          this._resetSessionId(OptionalReactNativeSessionReplay, sessionId)
+          this._resetSessionId(OptionalReactNativeSessionReplay, String(sessionId))
           this.logMsgIfDebug(() =>
             console.info('PostHog Debug', `sessionId rotated from ${this._currentSessionId} to ${sessionId}.`)
           )
@@ -473,7 +473,7 @@ export class PostHog extends PostHogCore {
             )
           } else {
             // if somehow the SDK is already enabled with a different sessionId, we reset it
-            this._resetSessionId(OptionalReactNativeSessionReplay, sessionId)
+            this._resetSessionId(OptionalReactNativeSessionReplay, String(sessionId))
             this.logMsgIfDebug(() =>
               console.log('PostHog Debug', `Session replay already started with sessionId ${sessionId}.`)
             )

--- a/yarn.lock
+++ b/yarn.lock
@@ -9257,10 +9257,10 @@ postcss@8.4.14:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-posthog-react-native-session-replay@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/posthog-react-native-session-replay/-/posthog-react-native-session-replay-1.1.0.tgz#a91b96e2f03c7dd42e5301511a491c4b561940d2"
-  integrity sha512-k1OBm5JzE8p019dATnOoxSY1fnMXuDJZz7GcvL9VIA3690tc5m2zEkRTypeO06N6KNMS79Qohw3J0V9qTzuTRA==
+posthog-react-native-session-replay@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/posthog-react-native-session-replay/-/posthog-react-native-session-replay-1.1.1.tgz#238692b4300c5d40ef1cd7034bd06b21903473c8"
+  integrity sha512-Qh3wzm94LHIbDW1xsyfFn+b/AJZDvJFnoO6rNTSRmiJCELSyL85vqF0GdFfIgxJf1jLrWYN/P1Ye3+mDkppeqA==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Problem

follow up https://github.com/PostHog/posthog-react-native-session-replay/pull/30/files

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [X] posthog-react-native
- [ ] posthog-nextjs

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
