### PR TITLE
feat(flags): decouple local evaluation from personal API keys; support decrypting remote config payloads without relying on the feature flags poller

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 5.3.1 - 2025-07-07
+
+1. feat: decouple feature flag local evaluation from personal API keys; support decrypting remote config payloads without relying on the feature flags poller
+
 # 5.2.1 - 2025-07-07
 
 1. feat: add captureExceptionImmediate method on posthog client

--- a/posthog-node/package.json
+++ b/posthog-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "5.2.1",
+  "version": "5.3.1",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/posthog-node/src/client.ts
+++ b/posthog-node/src/client.ts
@@ -8,6 +8,7 @@ import {
   PostHogFetchResponse,
   PostHogFlagsAndPayloadsResponse,
   PostHogPersistedProperty,
+  safeSetTimeout,
 } from 'posthog-core'
 import { EventMessage, GroupIdentifyMessage, IdentifyMessage, IPostHog, PostHogOptions } from './types'
 import { FeatureFlagDetail, FeatureFlagValue } from 'posthog-core'
@@ -667,7 +668,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     let abortTimeout = null
     if (this.options.requestTimeout && typeof this.options.requestTimeout === 'number') {
       const controller = new AbortController()
-      abortTimeout = setTimeout(() => {
+      abortTimeout = safeSetTimeout(() => {
         controller.abort()
       }, this.options.requestTimeout)
       options.signal = controller.signal

--- a/posthog-node/src/client.ts
+++ b/posthog-node/src/client.ts
@@ -648,10 +648,6 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     return super._shutdown(shutdownTimeoutMs)
   }
 
-  /**
-   * @param flagKey
-   * @returns
-   */
   private async _requestRemoteConfigPayload(flagKey: string): Promise<PostHogFetchResponse | undefined> {
     if (!this.options.personalApiKey) {
       return undefined

--- a/posthog-node/src/extensions/feature-flags/feature-flags.ts
+++ b/posthog-node/src/extensions/feature-flags/feature-flags.ts
@@ -537,26 +537,6 @@ class FeatureFlagsPoller {
   stopPoller(): void {
     clearTimeout(this.poller)
   }
-
-  _requestRemoteConfigPayload(flagKey: string): Promise<PostHogFetchResponse> {
-    const url = `${this.host}/api/projects/@current/feature_flags/${flagKey}/remote_config/`
-
-    const options = this.getPersonalApiKeyRequestOptions()
-
-    let abortTimeout = null
-    if (this.timeout && typeof this.timeout === 'number') {
-      const controller = new AbortController()
-      abortTimeout = safeSetTimeout(() => {
-        controller.abort()
-      }, this.timeout)
-      options.signal = controller.signal
-    }
-    try {
-      return this.fetch(url, options)
-    } finally {
-      clearTimeout(abortTimeout)
-    }
-  }
 }
 
 // # This function takes a distinct_id and a feature flag key and returns a float between 0 and 1.

--- a/posthog-node/src/types.ts
+++ b/posthog-node/src/types.ts
@@ -57,6 +57,9 @@ export type PostHogOptions = PostHogCoreOptions & {
   // Maximum size of cache that deduplicates $feature_flag_called calls per user.
   maxCacheSize?: number
   fetch?: (url: string, options: PostHogFetchOptions) => Promise<PostHogFetchResponse>
+  // Whether to enable feature flag polling for local evaluation by default. Defaults to true when personalApiKey is provided.
+  // We recommend setting this to false if you are using the personalApiKey for evaluating remote config payloads via `getRemoteConfigPayload`.
+  enableLocalEvaluation?: boolean
 }
 
 export type PostHogFeatureFlag = {

--- a/posthog-node/src/types.ts
+++ b/posthog-node/src/types.ts
@@ -58,7 +58,7 @@ export type PostHogOptions = PostHogCoreOptions & {
   maxCacheSize?: number
   fetch?: (url: string, options: PostHogFetchOptions) => Promise<PostHogFetchResponse>
   // Whether to enable feature flag polling for local evaluation by default. Defaults to true when personalApiKey is provided.
-  // We recommend setting this to false if you are using the personalApiKey for evaluating remote config payloads via `getRemoteConfigPayload`.
+  // We recommend setting this to false if you are only using the personalApiKey for evaluating remote config payloads via `getRemoteConfigPayload` and not using local evaluation.
   enableLocalEvaluation?: boolean
 }
 

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -1377,7 +1377,7 @@ describe('PostHog Node.js', () => {
         fetchRetryCount: 0,
         disableCompression: true,
       })
-      
+
       await expect(posthogWithoutKey.getRemoteConfigPayload('test-flag')).rejects.toThrow(
         'Personal API key is required for remote config payload decryption'
       )
@@ -1436,7 +1436,7 @@ describe('PostHog Node.js', () => {
       const payload = await posthogWithoutLocalEval.getRemoteConfigPayload('test-flag')
       expect(payload).toEqual({ test: 'payload' })
       expect(spy).toHaveBeenCalledWith('test-flag')
-      
+
       // Verify that no poller was created
       expect(posthogWithoutLocalEval['featureFlagsPoller']).toBeUndefined()
     })

--- a/posthog-node/test/posthog-node.spec.ts
+++ b/posthog-node/test/posthog-node.spec.ts
@@ -1359,7 +1359,7 @@ describe('PostHog Node.js', () => {
       // Reset the mock for each test
       mockedFetch.mockClear()
 
-      // Initialize posthog with personalApiKey to enable feature flags poller
+      // Initialize posthog with personalApiKey
       posthog = new PostHog('TEST_API_KEY', {
         host: 'http://example.com',
         fetchRetryCount: 0,
@@ -1367,18 +1367,20 @@ describe('PostHog Node.js', () => {
         personalApiKey: 'TEST_PERSONAL_API_KEY',
       })
 
-      // Mock the private method using jest.spyOn
-      requestRemoteConfigPayloadSpy = jest.spyOn(posthog['featureFlagsPoller'] as any, '_requestRemoteConfigPayload')
+      // Mock the private method using jest.spyOn (now on the client, not the poller)
+      requestRemoteConfigPayloadSpy = jest.spyOn(posthog as any, '_requestRemoteConfigPayload')
     })
 
-    it('should return undefined when featureFlagsPoller is not initialized', async () => {
-      const posthogWithoutPoller = new PostHog('TEST_API_KEY', {
+    it('should throw error when personalApiKey is not provided', async () => {
+      const posthogWithoutKey = new PostHog('TEST_API_KEY', {
         host: 'http://example.com',
         fetchRetryCount: 0,
         disableCompression: true,
       })
-      const payload = await posthogWithoutPoller.getRemoteConfigPayload('test-flag')
-      expect(payload).toBeUndefined()
+      
+      await expect(posthogWithoutKey.getRemoteConfigPayload('test-flag')).rejects.toThrow(
+        'Personal API key is required for remote config payload decryption'
+      )
     })
 
     it('should return empty object when no payload is available', async () => {
@@ -1413,6 +1415,30 @@ describe('PostHog Node.js', () => {
       const payload = await posthog.getRemoteConfigPayload('test-flag')
       expect(payload).toEqual(simplePayload)
       expect(requestRemoteConfigPayloadSpy).toHaveBeenCalledWith('test-flag')
+    })
+
+    it('should work without local evaluation enabled', async () => {
+      // Create a client with personalApiKey but local evaluation disabled
+      const posthogWithoutLocalEval = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        fetchRetryCount: 0,
+        disableCompression: true,
+        personalApiKey: 'TEST_PERSONAL_API_KEY',
+        enableLocalEvaluation: false,
+      })
+
+      // Spy on the method for this instance
+      const spy = jest.spyOn(posthogWithoutLocalEval as any, '_requestRemoteConfigPayload')
+      spy.mockResolvedValue({
+        json: () => Promise.resolve({ test: 'payload' }),
+      })
+
+      const payload = await posthogWithoutLocalEval.getRemoteConfigPayload('test-flag')
+      expect(payload).toEqual({ test: 'payload' })
+      expect(spy).toHaveBeenCalledWith('test-flag')
+      
+      // Verify that no poller was created
+      expect(posthogWithoutLocalEval['featureFlagsPoller']).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
## Problem

We have this problem with our server-side SDKs where we start the feature flag poller (for local evaluation) as soon as customers supply a `personalApiKey`.  This led to reports (e.g.: https://posthog.slack.com/archives/C04J1TJ11UZ/p1751499805232469) where customers were mentioning not wanting to pay for local eval when their goal for supplying the personal API key was to just use the `getRemoteConfigPayload` method.

Coupling the personal API key to feature flag polling is an artifact of when the only reason to supply a personal API key to the posthog-node library was to do local eval, but now that it's used for at least remote config decryption (and possibly more things), I think it makes sense to decouple those components.

## Changes

- decoupled `getRemoteConfigPayload` from the feature flag poller
- added an optional `enableLocalEvaluation` parameter to the posthog config that defaults to `true` when the `personalApiKey` is provided, but can be overridden by users who want to provide an API but not use local evaluation.  Designing it this way means that folks can safely upgrade their posthog-node version without changing any of the configuration if they wanted the coupled behavior to still exist.
- updated tests

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native
- [ ] posthog-nextjs-config

### Changelog notes

- feat(flags): decouple local evaluation from personal API keys; support decrypting remote config payloads without relying on the feature flags poller