### PR TITLE
avoid navigation tracking crash when using the new navigation version

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Next
 
+# 4.1.4 - 2025-07-01
+
+## Fixed
+
+1. avoid navigation tracking crash when using the new navigation version
+
 # 4.1.3 - 2025-06-26
 
 ## Fixed

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "license": "MIT",
   "main": "lib/posthog-react-native/index.js",
   "files": [


### PR DESCRIPTION
## Problem

Helps with https://github.com/PostHog/posthog-js-lite/issues/547

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [X] posthog-react-native
- [ ] posthog-nextjs-config

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
