### PR TITLE
Solve `outdated JSX transform` issue

### DIFF
--- a/posthog-react-native/CHANGELOG.md
+++ b/posthog-react-native/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Next
 
+# 4.2.1 - 2025-07-21
+
+## Fixed
+
+1. Solve outdated JSX transform warning
+
 # 4.2.0 - 2025-07-15
 
 ## Changed

--- a/posthog-react-native/babel.config.js
+++ b/posthog-react-native/babel.config.js
@@ -1,3 +1,8 @@
 module.exports = {
-  presets: ['module:metro-react-native-babel-preset', '@babel/env', '@babel/preset-typescript'],
+  presets: [
+    'module:metro-react-native-babel-preset',
+    '@babel/env',
+    '@babel/preset-typescript',
+    ['@babel/preset-react', { runtime: 'automatic' }],
+  ],
 }

--- a/posthog-react-native/package.json
+++ b/posthog-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-native",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "MIT",
   "main": "lib/posthog-react-native/index.js",
   "files": [


### PR DESCRIPTION
## Problem
As described in #495, react-native apps will currently show a warning when using posthog-react-native:

```
 WARN  Your app (or one of its dependencies) is using an outdated JSX transform. Update to the modern JSX transform for faster performance: https://react.dev/link/new-jsx-transform
```

The documentation describes how to fix the issue:

```
Currently, the old transform {"runtime": "classic"} is the default option. To enable the new transform, you can pass {"runtime": "automatic"} as an option to @babel/plugin-transform-react-jsx or @babel/preset-react:
// If you are using @babel/preset-react
{
  "presets": [
    ["@babel/preset-react", {
      "runtime": "automatic"
    }]
  ]
}
```


## Changes

I have added the configuration above and verified that the `React.createElement`-statements are gone from the output.

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [x] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [x] posthog-react-native
- [ ] posthog-nextjs-config

### Changelog notes

- Solve `Your app (or one of its dependencies) is using an outdated JSX transform` issue