### PR TITLE
fix: remove bens token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         package:
           - name: posthog-react-native
-            npm_token_secret: NPM_TOKEN_BEN_WHITE # TODO: Change to standard token once able
+            npm_token_secret: NPM_TOKEN # TODO: Change to standard token once able
           - name: posthog-node
-            npm_token_secret: NPM_TOKEN_BEN_WHITE # TODO: Change to standard token once able
+            npm_token_secret: NPM_TOKEN # TODO: Change to standard token once able
           - name: posthog-web
             npm_token_secret: NPM_TOKEN # TODO: Change to standard token once able
           - name: posthog-ai


### PR DESCRIPTION
## Problem

not sure who created npm_token but its been there for 5y, assuming its the 'org' token
all repos now are part of the posthog developers team
developers team belong to posthog org
https://github.com/PostHog/posthog-js-lite/settings/secrets/actions

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native
- [ ] posthog-nextjs-config

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
