### PR TITLE
chore: simplify access to NPM_TOKEN secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,10 @@ jobs:
       matrix:
         package:
           - name: posthog-react-native
-            npm_token_secret: NPM_TOKEN # TODO: Change to standard token once able
           - name: posthog-node
-            npm_token_secret: NPM_TOKEN # TODO: Change to standard token once able
           - name: posthog-web
-            npm_token_secret: NPM_TOKEN # TODO: Change to standard token once able
           - name: posthog-ai
-            npm_token_secret: NPM_TOKEN # TODO: Change to standard token once able
           - name: posthog-nextjs-config
-            npm_token_secret: NPM_TOKEN # TODO: Change to standard token once able
 
     steps:
       - name: Checkout the repository
@@ -62,7 +57,7 @@ jobs:
 
           npm publish --access public --tag $tag
         env:
-          NODE_AUTH_TOKEN: ${{ secrets[matrix.package.npm_token_secret] }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ steps.check-package-version.outputs.committed-version }}
 
       - name: Create GitHub release


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

All branches now use the same token, so this can be simplified. It seems the TODO also no longer applies.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Bump level

<!-- Please mark what level of change this is. -->

- [ ] Major
- [ ] Minor
- [ ] Patch

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-web
- [ ] posthog-node
- [ ] posthog-ai
- [ ] posthog-react-native
- [ ] posthog-nextjs-config

### Changelog notes

<!-- Add notes here that should be added to the changelogs. -->

- Added support for X
