### PR TITLE
fix: avoid undefined errors when extending OpenAI classes

### DIFF
--- a/posthog-ai/src/openai/index.ts
+++ b/posthog-ai/src/openai/index.ts
@@ -1,10 +1,14 @@
-import OpenAIOrignal, { ClientOptions } from 'openai'
+import { OpenAI as OpenAIOrignal, ClientOptions } from 'openai'
 import { PostHog } from 'posthog-node'
 import { v4 as uuidv4 } from 'uuid'
 import { formatResponseOpenAI, MonitoringParams, sendEventToPosthog } from '../utils'
 import type { APIPromise } from 'openai'
 import type { Stream } from 'openai/streaming'
 import type { ParsedResponse } from 'openai/resources/responses/responses'
+
+const Chat = OpenAIOrignal.Chat
+const Completions = Chat.Completions
+const Responses = OpenAIOrignal.Responses
 
 type ChatCompletion = OpenAIOrignal.ChatCompletion
 type ChatCompletionChunk = OpenAIOrignal.ChatCompletionChunk
@@ -37,7 +41,7 @@ export class PostHogOpenAI extends OpenAIOrignal {
   }
 }
 
-export class WrappedChat extends OpenAIOrignal.Chat {
+export class WrappedChat extends Chat {
   constructor(parentClient: PostHogOpenAI, phClient: PostHog) {
     super(parentClient)
     this.completions = new WrappedCompletions(parentClient, phClient)
@@ -46,7 +50,7 @@ export class WrappedChat extends OpenAIOrignal.Chat {
   public completions: WrappedCompletions
 }
 
-export class WrappedCompletions extends OpenAIOrignal.Chat.Completions {
+export class WrappedCompletions extends Completions {
   private readonly phClient: PostHog
 
   constructor(client: OpenAIOrignal, phClient: PostHog) {
@@ -223,7 +227,7 @@ export class WrappedCompletions extends OpenAIOrignal.Chat.Completions {
   }
 }
 
-export class WrappedResponses extends OpenAIOrignal.Responses {
+export class WrappedResponses extends Responses {
   private readonly phClient: PostHog
 
   constructor(client: OpenAIOrignal, phClient: PostHog) {


### PR DESCRIPTION
## Problem

Consumers of `@posthog/ai` encountered runtime crashes when using it alongside OpenAI SDK v5.x.

The issue was that `@posthog/ai` internally extended OpenAI classes like `Chat`, `Completions`, and `Responses` at module load time. However, in OpenAI SDK v5, these classes are only assigned to the `OpenAI` object at runtime — they are not immediately available as static properties.

This caused errors like:

```
TypeError: Class extends value undefined is not a constructor or null
```

…whenever someone tried to import and instantiate the OpenAI wrapper from `@posthog/ai`.

Issue: #535.

## Changes

- Deferred access to `Chat`, `Completions`, and `Responses` by assigning them to local constants after the OpenAI SDK has finished its runtime setup.
- Replaced all `OpenAI.Chat`, `OpenAI.Chat.Completions`, and `OpenAI.Responses` references used during class extension.
- This ensures the resource classes are defined before subclassing them, preventing `undefined` runtime errors.

## Release info Sub-libraries affected

### Bump level

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [x] posthog-ai
- [ ] posthog-react-native
- [ ] posthog-nextjs-config

### Changelog notes

- Fixed crash when importing `@posthog/ai` with OpenAI SDK v5.x by deferring access to Chat, Completions, and Responses classes until runtime.