### PR TITLE
docs: Add CHANGELOG notice about GZip compression

### DIFF
--- a/posthog-node/CHANGELOG.md
+++ b/posthog-node/CHANGELOG.md
@@ -27,6 +27,7 @@
 ## Breaking changes
 
 1. feat: migrate to native fetch, Node 20+ required
+2. PostHog Node now compresses messages with GZip before sending them to our servers when the runtime supports compression. This reduces network bandwidth and improves performance. Network traffic interceptors and test assertions on payloads must handle GZip decompression to inspect the data. Alternatively, you can disable compression by setting `disableCompression: true` in the client configuration during tests.
 
 # 5.0.0-alpha.1 - 2025-04-29
 

--- a/posthog-web/CHANGELOG.md
+++ b/posthog-web/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 # 4.0.0 - 2025-06-10
 
+## Breaking changes
+
+1. PostHog Web now compresses messages with GZip before sending them to our servers when the runtime supports compression. This reduces network bandwidth and improves performance. Network traffic interceptors and test assertions on payloads must handle GZip decompression to inspect the data. Alternatively, you can disable compression by setting `disableCompression: true` in the client configuration during tests.
+
 ## Removed
 
 1. Remove `captureMode` in favor of `json` capture mode only


### PR DESCRIPTION
PostHog web now attempts to compress messages with GZip before sending them to our servers if available in your runtime. This shouldn't cause you any problems, but if someone's tests are attempting to assert on the data that's sent to our servers, they'll now need to decompress it first.

Let's note this on the BREAKING CHANGES section of both our web and node versions

See https://github.com/PostHog/posthog-js-lite/pull/481