### PR TITLE
chore: Add bin/fmt script

### DIFF
--- a/bin/fmt
+++ b/bin/fmt
@@ -1,0 +1,1 @@
+yarn prettier

--- a/bin/fmt
+++ b/bin/fmt
@@ -1,1 +1,2 @@
+#!/bin/sh
 yarn prettier

--- a/bin/helpers/_utils.sh
+++ b/bin/helpers/_utils.sh
@@ -1,0 +1,15 @@
+error() {
+    echo "$@" >&2
+}
+
+fatal() {
+    error "$@"
+    exit 1
+}
+
+set_source_and_root_dir() {
+    { set +x; } 2>/dev/null
+    source_dir="$( cd -P "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+    root_dir=$(cd $source_dir && cd ../ && pwd)
+    cd $root_dir
+}

--- a/bin/helpers/_utils.sh
+++ b/bin/helpers/_utils.sh
@@ -10,6 +10,6 @@ fatal() {
 set_source_and_root_dir() {
     { set +x; } 2>/dev/null
     source_dir="$( cd -P "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
-    root_dir=$(cd $source_dir && cd ../ && pwd)
+    root_dir=$(cd "$source_dir" && cd ../ && pwd)
     cd $root_dir
 }


### PR DESCRIPTION
Adding a `fmt` script to this repo as described by https://posthog.com/handbook/engineering/conventions/scripts.

Because this repo builds so many projects, the other scripts will take more thought.

## Problem

I always forget what command to run when I'm editing a bunch of SDKs.

## Changes

Adds a bin script.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

No version change needed. It's purely a developer experience thing.

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native
- [ ] posthog-nextjs-config

### Changelog notes

