### PR TITLE
fix: use correct types for PostHogContext which cascades through usePostHog hook and callers

### DIFF
--- a/posthog-react-native/src/PostHogContext.ts
+++ b/posthog-react-native/src/PostHogContext.ts
@@ -1,4 +1,4 @@
 import React from 'react'
 import { PostHog } from './posthog-rn'
 
-export const PostHogContext = React.createContext<{ client: PostHog }>({ client: undefined as unknown as PostHog })
+export const PostHogContext = React.createContext<{ client: PostHog | undefined }>({ client: undefined })

--- a/posthog-react-native/src/hooks/useFeatureFlag.ts
+++ b/posthog-react-native/src/hooks/useFeatureFlag.ts
@@ -7,12 +7,12 @@ export function useFeatureFlag(flag: string, client?: PostHog): FeatureFlagValue
   const contextClient = usePostHog()
   const posthog = client || contextClient
 
-  const [featureFlag, setFeatureFlag] = useState<FeatureFlagValue | undefined>(posthog.getFeatureFlag(flag))
+  const [featureFlag, setFeatureFlag] = useState<FeatureFlagValue | undefined>(posthog?.getFeatureFlag(flag))
 
   useEffect(() => {
-    setFeatureFlag(posthog.getFeatureFlag(flag))
-    return posthog.onFeatureFlags(() => {
-      setFeatureFlag(posthog.getFeatureFlag(flag))
+    setFeatureFlag(posthog?.getFeatureFlag(flag))
+    return posthog?.onFeatureFlags(() => {
+      setFeatureFlag(posthog?.getFeatureFlag(flag))
     })
   }, [posthog, flag])
 
@@ -27,9 +27,9 @@ export function useFeatureFlagWithPayload(flag: string, client?: PostHog): Featu
   const [featureFlag, setFeatureFlag] = useState<FeatureFlagWithPayload>([undefined, undefined])
 
   useEffect(() => {
-    setFeatureFlag([posthog.getFeatureFlag(flag), posthog.getFeatureFlagPayload(flag)])
-    return posthog.onFeatureFlags(() => {
-      setFeatureFlag([posthog.getFeatureFlag(flag), posthog.getFeatureFlagPayload(flag)])
+    setFeatureFlag([posthog?.getFeatureFlag(flag), posthog?.getFeatureFlagPayload(flag)])
+    return posthog?.onFeatureFlags(() => {
+      setFeatureFlag([posthog?.getFeatureFlag(flag), posthog?.getFeatureFlagPayload(flag)])
     })
   }, [posthog, flag])
 

--- a/posthog-react-native/src/hooks/useFeatureFlags.ts
+++ b/posthog-react-native/src/hooks/useFeatureFlags.ts
@@ -7,12 +7,12 @@ export function useFeatureFlags(client?: PostHog): PostHogFlagsResponse['feature
   const contextClient = usePostHog()
   const posthog = client || contextClient
   const [featureFlags, setFeatureFlags] = useState<PostHogFlagsResponse['featureFlags'] | undefined>(
-    posthog.getFeatureFlags()
+    posthog?.getFeatureFlags()
   )
 
   useEffect(() => {
-    setFeatureFlags(posthog.getFeatureFlags())
-    return posthog.onFeatureFlags((flags) => {
+    setFeatureFlags(posthog?.getFeatureFlags())
+    return posthog?.onFeatureFlags((flags) => {
       setFeatureFlags(flags)
     })
   }, [posthog])

--- a/posthog-react-native/src/hooks/useNavigationTracker.ts
+++ b/posthog-react-native/src/hooks/useNavigationTracker.ts
@@ -97,7 +97,7 @@ function _useNavigationTracker(
 
     if (currentRouteName) {
       const properties = options?.routeToProperties?.(currentRouteName, params)
-      posthog.screen(currentRouteName, properties)
+      posthog?.screen(currentRouteName, properties)
     }
   }, [navigation, options, posthog])
 

--- a/posthog-react-native/src/hooks/usePostHog.ts
+++ b/posthog-react-native/src/hooks/usePostHog.ts
@@ -2,7 +2,7 @@ import { PostHog } from '../posthog-rn'
 import React from 'react'
 import { PostHogContext } from '../PostHogContext'
 
-export const usePostHog = (): PostHog => {
+export const usePostHog = (): PostHog | undefined => {
   const { client } = React.useContext(PostHogContext)
   return client
 }

--- a/posthog-react-native/src/surveys/PostHogSurveyProvider.tsx
+++ b/posthog-react-native/src/surveys/PostHogSurveyProvider.tsx
@@ -86,10 +86,10 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
     // TODO: for the first time, sometimes the surveys are not fetched from storage, so we need to fetch them from the API
     // because the remote config is still being fetched from the API
     posthog
-      .ready()
-      .then(() => posthog.getSurveys())
-      .then(setSurveys)
-      .catch(() => {})
+      ?.ready()
+      ?.then(() => posthog?.getSurveys())
+      ?.then(setSurveys)
+      ?.catch(() => {})
   }, [posthog])
 
   // Whenever state changes and there's no active survey, check if there is a new survey to show

--- a/posthog-react-native/src/surveys/components/Surveys.tsx
+++ b/posthog-react-native/src/surveys/components/Surveys.tsx
@@ -16,8 +16,8 @@ const getSurveyInteractionProperty = (survey: Survey, action: string): string =>
   return surveyProperty
 }
 
-export const sendSurveyShownEvent = (survey: Survey, posthog: PostHog): void => {
-  posthog.capture('survey shown', {
+export const sendSurveyShownEvent = (survey: Survey, posthog: PostHog | undefined): void => {
+  posthog?.capture('survey shown', {
     $survey_name: survey.name,
     $survey_id: survey.id,
     ...maybeAdd('$survey_iteration', survey.current_iteration),
@@ -28,9 +28,9 @@ export const sendSurveyShownEvent = (survey: Survey, posthog: PostHog): void => 
 export const sendSurveyEvent = (
   responses: Record<string, string | number | string[] | null> = {},
   survey: Survey,
-  posthog: PostHog
+  posthog: PostHog | undefined
 ): void => {
-  posthog.capture('survey sent', {
+  posthog?.capture('survey sent', {
     $survey_name: survey.name,
     $survey_id: survey.id,
     ...maybeAdd('$survey_iteration', survey.current_iteration),
@@ -43,8 +43,8 @@ export const sendSurveyEvent = (
   })
 }
 
-export const dismissedSurveyEvent = (survey: Survey, posthog: PostHog): void => {
-  posthog.capture('survey dismissed', {
+export const dismissedSurveyEvent = (survey: Survey, posthog: PostHog | undefined): void => {
+  posthog?.capture('survey dismissed', {
     $survey_name: survey.name,
     $survey_id: survey.id,
     ...maybeAdd('$survey_iteration', survey.current_iteration),

--- a/posthog-react-native/src/surveys/useActivatedSurveys.ts
+++ b/posthog-react-native/src/surveys/useActivatedSurveys.ts
@@ -6,7 +6,7 @@ import { PostHog } from '../posthog-rn'
 
 const SURVEY_SHOWN_EVENT_NAME = 'survey shown'
 
-export function useActivatedSurveys(posthog: PostHog, surveys: Survey[]): ReadonlySet<string> {
+export function useActivatedSurveys(posthog: PostHog | undefined, surveys: Survey[]): ReadonlySet<string> {
   const [activatedSurveys, setActivatedSurveys] = useState<ReadonlySet<string>>(new Set())
 
   const eventMap = useMemo(() => {
@@ -23,7 +23,7 @@ export function useActivatedSurveys(posthog: PostHog, surveys: Survey[]): Readon
 
   useEffect(() => {
     if (eventMap.size > 0) {
-      return posthog.on('capture', (payload: { event: string; properties?: { $survey_id?: string } }) => {
+      return posthog?.on('capture', (payload: { event: string; properties?: { $survey_id?: string } }) => {
         if (eventMap.has(payload.event)) {
           setActivatedSurveys((current) => new Set([...current, ...(eventMap.get(payload.event) ?? [])]))
         } else if (payload.event === SURVEY_SHOWN_EVENT_NAME) {

--- a/posthog-react-native/src/surveys/useSurveyStorage.ts
+++ b/posthog-react-native/src/surveys/useSurveyStorage.ts
@@ -15,13 +15,13 @@ export function useSurveyStorage(): SurveyStorage {
   const [seenSurveys, setSeenSurveys] = useState<string[]>([])
 
   useEffect(() => {
-    posthogStorage.ready().then(() => {
-      const lastSeenSurveyDate = posthogStorage.getPersistedProperty(PostHogPersistedProperty.SurveyLastSeenDate)
+    posthogStorage?.ready()?.then(() => {
+      const lastSeenSurveyDate = posthogStorage?.getPersistedProperty(PostHogPersistedProperty.SurveyLastSeenDate)
       if (typeof lastSeenSurveyDate === 'string') {
         setLastSeenSurveyDate(new Date(lastSeenSurveyDate))
       }
 
-      const serialisedSeenSurveys = posthogStorage.getPersistedProperty(PostHogPersistedProperty.SurveysSeen)
+      const serialisedSeenSurveys = posthogStorage?.getPersistedProperty(PostHogPersistedProperty.SurveysSeen)
       if (typeof serialisedSeenSurveys === 'string') {
         const parsedSeenSurveys: unknown = JSON.parse(serialisedSeenSurveys)
         if (Array.isArray(parsedSeenSurveys) && typeof parsedSeenSurveys[0] === 'string') {
@@ -38,7 +38,7 @@ export function useSurveyStorage(): SurveyStorage {
         setSeenSurveys((current) => {
           // To keep storage bounded, only keep the last 20 seen surveys
           const newValue = [surveyId, ...current.filter((id) => id !== surveyId)]
-          posthogStorage.setPersistedProperty(
+          posthogStorage?.setPersistedProperty(
             PostHogPersistedProperty.SurveysSeen,
             JSON.stringify(newValue.slice(0, 20))
           )
@@ -51,7 +51,7 @@ export function useSurveyStorage(): SurveyStorage {
     setLastSeenSurveyDate: useCallback(
       (date: Date) => {
         setLastSeenSurveyDate(date)
-        posthogStorage.setPersistedProperty(PostHogPersistedProperty.SurveyLastSeenDate, date.toISOString())
+        posthogStorage?.setPersistedProperty(PostHogPersistedProperty.SurveyLastSeenDate, date.toISOString())
       },
       [posthogStorage]
     ),


### PR DESCRIPTION
## Problem

We discovered that usePostHog was typed incorrectly:
```
diff --git a/node_modules/posthog-react-native/lib/posthog-react-native/src/hooks/usePostHog.d.ts b/node_modules/posthog-react-native/lib/posthog-react-native/src/hooks/usePostHog.d.ts
index 4268052..e1ab864 100644
--- a/node_modules/posthog-react-native/lib/posthog-react-native/src/hooks/usePostHog.d.ts
+++ b/node_modules/posthog-react-native/lib/posthog-react-native/src/hooks/usePostHog.d.ts
@@ -1,2 +1,2 @@
 import { PostHog } from '../posthog-rn';
-export declare const usePostHog: () => PostHog;
+export declare const usePostHog: () => PostHog | undefined;
```

Checking PostHogContext, we can see that the client type is initialized as `undefined` and then coerced into PostHog:
https://github.com/PostHog/posthog-js-lite/blob/0b983d8305a0b20fb0940bbbb43195de9b7ca2e4/posthog-react-native/src/PostHogContext.ts#L4C103-L4C113

## Changes

Properly type the context and usePostHog hook, and then slap our troubles away with the optional chaining operator. I don't think this is the correct solution, but don't have enough context for the other features. It is at least an improvement of the call onto a maybe undefined. Happy to fix up with a different approach. 

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [x] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [x] posthog-react-native
- [ ] posthog-nextjs-config

### Changelog notes

- Added correct type for `usePostHog`
