### PR TITLE
fix: Ignore new `flag` filter type in local evaluation

### DIFF
--- a/posthog-node/src/extensions/feature-flags/feature-flags.ts
+++ b/posthog-node/src/extensions/feature-flags/feature-flags.ts
@@ -324,6 +324,14 @@ class FeatureFlagsPoller {
 
         if (propertyType === 'cohort') {
           matches = matchCohort(prop, properties, this.cohorts, this.debugMode)
+        } else if (propertyType === 'flag') {
+          this.logMsgIfDebug(() =>
+            console.warn(
+              `[FEATURE FLAGS] Flag dependency filters are not supported in local evaluation. ` +
+                `Skipping condition for flag '${flag.key}' with dependency on flag '${prop.key || 'unknown'}'`
+            )
+          )
+          continue
         } else {
           matches = matchProperty(prop, properties, warnFunction)
         }
@@ -731,6 +739,14 @@ function matchPropertyGroup(
         let matches: boolean
         if (prop.type === 'cohort') {
           matches = matchCohort(prop, propertyValues, cohortProperties, debugMode)
+        } else if (prop.type === 'flag') {
+          if (debugMode) {
+            console.warn(
+              `[FEATURE FLAGS] Flag dependency filters are not supported in local evaluation. ` +
+                `Skipping condition with dependency on flag '${prop.key || 'unknown'}'`
+            )
+          }
+          continue
         } else {
           matches = matchProperty(prop, propertyValues)
         }


### PR DESCRIPTION
## Problem

Add support for the new "flag" filter type to prevent serialization errors during local feature flag evaluation. Flag dependencies are not yet implemented in local evaluation, so these conditions are skipped to allow other conditions to be evaluated properly.

## Changes

Ignore filter type of "flag" which nobody can create yet, but is coming soon.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native
- [ ] posthog-nextjs-config

### Changelog notes

