### PR TITLE
fix(flags): log level for locally evaluated flags

### DIFF
--- a/posthog-node/src/extensions/feature-flags/feature-flags.ts
+++ b/posthog-node/src/extensions/feature-flags/feature-flags.ts
@@ -193,7 +193,7 @@ class FeatureFlagsPoller {
           }
         } catch (e) {
           if (e instanceof InconclusiveMatchError) {
-            this.onError?.(new Error(`Unable to compute flag locally: ${flag.key} - ${e.message}`))
+            this.logMsgIfDebug(() => console.debug(`InconclusiveMatchError when computing flag locally: ${key}: ${e}`))
           } else if (e instanceof Error) {
             this.onError?.(new Error(`Error computing flag locally: ${flag.key}: ${e}`))
           }


### PR DESCRIPTION
## Problem

Forgot to wrap the InconclusiveMatchError (which isn't even really an error, tbh) in the `logMsgIfDebug`, and it's blowing up in customer apps.  Let's turn that down, eh?

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [x] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native
- [ ] posthog-nextjs-config

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- wrap `InconclusiveMatchError`s in `logMsgIfDebug` for local flag evaluations on `sendFeatureFlags`
