### PR TITLE
fix(flags): fix the way we optimistically send feature flags with `capture` methods when we have locally evaluated feature flags for a given instance

### DIFF
--- a/posthog-node/src/types.ts
+++ b/posthog-node/src/types.ts
@@ -15,7 +15,12 @@ export interface IdentifyMessage {
 export interface EventMessage extends IdentifyMessage {
   event: string
   groups?: Record<string, string | number> // Mapping of group type to group id
-  sendFeatureFlags?: boolean
+  sendFeatureFlags?: boolean | {
+    personProperties?: Record<string, string>
+    groupProperties?: Record<string, Record<string, string>>
+    onlyEvaluateLocally?: boolean
+    strictLocalEvaluation?: boolean
+  }
   timestamp?: Date
   uuid?: string
 }
@@ -39,6 +44,7 @@ export type FlagProperty = {
   value: string | number | (string | number)[]
   operator?: string
   negation?: boolean
+  group_type_index?: number
 }
 
 export type FeatureFlagCondition = {
@@ -60,6 +66,8 @@ export type PostHogOptions = PostHogCoreOptions & {
   // Whether to enable feature flag polling for local evaluation by default. Defaults to true when personalApiKey is provided.
   // We recommend setting this to false if you are only using the personalApiKey for evaluating remote config payloads via `getRemoteConfigPayload` and not using local evaluation.
   enableLocalEvaluation?: boolean
+  // Whether to enforce strict local evaluation. When true, missing properties will cause evaluation to fail rather than fall back to remote evaluation.
+  strictLocalEvaluation?: boolean
 }
 
 export type PostHogFeatureFlag = {
@@ -159,6 +167,7 @@ export interface IPostHog {
    * @param groupProperties optional - what group properties are known. Used to compute flags locally, if personalApiKey is present.
    * @param onlyEvaluateLocally optional - whether to only evaluate the flag locally. Defaults to false.
    * @param sendFeatureFlagEvents optional - whether to send feature flag events. Used for Experiments. Defaults to true.
+   * @param strictLocalEvaluation optional - whether to enforce strict local evaluation. When true, missing properties will cause evaluation to fail rather than fall back to remote evaluation.
    *
    * @returns true if the flag is on, false if the flag is off, undefined if there was an error.
    */
@@ -171,6 +180,7 @@ export interface IPostHog {
       groupProperties?: Record<string, Record<string, string>>
       onlyEvaluateLocally?: boolean
       sendFeatureFlagEvents?: boolean
+      strictLocalEvaluation?: boolean
     }
   ): Promise<boolean | undefined>
 
@@ -187,6 +197,7 @@ export interface IPostHog {
    * @param groupProperties optional - what group properties are known. Used to compute flags locally, if personalApiKey is present.
    * @param onlyEvaluateLocally optional - whether to only evaluate the flag locally. Defaults to false.
    * @param sendFeatureFlagEvents optional - whether to send feature flag events. Used for Experiments. Defaults to true.
+   * @param strictLocalEvaluation optional - whether to enforce strict local evaluation. When true, missing properties will cause evaluation to fail rather than fall back to remote evaluation.
    *
    * @returns true or string(for multivariates) if the flag is on, false if the flag is off, undefined if there was an error.
    */
@@ -199,6 +210,7 @@ export interface IPostHog {
       groupProperties?: Record<string, Record<string, string>>
       onlyEvaluateLocally?: boolean
       sendFeatureFlagEvents?: boolean
+      strictLocalEvaluation?: boolean
     }
   ): Promise<FeatureFlagValue | undefined>
 


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/34188

## Changes

TODO

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [x] Minor
- [ ] Patch

### Libraries affected

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native
- [ ] posthog-nextjs-config

### Changelog notes

- fix: fix the way we optimistically send feature flags with `capture` methods when we have locally evaluated feature flags for a given instance
