### PR TITLE
docs: fix overflowing code block

### DIFF
--- a/posthog-web/README.md
+++ b/posthog-web/README.md
@@ -72,6 +72,7 @@ posthog.onFeatureFlag('my-feature-flag', (value) => {
 // Opt users in or out, persisting across sessions (default is they are opted in)
 posthog.optOut() // Will stop tracking
 posthog.optIn() // Will start tracking
+```
 
 ## History API Navigation Tracking
 


### PR DESCRIPTION
## Problem

Fixes documentation missing a codeblock terminator

## Changes

See before and after of that README

## Release info Sub-libraries affected

### Bump level

None, documentation-only change

### Libraries affected

- [ ] All of them
- [x] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native
- [ ] posthog-nextjs-config

### Changelog notes

None
