### PR TITLE
fix: read the navigation ref from the current property if it exists for expo-router and @react-navigation/native

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Next
 
+# 4.1.5 - 2025-07-14
+
+## Fixed
+
+1. read the navigation ref from the current property if it exists for expo-router and @react-navigation/native
+
 # 4.1.4 - 2025-07-01
 
 ## Fixed

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "license": "MIT",
   "main": "lib/posthog-react-native/index.js",
   "files": [

--- a/posthog-react-native/src/hooks/useNavigationTracker.ts
+++ b/posthog-react-native/src/hooks/useNavigationTracker.ts
@@ -51,6 +51,12 @@ function _useNavigationTracker(
     if (!navigation) {
       return
     }
+    
+    // if you create a navigation ref with createNavigationContainerRef, you need to use the current property to get the navigation object
+    let currentNavigation = navigation
+    if (navigation.current) {
+      currentNavigation = navigation.current
+    }
 
     let currentRoute = undefined
 
@@ -58,7 +64,7 @@ function _useNavigationTracker(
     try {
       let isReady = false
       try {
-        isReady = (navigation as any).isReady()
+        isReady = (currentNavigation as any).isReady()
       } catch (error) {
         // keep compatibility with older versions of react-navigation
         isReady = true
@@ -68,9 +74,9 @@ function _useNavigationTracker(
         return
       }
 
-      currentRoute = (navigation as any).getCurrentRoute()
+      currentRoute = (currentNavigation as any).getCurrentRoute()
     } catch (error) {
-      console.error('getCurrentRoute error', error)
+      // if this happens, we're not in a navigation context, so we can't track the route
       return
     }
 

--- a/posthog-react-native/src/hooks/useNavigationTracker.ts
+++ b/posthog-react-native/src/hooks/useNavigationTracker.ts
@@ -51,7 +51,7 @@ function _useNavigationTracker(
     if (!navigation) {
       return
     }
-    
+
     // if you create a navigation ref with createNavigationContainerRef, you need to use the current property to get the navigation object
     let currentNavigation = navigation
     if (navigation.current) {


### PR DESCRIPTION
## Problem

helps with https://github.com/PostHog/posthog-js-lite/issues/560

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [X] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [X] posthog-react-native
- [ ] posthog-nextjs-config

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
